### PR TITLE
feat: add mock source service handler

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,10 @@ COMPOSE_DOCKER_CLI_BUILD=1
 #----------- Triton server version ------------#
 TRITONSERVER_VERSION=22.01-py3
 
+#----------- For Jest -------------------------#
 
+NEXT_PUBLIC_MGMT_API_ENDPOINT=http://localhost:8080
+NEXT_PUBLIC_PIPELINE_API_ENDPOINT=http://localhost:8081
+NEXT_PUBLIC_CONNECTOR_API_ENDPOINT=http://localhost:8082
+NEXT_PUBLIC_MODEL_API_ENDPOINT=http://localhost:8083
+NEXT_PUBLIC_API_VERSION=v1alpha

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,17 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jest-environment-jsdom",
   modulePathIgnorePatterns: ["<rootDir>/__tests__/e2e/"],
+  moduleNameMapper: {
+    "^@/components/(.*)$": "<rootDir>/src/components/$1",
+    "^@/utils/(.*)$": "<rootDir>/src/utils/$1",
+    "^@/types/(.*)$": "<rootDir>/src/types/$1",
+    "^@/hooks/(.*)$": "<rootDir>/src/hooks/$1",
+    "^@/style/(.*)$": "<rootDir>/src/style/$1",
+    "^@/services/(.*)$": "<rootDir>/src/services/$1",
+    "^@/lib/(.*)$": "<rootDir>/src/lib/$1",
+    "^@/pages/(.*)$": "<rootDir>/src/pages/$1",
+    "^@/mocks/(.*)$": "<rootDir>/src/mocks/$1",
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -8,7 +8,13 @@ import "@testing-library/jest-dom/extend-expect";
 // ref: https://nextjs.org/docs/basic-features/environment-variables#test-environment-variables
 import { loadEnvConfig } from "@next/env";
 import { server } from "mocks";
+import axios from "axios";
+
 loadEnvConfig(process.cwd());
 
-beforeAll(() => server.listen());
+beforeAll(() => {
+  // To avoid Error: Cross origin http://localhost forbidden
+  axios.defaults.adapter = require("axios/lib/adapters/http");
+  server.listen();
+});
 afterAll(() => server.close());

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -7,8 +7,8 @@ import "@testing-library/jest-dom/extend-expect";
 
 // ref: https://nextjs.org/docs/basic-features/environment-variables#test-environment-variables
 import { loadEnvConfig } from "@next/env";
-import { server } from "mocks";
 import axios from "axios";
+import { server } from "./src/mocks";
 
 loadEnvConfig(process.cwd());
 

--- a/src/mocks/README.md
+++ b/src/mocks/README.md
@@ -1,0 +1,3 @@
+# About mock (most are Mock Server Workers)
+
+This folder is a placeholder for msw. We discover that currently there has so incentive to run a mock server using msw, due to we can already run our vdp backend locally using docker images.

--- a/src/mocks/handlers/connector/source/getSource.ts
+++ b/src/mocks/handlers/connector/source/getSource.ts
@@ -9,28 +9,32 @@ const getSourceHandler = rest.get<
   Record<string, never>,
   GetSourceParam,
   GetSourceResponse
->("/source-connectors/:sourceId", (req, res, ctx) => {
-  const { sourceId } = req.params;
-  return res(
-    ctx.json({
-      source_connector: {
-        name: "source-connectors/source-http",
-        uid: "3a98d0ce-b738-40c4-a5ab-6b359f00b3ba",
-        id: "source-http",
-        source_connector_definition: "source-connector-definitions/source-http",
-        connector: {
-          description: "",
-          configuration: "{}",
-          state: "STATE_CONNECTED",
-          tombstone: false,
-          user: "users/local-user",
-          create_time: "2022-06-14T05:14:47.801646Z",
-          update_time: "2022-06-14T05:14:47.803989Z",
-          org: "",
+>(
+  `${process.env.NEXT_PUBLIC_CONNECTOR_API_ENDPOINT}/${process.env.NEXT_PUBLIC_API_VERSION}/source-connectors/:sourceId`,
+  (req, res, ctx) => {
+    const { sourceId } = req.params;
+    return res(
+      ctx.json({
+        source_connector: {
+          name: "source-connectors/source-http",
+          uid: "3a98d0ce-b738-40c4-a5ab-6b359f00b3ba",
+          id: "source-http",
+          source_connector_definition:
+            "source-connector-definitions/source-http",
+          connector: {
+            description: "",
+            configuration: "{}",
+            state: "STATE_CONNECTED",
+            tombstone: false,
+            user: "users/local-user",
+            create_time: "2022-06-14T05:14:47.801646Z",
+            update_time: "2022-06-14T05:14:47.803989Z",
+            org: "",
+          },
         },
-      },
-    })
-  );
-});
+      })
+    );
+  }
+);
 
 export default getSourceHandler;

--- a/src/mocks/handlers/connector/source/getSource.ts
+++ b/src/mocks/handlers/connector/source/getSource.ts
@@ -1,0 +1,36 @@
+import { GetSourceResponse } from "@/lib/instill";
+import { rest } from "msw";
+
+type GetSourceParam = {
+  sourceId: string;
+};
+
+const getSourceHandler = rest.get<
+  Record<string, never>,
+  GetSourceParam,
+  GetSourceResponse
+>("/source-connectors/:sourceId", (req, res, ctx) => {
+  const { sourceId } = req.params;
+  return res(
+    ctx.json({
+      source_connector: {
+        name: "source-connectors/source-http",
+        uid: "3a98d0ce-b738-40c4-a5ab-6b359f00b3ba",
+        id: "source-http",
+        source_connector_definition: "source-connector-definitions/source-http",
+        connector: {
+          description: "",
+          configuration: "{}",
+          state: "STATE_CONNECTED",
+          tombstone: false,
+          user: "users/local-user",
+          create_time: "2022-06-14T05:14:47.801646Z",
+          update_time: "2022-06-14T05:14:47.803989Z",
+          org: "",
+        },
+      },
+    })
+  );
+});
+
+export default getSourceHandler;

--- a/src/mocks/handlers/connector/source/getSource.ts
+++ b/src/mocks/handlers/connector/source/getSource.ts
@@ -5,6 +5,27 @@ type GetSourceParam = {
   sourceId: string;
 };
 
+export const getPredefindedSource = (sourceId: string): GetSourceResponse => {
+  return {
+    source_connector: {
+      name: `source-connectors/${sourceId}`,
+      uid: "3a98d0ce-b738-40c4-a5ab-6b359f00b3ba",
+      id: sourceId,
+      source_connector_definition: `source-connector-definitions/${sourceId}`,
+      connector: {
+        description: "",
+        configuration: "{}",
+        state: "STATE_CONNECTED",
+        tombstone: false,
+        user: "users/local-user",
+        create_time: "2022-06-14T05:14:47.801646Z",
+        update_time: "2022-06-14T05:14:47.803989Z",
+        org: "",
+      },
+    },
+  };
+};
+
 const getSourceHandler = rest.get<
   Record<string, never>,
   GetSourceParam,
@@ -13,27 +34,7 @@ const getSourceHandler = rest.get<
   `${process.env.NEXT_PUBLIC_CONNECTOR_API_ENDPOINT}/${process.env.NEXT_PUBLIC_API_VERSION}/source-connectors/:sourceId`,
   (req, res, ctx) => {
     const { sourceId } = req.params;
-    return res(
-      ctx.json({
-        source_connector: {
-          name: "source-connectors/source-http",
-          uid: "3a98d0ce-b738-40c4-a5ab-6b359f00b3ba",
-          id: "source-http",
-          source_connector_definition:
-            "source-connector-definitions/source-http",
-          connector: {
-            description: "",
-            configuration: "{}",
-            state: "STATE_CONNECTED",
-            tombstone: false,
-            user: "users/local-user",
-            create_time: "2022-06-14T05:14:47.801646Z",
-            update_time: "2022-06-14T05:14:47.803989Z",
-            org: "",
-          },
-        },
-      })
-    );
+    return res(ctx.json(getPredefindedSource(sourceId)));
   }
 );
 

--- a/src/mocks/handlers/connector/source/index.ts
+++ b/src/mocks/handlers/connector/source/index.ts
@@ -1,3 +1,2 @@
-import getSourceHandler from "./getSource";
-
-export { getSourceHandler };
+export { default } from "./getSource";
+export * from "./getSource";

--- a/src/mocks/handlers/connector/source/index.ts
+++ b/src/mocks/handlers/connector/source/index.ts
@@ -1,0 +1,3 @@
+import getSourceHandler from "./getSource";
+
+export { getSourceHandler };

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,6 @@
 import { getPipelineHandler } from "./pipeline";
+import { getSourceHandler } from "./connector/source";
 
-const handlers = [getPipelineHandler];
+const handlers = [getPipelineHandler, getSourceHandler];
 
 export default handlers;

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,5 @@
 import { getPipelineHandler } from "./pipeline";
-import { getSourceHandler } from "./connector/source";
+import getSourceHandler from "./connector/source";
 
 const handlers = [getPipelineHandler, getSourceHandler];
 

--- a/src/mocks/server/index.ts
+++ b/src/mocks/server/index.ts
@@ -1,4 +1,4 @@
-import handlers from "mocks/handlers";
+import handlers from "../handlers";
 import { setupServer } from "msw/node";
 
 const server = setupServer(...handlers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@/style/*": ["styles/*"],
       "@/services/*": ["services/*"],
       "@/lib/*": ["lib/*"],
-      "@/pages/*": ["pages/*"]
+      "@/pages/*": ["pages/*"],
+      "@/mocks/*": ["mocks/*"]
     },
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
Because

- We need unit-test for services

This commit

- add mock source service handler
- setup the correct jest config
