### PR TITLE
Use token within cookie to track

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "Apache-2.0",
   "private": false,
   "scripts": {
-    "docker:app:install": "docker buildx bake -f ./docker-compose.app.yml --progress=tty deps",
     "docker:app:develop": "cross-env DOCKER_BUILDKIT=1 docker-compose -f ./docker-compose.app.yml up --build",
     "docker:prune-cache": "docker buildx prune",
     "docker:nuke-all": "npm-run-all --sequential --continue-on-error --print-label \"docker:nuke:*\"",

--- a/src/lib/instill/mgmt/mocks.ts
+++ b/src/lib/instill/mgmt/mocks.ts
@@ -31,6 +31,6 @@ export const mockMgmtRoles: SingleSelectOption[] = [
   },
   {
     label: "Hobbyist (I love Vision AI!)",
-    value: "hobbyist",
+    value: "Hobbyist",
   },
 ];

--- a/src/lib/instill/mgmt/mutations.ts
+++ b/src/lib/instill/mgmt/mutations.ts
@@ -6,18 +6,12 @@ export type UpdateUserResponse = {
 };
 
 export const updateLocalUserMutation = async (
-  user: Partial<User>
+  payload: Partial<User>
 ): Promise<User> => {
   try {
     const { data } = await axios.patch(
       `${process.env.NEXT_PUBLIC_MGMT_API_ENDPOINT}/${process.env.NEXT_PUBLIC_API_VERSION}/users/local-user`,
-      {
-        email: user.email,
-        company_name: user.company_name,
-        role: user.role,
-        usage_data_collection: user.usage_data_collection,
-        newsletter_subscription: user.newsletter_subscription,
-      }
+      payload
     );
 
     return Promise.resolve(data.user);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,9 +29,18 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const trackingToken = useTrackingToken();
 
   useEffect(() => {
-    if (!trackingToken || !router.isReady) return;
-    initAmplitude(trackingToken);
-    setAmplitudeIsInit(true);
+    if (!router.isReady) return;
+
+    if (!trackingToken) {
+      router.push("/onboarding");
+    }
+
+    if (process.env.NODE_ENV === "production") {
+      initAmplitude(trackingToken);
+      setAmplitudeIsInit(true);
+    } else {
+      setAmplitudeIsInit(false);
+    }
   }, [router.isReady, trackingToken]);
 
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,7 +34,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
     if (trackingToken.data === "redirect-to-onboard") {
       // We should clear the trackingToken to avoid once user had successfully setup user data, when we push them to the
       // pipelines page, because there has no changes related to state, the trackingToken won't be flushed, so it remains
-      // redirect-to-onboard, so user will be redirected to onboarding page again.
+      // redirect-to-onboard, user will be redirected to onboarding page again.
       trackingToken.setData(null);
       router.push("/onboarding");
     }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,13 +35,11 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       router.push("/onboarding");
     }
 
-    if (process.env.NODE_ENV === "production") {
+    if (process.env.NODE_ENV === "production" && !amplitudeIsInit) {
       initAmplitude(trackingToken);
       setAmplitudeIsInit(true);
-    } else {
-      setAmplitudeIsInit(false);
     }
-  }, [router.isReady, trackingToken]);
+  }, [router.isReady, trackingToken, router.asPath]);
 
   return (
     <AmplitudeCtx.Provider value={{ amplitudeIsInit, setAmplitudeIsInit }}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,17 +29,21 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const trackingToken = useTrackingToken();
 
   useEffect(() => {
-    if (!router.isReady) return;
+    if (!router.isReady || !trackingToken.data) return;
 
-    if (!trackingToken) {
+    if (trackingToken.data === "redirect-to-onboard") {
+      // We should clear the trackingToken to avoid once user had successfully setup user data, when we push them to the
+      // pipelines page, because there has no changes related to state, the trackingToken won't be flushed, so it remains
+      // redirect-to-onboard, so user will be redirected to onboarding page again.
+      trackingToken.setData(null);
       router.push("/onboarding");
     }
 
     if (process.env.NODE_ENV === "production" && !amplitudeIsInit) {
-      initAmplitude(trackingToken);
+      initAmplitude(trackingToken.data);
       setAmplitudeIsInit(true);
     }
-  }, [router.isReady, trackingToken, router.asPath]);
+  }, [router.isReady, trackingToken.data, router.asPath]);
 
   return (
     <AmplitudeCtx.Provider value={{ amplitudeIsInit, setAmplitudeIsInit }}>

--- a/src/pages/api/get-user-cookie.ts
+++ b/src/pages/api/get-user-cookie.ts
@@ -1,0 +1,22 @@
+import { InstillAiUserCookie } from "@/types/general";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { method, cookies } = req;
+
+  if (method !== "GET") {
+    res.setHeader("Allow", ["GET"]);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+
+  const instillAiUserCookie: InstillAiUserCookie = JSON.parse(
+    cookies["instill-ai-user"]
+  );
+
+  return res.status(200).json({
+    status: "ok",
+    token: instillAiUserCookie,
+  });
+};
+
+export default handler;

--- a/src/pages/api/get-user-cookie.ts
+++ b/src/pages/api/get-user-cookie.ts
@@ -9,14 +9,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     res.status(405).end(`Method ${method} Not Allowed`);
   }
 
