### PR TITLE
feat: add empty package_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           command: manifest
           config-file: release-please/config.json
           manifest-file: release-please/manifest.json
+          package-name: ""
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.botGitHubToken }}


### PR DESCRIPTION
Because

- Right now release-please use our package.json.name as prefix, need to remove it

This commit

- try to solve above issue with empty package-name config
