### PR TITLE
feat: add tailwind plugin to support intelligence picking up custom style and refactor classnames

### DIFF
--- a/src/components/forms/CreateModelForm/CreateModelForm.tsx
+++ b/src/components/forms/CreateModelForm/CreateModelForm.tsx
@@ -387,7 +387,7 @@ const CreateNewModelFlow: FC = () => {
             </div>
             {canDisplayDeployModelSection ? (
               <>
-                <h3 className="instill-text-h3 mt-[60px] mb-5 text-black">
+                <h3 className="text-instill-h3 mt-[60px] mb-5 text-black">
                   Deploy a model instance
                 </h3>
                 <SingleSelect

--- a/src/components/forms/CreatePipelineForm/SetupDestinationStep/CreateNewDestinationFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupDestinationStep/CreateNewDestinationFlow.tsx
@@ -123,7 +123,7 @@ const CreateNewDestinationFlow: FC<CreateNewDestinationFlowProps> = ({
 
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">Setup a new destination</h3>
+      <h3 className="text-instill-h3 text-black">Setup a new destination</h3>
       <TextField
         name="destination.new.id"
         label="Name"

--- a/src/components/forms/CreatePipelineForm/SetupDestinationStep/UseExistingDestinationFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupDestinationStep/UseExistingDestinationFlow.tsx
@@ -82,7 +82,7 @@ const UseExistingDestinationFlow: FC<UseExistingDestinationFlowProps> = ({
 
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">
+      <h3 className="text-instill-h3 text-black">
         Select a existing destination
       </h3>
       <SingleSelect

--- a/src/components/forms/CreatePipelineForm/SetupModelStep/CreateNewModelFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupModelStep/CreateNewModelFlow.tsx
@@ -315,7 +315,7 @@ const CreateNewModelFlow: FC<CreateNewModelFlowProps> = ({
 
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">Set up a new model</h3>
+      <h3 className="text-instill-h3 text-black">Set up a new model</h3>
       <TextField
         name="model.new.id"
         label="Name"
@@ -414,7 +414,7 @@ const CreateNewModelFlow: FC<CreateNewModelFlowProps> = ({
 
       {canDisplayDeployModelSection ? (
         <>
-          <h3 className="instill-text-h3 mt-[60px] mb-5 text-black">
+          <h3 className="text-instill-h3 mt-[60px] mb-5 text-black">
             Deploy a model instance
           </h3>
           <SingleSelect

--- a/src/components/forms/CreatePipelineForm/SetupModelStep/UseExistingModelFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupModelStep/UseExistingModelFlow.tsx
@@ -132,7 +132,7 @@ const UseExistingModelFlow: FC<UseExistingModelFlowProps> = ({
 
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">
+      <h3 className="text-instill-h3 text-black">
         Select a existing online model
       </h3>
       <SingleSelect

--- a/src/components/forms/CreatePipelineForm/SetupSourceStep/CreateNewSourceFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupSourceStep/CreateNewSourceFlow.tsx
@@ -101,7 +101,7 @@ const CreateNewSourceFlow: FC<CreateNewSourceFlowProps> = ({
 
   return (
     <div ref={flowRef} className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">Setup a new source</h3>
+      <h3 className="text-instill-h3 text-black">Setup a new source</h3>
       <TextField
         name="source.new.id"
         label="Name"

--- a/src/components/forms/CreatePipelineForm/SetupSourceStep/UseExistingSourceFlow.tsx
+++ b/src/components/forms/CreatePipelineForm/SetupSourceStep/UseExistingSourceFlow.tsx
@@ -101,7 +101,7 @@ const UseExistingSourceFlow: FC<UseExistingSourceFlowProps> = ({
 
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
-      <h3 className="instill-text-h3 text-black">
+      <h3 className="text-instill-h3 text-black">
         Select a existing online source
       </h3>
       <SingleSelect

--- a/src/components/modals/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/src/components/modals/DeleteResourceModal/DeleteResourceModal.tsx
@@ -122,7 +122,7 @@ const DeleteResourceModal: FC<DeleteResourceModalProps> = ({
       modalIsOpen={modalIsOpen}
     >
       <div className="flex flex-col gap-y-5">
-        <h2 className="instill-text-h2">{modalDetails.title}</h2>
+        <h2 className="text-instill-h2">{modalDetails.title}</h2>
         <p>{modalDetails.description}</p>
         <BasicTextField
           id="confirmation-code"

--- a/src/components/ui/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/Breadcrumb/Breadcrumb.tsx
@@ -10,7 +10,7 @@ const Breadcrumb: FC<BreadcrumbProps> = ({ breadcrumbs }) => {
       {breadcrumbs.map((e, index) => {
         if (breadcrumbs.length === 1) {
           return (
-            <span key={e} className="instill-text-body text-instillGrey70">
+            <span key={e} className="text-instillGrey70 text-instill-body">
               {`${e}`}
             </span>
           );
@@ -18,13 +18,13 @@ const Breadcrumb: FC<BreadcrumbProps> = ({ breadcrumbs }) => {
 
         if (index === breadcrumbs.length - 1) {
           return (
-            <span key={e} className="instill-text-body text-instillBlue50">
+            <span key={e} className="text-instillBlue50 text-instill-body">
               &nbsp;{`${e}`}
             </span>
           );
         }
         return (
-          <span key={e} className="instill-text-body text-instillGrey70">
+          <span key={e} className="text-instillGrey70 text-instill-body">
             {`${e}`}&nbsp;/
           </span>
         );

--- a/src/components/ui/CreatePipelineProgress/ProgressStep.tsx
+++ b/src/components/ui/CreatePipelineProgress/ProgressStep.tsx
@@ -25,7 +25,7 @@ const ProgressStep = forwardRef<HTMLDivElement, ProgressStepProps>(
         >
           <p
             className={cn(
-              "instill-text-h3 m-auto",
+              "text-instill-h3 m-auto",
               isCurrent
                 ? "text-instillBlue50"
                 : isPassed

--- a/src/components/ui/CreatePipelineProgress/ProgressStep.tsx
+++ b/src/components/ui/CreatePipelineProgress/ProgressStep.tsx
@@ -25,7 +25,7 @@ const ProgressStep = forwardRef<HTMLDivElement, ProgressStepProps>(
         >
           <p
             className={cn(
-              "text-instill-h3 m-auto",
+              "m-auto text-instill-h3",
               isCurrent
                 ? "text-instillBlue50"
                 : isPassed
@@ -38,7 +38,7 @@ const ProgressStep = forwardRef<HTMLDivElement, ProgressStepProps>(
         </div>
         <p
           className={cn(
-            "instill-text-small mx-auto",
+            "mx-auto text-instill-small",
             isCurrent
               ? "text-instillBlue50"
               : isPassed

--- a/src/components/ui/FormVerticalDividers/FormVerticalDividers.tsx
+++ b/src/components/ui/FormVerticalDividers/FormVerticalDividers.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 const FormVerticalDividers: FC = () => {
   return (
     <div className="relative mx-5 h-full w-6">
-      <p className="instill-text-h3 absolute top-5 z-10 bg-instillGrey05">OR</p>
+      <p className="text-instill-h3 absolute top-5 z-10 bg-instillGrey05">OR</p>
       <div className="absolute left-1/2 h-full border-r"></div>
     </div>
   );

--- a/src/components/ui/ModelDefinitionLabel/ModelDefinitionLabel.tsx
+++ b/src/components/ui/ModelDefinitionLabel/ModelDefinitionLabel.tsx
@@ -50,7 +50,7 @@ const ModelDefinitionLabel: FC<ModelDefinitionLabelProps> = ({
       {modelDefinition ? (
         <>
           {modelDefinitionIcon}
-          <p className="instill-text-small my-auto flex text-instillGrey90">
+          <p className="my-auto flex text-instillGrey90 text-instill-small">
             {modelDefinition === "model-definitions/github"
               ? "GitHub"
               : "Local"}

--- a/src/components/ui/ModelInstanceTaskLabel/ModelInstanceTaskLabel.tsx
+++ b/src/components/ui/ModelInstanceTaskLabel/ModelInstanceTaskLabel.tsx
@@ -54,7 +54,7 @@ const ModelInstanceTaskLabel: FC<ModelInstanceTaskLabelProps> = ({
       )}
     >
       {modelInstanceTaskIcon}
-      <p className="instill-text-small my-auto flex text-instillGrey90">
+      <p className="my-auto flex text-instillGrey90 text-instill-small">
         {modelInstanceTaskLabel}
       </p>
     </div>

--- a/src/components/ui/PageTitle/PageTitle.tsx
+++ b/src/components/ui/PageTitle/PageTitle.tsx
@@ -32,7 +32,7 @@ const PageTitle: FC<PageTitleProps> = ({
     <div className={cn("flex w-full flex-col", marginBottom)}>
       <Breadcrumb breadcrumbs={breadcrumbs} />
       <div className="flex min-h-[44px] w-full flex-row">
-        <h2 className="instill-text-h2 mt-auto mr-auto text-black">{title}</h2>
+        <h2 className="text-instill-h2 mt-auto mr-auto text-black">{title}</h2>
         {enableButton ? (
           <PrimaryButton
             type="button"

--- a/src/components/ui/PipelineModeLabel/PipelineModeLabel.tsx
+++ b/src/components/ui/PipelineModeLabel/PipelineModeLabel.tsx
@@ -77,7 +77,7 @@ const PipelineModeLabel: FC<PipelineModeLabelProps> = ({
       )}
     >
       {enableIcon ? modeIcon : null}
-      <span className={cn("instill-text-small my-auto", textColor)}>
+      <span className={cn("my-auto text-instill-small", textColor)}>
         {label}
       </span>
     </div>

--- a/src/components/ui/StateLabel/StateLabel.tsx
+++ b/src/components/ui/StateLabel/StateLabel.tsx
@@ -150,7 +150,7 @@ const StateLabel: FC<StateLabelProps> = ({
       )}
     >
       {enableIcon ? stateIcon : null}
-      <span className={cn("instill-text-small my-auto", textColor)}>
+      <span className={cn("my-auto text-instill-small", textColor)}>
         {stateLabelName}
       </span>
     </div>

--- a/src/components/ui/StateOverview/StateOverview.tsx
+++ b/src/components/ui/StateOverview/StateOverview.tsx
@@ -17,7 +17,7 @@ const StateOverview: FC<StateOverviewProps> = ({
     return (
       <div className="flex flex-row gap-x-[5px] py-[3px] pl-[3px] pr-[10px]">
         {icon}
-        <p className="instill-text-body text-black">{counts}</p>
+        <p className="text-black text-instill-body">{counts}</p>
       </div>
     );
   };

--- a/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
+++ b/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
@@ -164,7 +164,7 @@ const ConnectionTypeCell: FC<ConnectionTypeCellProps> = ({
             {icon}
             <p
               className={cn(
-                "instill-text-body my-auto text-instillGrey90",
+                "my-auto text-instillGrey90 text-instill-body",
                 lineClamp
               )}
             >
@@ -192,7 +192,7 @@ const ConnectionTypeCell: FC<ConnectionTypeCellProps> = ({
             </div>
             <p
               className={cn(
-                "instill-text-body my-auto text-instillGrey90",
+                "my-auto text-instillGrey90 text-instill-body",
                 lineClamp
               )}
             >

--- a/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
+++ b/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
@@ -186,7 +186,7 @@ const ConnectionTypeCell: FC<ConnectionTypeCellProps> = ({
           <div className="flex flex-col gap-y-[6px]">
             <div className="flex flex-row gap-x-[5px]">
               {icon}
-              <p className="instill-text-small my-auto text-instillGrey90">
+              <p className="my-auto text-instillGrey90 text-instill-small">
                 {definitionName}
               </p>
             </div>

--- a/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
+++ b/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
@@ -79,7 +79,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
               enableItemBgColor={false}
               indicator="modelInstance"
               listItemsContainerWidth={widthInNumber}
-              textStyle="instill-text-body"
+              textStyle="text-instill-body"
             />
           </div>
         </CellBase>
@@ -93,7 +93,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
           <div className={cn("flex flex-col gap-y-3", width)}>
             <div className="flex flex-row gap-x-3">
               {icon}
-              <p className="instill-text-body text-instillGrey90">
+              <p className="text-instillGrey90 text-instill-body">
                 {instances ? instances.length : 0}
               </p>
             </div>

--- a/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
+++ b/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
@@ -102,7 +102,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
               enableItemBgColor={true}
               indicator="state"
               listItemsContainerWidth={widthInNumber}
-              textStyle="instill-text-small"
+              textStyle="text-instill-small"
             />
           </div>
         </CellBase>

--- a/src/components/ui/TableCells/InstanceCell/InstanceInnerList.tsx
+++ b/src/components/ui/TableCells/InstanceCell/InstanceInnerList.tsx
@@ -113,7 +113,7 @@ const InstanceInnerList: FC<InstanceInnerListProps> = ({
               : ""
           )}
         >
-          <p className="instill-text-small my-auto text-instillGrey70">{`+ ${
+          <p className="my-auto text-instillGrey70 text-instill-small">{`+ ${
             items.length - displayLimit
           }`}</p>
         </div>

--- a/src/components/ui/TableCells/ModeCell/ModeCell.tsx
+++ b/src/components/ui/TableCells/ModeCell/ModeCell.tsx
@@ -60,7 +60,7 @@ const ModeCell: FC<ModeCellProps> = ({
     >
       <div className={cn("flex gap-x-2 px-2 py-3", width)}>
         {modeIcon}
-        <p className="instill-text-body text-instillGrey90">
+        <p className="text-instillGrey90 text-instill-body">
           {mode === "MODE_ASYNC" ? "Async" : "Sync"}
         </p>
       </div>

--- a/src/components/ui/TableCells/ModelDefinitionCell/ModelDefinitionCell.tsx
+++ b/src/components/ui/TableCells/ModelDefinitionCell/ModelDefinitionCell.tsx
@@ -61,7 +61,7 @@ const ModelDefintionCell: FC<ModelDefintionCellProps> = ({
     >
       <div className={cn("flex flex-row gap-x-2", width)}>
         {definitionIcon}
-        <p className="instill-text-body my-auto flex text-instillGrey90">
+        <p className="my-auto flex text-instillGrey90 text-instill-body">
           {modelDefinition === "model-definitions/local" ? "Local" : "GitHub"}
         </p>
       </div>

--- a/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
+++ b/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
@@ -63,7 +63,7 @@ const ModelsCell: FC<ModelsCellProps> = ({
                 <div
                   key={e.id}
                   className={cn(
-                    "instill-text-body",
+                    "text-instill-body",
                     getStateTextColor(e.state)
                   )}
                 >{`${key}/${e.id}`}</div>

--- a/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
+++ b/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
@@ -54,7 +54,7 @@ const ModelsCell: FC<ModelsCellProps> = ({
                 color="fill-black"
                 position="my-auto"
               />
-              <p className="instill-text-small my-auto text-instillGrey70">
+              <p className="my-auto text-instillGrey70 text-instill-small">
                 {key}
               </p>
             </div>

--- a/src/components/ui/TableCells/NameCell/NameCell.tsx
+++ b/src/components/ui/TableCells/NameCell/NameCell.tsx
@@ -42,7 +42,7 @@ const NameCell: FC<NameCellProps> = ({
         />
       </div>
       <div className="flex flex-col gap-y-2">
-        <h3 className={cn("instill-text-h3", lineClamp)}>{name}</h3>
+        <h3 className={cn("text-instill-h3", lineClamp)}>{name}</h3>
         {displayUpdateTime ? (
           <p className="instill-text-small text-instillGrey50">{`last sync ${time}`}</p>
         ) : null}

--- a/src/components/ui/TableCells/NameCell/NameCell.tsx
+++ b/src/components/ui/TableCells/NameCell/NameCell.tsx
@@ -44,7 +44,7 @@ const NameCell: FC<NameCellProps> = ({
       <div className="flex flex-col gap-y-2">
         <h3 className={cn("text-instill-h3", lineClamp)}>{name}</h3>
         {displayUpdateTime ? (
-          <p className="instill-text-small text-instillGrey50">{`last sync ${time}`}</p>
+          <p className="text-instillGrey50 text-instill-small">{`last sync ${time}`}</p>
         ) : null}
       </div>
     </div>

--- a/src/components/ui/TableHeads/PipelineOverviewTableHead/PipelineOverviewTableHead.tsx
+++ b/src/components/ui/TableHeads/PipelineOverviewTableHead/PipelineOverviewTableHead.tsx
@@ -5,7 +5,7 @@ const PipelineOverviewTableHead: FC = () => {
   const getHeadItem = (name: string) => {
     return (
       <div className="flex flex-row gap-x-[15px]">
-        <div className="instill-text-body my-auto text-instillGrey90">
+        <div className="my-auto text-instillGrey90 text-instill-body">
           {name}
         </div>
       </div>

--- a/src/components/ui/TableHeads/TableHeadBase/TableHeadBase.tsx
+++ b/src/components/ui/TableHeads/TableHeadBase/TableHeadBase.tsx
@@ -23,7 +23,7 @@ const TableHeadBase: FC<TableHeadBaseProps> = ({
         {items.map((e, index) => {
           const element =
             typeof e.item === "string" ? (
-              <p className="instill-text-body text-instillGrey90 flex">
+              <p className="flex text-instillGrey90 text-instill-body">
                 {e.item}
               </p>
             ) : (

--- a/src/components/ui/TableLoadingProgress/TableLoadingProgress.tsx
+++ b/src/components/ui/TableLoadingProgress/TableLoadingProgress.tsx
@@ -21,7 +21,7 @@ const TableLoadingProgress: FC<TableLoadingProgressProps> = ({
             position="m-auto"
           />
         </div>
-        <p className="instill-text-small mx-auto text-instillGrey50">
+        <p className="mx-auto text-instillGrey50 text-instill-small">
           loading...
         </p>
       </div>

--- a/src/components/ui/TablePlaceholders/TablePlaceholderBase/TablePlaceholderBase.tsx
+++ b/src/components/ui/TablePlaceholders/TablePlaceholderBase/TablePlaceholderBase.tsx
@@ -42,7 +42,7 @@ const TablePlaceholderBase: FC<TablePlaceholderBaseProps> = ({
         ))}
       </div>
       <div className="m-auto flex flex-col gap-y-5">
-        <h3 className="instill-text-h3 text-instillGrey80">
+        <h3 className="text-instill-h3 text-instillGrey80">
           {placeholderTitle}
         </h3>
         {enableCreateButton ? (

--- a/src/components/ui/TestModelInstanceResultBlock/TestModelInstanceResultBlock.tsx
+++ b/src/components/ui/TestModelInstanceResultBlock/TestModelInstanceResultBlock.tsx
@@ -18,7 +18,7 @@ const TestModelInstanceResultBlock: FC<TestModelInstanceResultBlockProps> = ({
   return (
     <div className={cn("flex flex-col bg-white", width)}>
       <div className="flex flex-row p-2.5">
-        <p className="instill-text-body my-auto mr-auto text-instillGrey90">
+        <p className="my-auto mr-auto text-instillGrey90 text-instill-body">
           Testing result
         </p>
         <button

--- a/src/pages/destinations/[id].tsx
+++ b/src/pages/destinations/[id].tsx
@@ -77,7 +77,7 @@ const DestinationDetailsPage: FC & {
         marginBottom="mb-[50px]"
       />
       <div className="mb-5 flex flex-row gap-x-5">
-        <h3 className="instill-text-h3 my-auto text-black">State</h3>
+        <h3 className="text-instill-h3 my-auto text-black">State</h3>
         <StateLabel
           enableIcon={true}
           enableBgColor={true}
@@ -89,7 +89,7 @@ const DestinationDetailsPage: FC & {
           paddingX="px-2"
         />
       </div>
-      <h3 className="instill-text-h3 mb-5 text-black">Overview</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Overview</h3>
       <PipelinesTable
         pipelines={
           destinationWithPipelines.data
@@ -100,7 +100,7 @@ const DestinationDetailsPage: FC & {
         marginBottom="mb-10"
         enablePlaceholderCreateButton={false}
       />
-      <h3 className="instill-text-h3 mb-5 text-black">Settings</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Settings</h3>
       <div>
         <ConfigureDestinationForm
           destination={

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -194,7 +194,7 @@ const ModelDetailsPage: FC & {
         marginBottom="mb-10"
       />
       <div className="mb-5 flex flex-row gap-x-2.5">
-        <h2 className="text-instill-h2 my-auto text-black ">{`${
+        <h2 className="my-auto text-black text-instill-h2 ">{`${
           model.isSuccess ? model.data.id : ""
         }`}</h2>
         <BasicSingleSelect
@@ -229,14 +229,14 @@ const ModelDetailsPage: FC & {
           iconPosition="my-auto"
         />
       </div>
-      <h3 className="instill-text-h3 mb-5 text-black">Overview</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Overview</h3>
       <PipelinesTable
         pipelines={selectedModelInstancePipelines}
         isLoadingPipeline={pipelines.isLoading}
         marginBottom="mb-10"
         enablePlaceholderCreateButton={false}
       />
-      <h3 className="instill-text-h3 mb-5 text-black">Settings</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Settings</h3>
       {modelWithInstances.isLoading ? null : selectedModelInstances ? (
         <>
           <ConfigureModelInstanceForm

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -194,7 +194,7 @@ const ModelDetailsPage: FC & {
         marginBottom="mb-10"
       />
       <div className="mb-5 flex flex-row gap-x-2.5">
-        <h2 className="instill-text-h2 my-auto text-black ">{`${
+        <h2 className="text-instill-h2 my-auto text-black ">{`${
           model.isSuccess ? model.data.id : ""
         }`}</h2>
         <BasicSingleSelect

--- a/src/pages/pipelines/[id].tsx
+++ b/src/pages/pipelines/[id].tsx
@@ -96,7 +96,7 @@ const PipelineDetailsPage: FC & {
         isLoading={false}
         marginBottom="mb-10"
       />
-      <h3 className="instill-text-h3 mb-5 text-black">Settings</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Settings</h3>
       <ConfigurePipelineForm
         pipeline={pipeline.isSuccess ? pipeline.data : null}
         marginBottom={null}

--- a/src/pages/sources/[id].tsx
+++ b/src/pages/sources/[id].tsx
@@ -75,7 +75,7 @@ const SourceDetailsPage: FC & {
         marginBottom="mb-[50px]"
       />
       <div className="mb-5 flex flex-row gap-x-5">
-        <h3 className="instill-text-h3 my-auto text-black">State</h3>
+        <h3 className="text-instill-h3 my-auto text-black">State</h3>
         <StateLabel
           enableIcon={true}
           enableBgColor={true}
@@ -87,7 +87,7 @@ const SourceDetailsPage: FC & {
           paddingX="px-2"
         />
       </div>
-      <h3 className="instill-text-h3 mb-5 text-black">Overview</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Overview</h3>
       <PipelinesTable
         pipelines={
           sourceWithPipelines.data ? sourceWithPipelines.data.pipelines : []
@@ -96,7 +96,7 @@ const SourceDetailsPage: FC & {
         marginBottom="mb-10"
         enablePlaceholderCreateButton={false}
       />
-      <h3 className="instill-text-h3 mb-5 text-black">Settings</h3>
+      <h3 className="text-instill-h3 mb-5 text-black">Settings</h3>
       <div>
         <ConfigureSourceForm
           source={sourceWithPipelines.data ? sourceWithPipelines.data : null}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,16 +5,10 @@
 @tailwind utilities;
 
 @layer utilities {
-  .text-instill-h1 {
-    @apply font-sans text-[32px] font-medium leading-[42px];
-  }
-  .text-instill-h2 {
-    @apply font-mono text-[20px] font-medium leading-[26px];
-  }
   .text-instill-h3 {
     @apply font-sans text-base font-normal leading-[28px];
   }
-  .instill-text-body {
+  .text-instill-body {
     @apply font-sans text-sm font-normal leading-[18px];
   }
   .instill-text-bold-body {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,7 +11,7 @@
   .text-instill-h2 {
     @apply font-mono text-[20px] font-medium leading-[26px];
   }
-  .instill-text-h3 {
+  .text-instill-h3 {
     @apply font-sans text-base font-normal leading-[28px];
   }
   .instill-text-body {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,10 +5,10 @@
 @tailwind utilities;
 
 @layer utilities {
-  .instill-text-h1 {
+  .text-instill-h1 {
     @apply font-sans text-[32px] font-medium leading-[42px];
   }
-  .instill-text-h2 {
+  .text-instill-h2 {
     @apply font-mono text-[20px] font-medium leading-[26px];
   }
   .instill-text-h3 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,13 +8,10 @@
   .text-instill-h3 {
     @apply font-sans text-base font-normal leading-[28px];
   }
-  .text-instill-body {
-    @apply font-sans text-sm font-normal leading-[18px];
-  }
   .instill-text-bold-body {
     @apply font-sans text-sm font-semibold leading-[18px];
   }
-  .instill-text-small {
+  .text-instill-small {
     @apply font-mono text-xs font-normal;
   }
   .instill-input-highlight {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,36 +4,7 @@
 
 @tailwind utilities;
 
-@layer utilities {
-  .text-instill-h3 {
-    @apply font-sans text-base font-normal leading-[28px];
-  }
-  .instill-text-bold-body {
-    @apply font-sans text-sm font-semibold leading-[18px];
-  }
-  .text-instill-small {
-    @apply font-mono text-xs font-normal;
-  }
-  .instill-input-highlight {
-    @apply focus:border-instillBlue50 focus:outline-none focus:ring-0 focus:ring-white;
-  }
-
-  .instill-input-highlight:focus {
-    box-shadow: 0px 0px 0px 3px rgba(64, 168, 245, 0.2);
-  }
-
-  .instill-input-focus-shadow {
-    box-shadow: 0px 0px 0px 3px rgba(64, 168, 245, 0.2);
-  }
-
-  .instill-progress-message-box-shadow {
-    box-shadow: 2px 2px 5px 4px rgba(0, 0, 0, 0.04);
-  }
-
-  .instill-input-no-highlight {
-    @apply focus:outline-none focus:ring-0 focus:ring-opacity-0;
-  }
-}
+@layer utilities 
 
 @font-face {
   font-family: "instill";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,7 +74,7 @@ module.exports = {
 
     // We have to use plugin to let intelligence pick up our custom classname's style
     // ref: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/227
-    ({ addUtilities, theme, addComponents }) => {
+    ({ addUtilities }) => {
       addUtilities({
         ".text-instill-h1": {
           fontFamily: `IBM Plex Sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
@@ -118,9 +118,6 @@ module.exports = {
         ".instill-progress-message-box-shadow": {
           boxShadow: "2px 2px 5px 4px rgba(0, 0, 0, 0.04)",
         },
-      });
-
-      addComponents({
         ".instill-input-no-highlight": {
           "@apply focus:outline-none focus:ring-0 focus:ring-opacity-0": {},
         },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,5 +69,66 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/line-clamp")],
+  plugins: [
+    require("@tailwindcss/line-clamp"),
+
+    // We have to use plugin to let intelligence pick up our custom classname's style
+    // ref: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/227
+    ({ addUtilities, theme, addComponents }) => {
+      addUtilities({
+        ".text-instill-h1": {
+          fontFamily: `IBM Plex Sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+          fontSize: "32px",
+          fontWeight: 500,
+          lineHeight: "42px",
+        },
+        ".text-instill-h2": {
+          fontFamily: `IBM Plex Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+          fontSize: "20px",
+          fontWeight: 500,
+          lineHeight: "26px",
+        },
+        ".text-instill-h3": {
+          fontFamily: `IBM Plex Sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+          fontSize: "16px",
+          fontWeight: 500,
+          lineHeight: "28px",
+        },
+        ".text-instill-body": {
+          fontFamily: `IBM Plex Sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+          fontSize: "14px",
+          fontWeight: 400,
+          lineHeight: "18px",
+        },
+        ".text-instill-bold-body": {
+          fontFamily: `IBM Plex Sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"`,
+          fontSize: "14px",
+          fontWeight: 600,
+          lineHeight: "18px",
+        },
+        ".text-instill-small": {
+          fontFamily: `IBM Plex Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+          fontSize: "12px",
+          fontWeight: 400,
+          lineHeight: "16px",
+        },
+        ".instill-input-focus-shadow": {
+          boxShadow: "0px 0px 0px 3px rgba(64, 168, 245, 0.2)",
+        },
+        ".instill-progress-message-box-shadow": {
+          boxShadow: "2px 2px 5px 4px rgba(0, 0, 0, 0.04)",
+        },
+      });
+
+      addComponents({
+        ".instill-input-no-highlight": {
+          "@apply focus:outline-none focus:ring-0 focus:ring-opacity-0": {},
+        },
+        ".instill-input-highlight": {
+          "@apply focus:border-instillBlue50 focus:outline-none focus:ring-0 focus:ring-white":
+            {},
+        },
+      });
+    },
+  ],
 };


### PR DESCRIPTION
Because

- Intelligence can't pick up custom style due to the constraint of TailwindCSS intelligence
- Refactor instill-text-h1 to text-instill-h1 to follow the Tailwind naming convention

This commit

- Implement custom plugin to let intelligence pick up custom style
- Refactor classnames