-  const instillAiUserCookie: InstillAiUserCookie = JSON.parse(
-    cookies["instill-ai-user"]
-  );
+  const instillAiUserCookie: InstillAiUserCookie = cookies["instill-ai-user"]
+    ? JSON.parse(cookies["instill-ai-user"])
+    : { cookie_token: null };
 
-  return res.status(200).json({
-    status: "ok",
-    token: instillAiUserCookie,
-  });
+  return res.status(200).json(instillAiUserCookie);
 };
 
 export default handler;

--- a/src/pages/api/set-user-cookie.ts
+++ b/src/pages/api/set-user-cookie.ts
@@ -1,0 +1,27 @@
+import { setCookie } from "@/lib/cookie";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { method, body } = req;
+
+  if (method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    res.status(405).end(`Method ${method} Not Allowed`);
+  }
+
+  if (!body.token) {
+    return res.status(500).end("Token not provided");
+  }
+
+  const payload = {
+    cookie_token: body.token,
+  };
+
+  setCookie(res, JSON.stringify(payload), "instill-ai-user", 60 * 60 * 24 * 30);
+
+  return res.status(200).json({
+    status: "ok",
+  });
+};
+
+export default handler;

--- a/src/services/mgmt/useTrackingToken.ts
+++ b/src/services/mgmt/useTrackingToken.ts
@@ -1,34 +1,65 @@
 import { useEffect, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
 
 import { getUserQuery, updateLocalUserMutation } from "@/lib/instill/mgmt";
-import { Nullable } from "@/types/general";
+import { InstillAiUserCookie, Nullable } from "@/types/general";
+import axios from "axios";
+import { useRouter } from "next/router";
 
 const useTrackingToken = () => {
   const [trackingToken, setTrackingToken] = useState<Nullable<string>>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const fetchOrPatchToken = async () => {
+      const instillAiUserCookie = await axios.get<InstillAiUserCookie>(
+        "/api/get-user-cookie"
+      );
+
       const user = await getUserQuery("users/local-user");
-      if (user.cookie_token) {
+
+      // Both backend and cookie have user tracking token that means backend haven't been made down during the session.
+
+      if (instillAiUserCookie.data.cookie_token && user.cookie_token) {
+        if (instillAiUserCookie.data.cookie_token !== user.cookie_token) {
+          console.error("User tracking token conflict, re-initialize cookie");
+
+          await axios.post("/api/set-user-cookie", {
+            token: user.cookie_token,
+          });
+        }
         setTrackingToken(user.cookie_token);
         return;
       }
 
-      const newTrackingToken = uuidv4();
+      // Both backend and cookie don't have tracking token that means user haven't onboard yet.
 
-      const newUser = await updateLocalUserMutation({
-        name: "users/local-user",
-        cookie_token: newTrackingToken,
+      if (!instillAiUserCookie.data.cookie_token && !user.cookie_token) {
+        setTrackingToken("redirect-to-onboard");
+        return;
+      }
+
+      // We only have tracking token inside the backend that means our cookie had been expired.
+
+      if (!instillAiUserCookie.data.cookie_token) {
+        await axios.post("/api/set-user-cookie", {
+          token: user.cookie_token,
+        });
+        setTrackingToken(user.cookie_token as string);
+        return;
+      }
+
+      // We only have tracking token inside the cookie that means our backend had been made down.
+      await updateLocalUserMutation({
+        cookie_token: instillAiUserCookie.data.cookie_token,
       });
 
-      setTrackingToken(newTrackingToken);
+      setTrackingToken(instillAiUserCookie.data.cookie_token);
     };
 
     fetchOrPatchToken().catch((err) => console.error(err));
-  }, []);
+  }, [router.asPath]);
 
-  return trackingToken;
+  return { data: trackingToken, setData: setTrackingToken };
 };
 
 export default useTrackingToken;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -6,3 +6,7 @@ export type State = PipelineState | ConnectorState | ModelState;
 export type Mode = "sync" | "async" | "unspecific";
 
 export type Nullable<T> = T | null;
+
+export type InstillAiUserCookie = {
+  cookie_token: string;
+};


### PR DESCRIPTION
Because

- We want to persist user tracking token in current session but when user `make down` all data exist in local backend will lose, so we need to persist user tracking token inside session cookie

This commit

- Store user tracking token inside the cookie
