### PR TITLE
refactor: refactor docker-compose from args to env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 ARG DISABLE_USAGE_COLLECTION
 
-RUN NEXT_PUBLIC_DISABLE_USAGE_COLLECTION=${DISABLE_USAGE_COLLECTION} yarn build
+RUN NEXT_PUBLIC_DISABLE_USAGE_COLLECTION=NEXT_PUBLIC_DISABLE_USAGE_COLLECTION yarn build
 
 # If using npm comment out above and use below instead
 # RUN npm run build
@@ -50,10 +50,17 @@ COPY --from=builder /app/.env.production ./.env.production
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
+# Because we need to execute this script, it needs to be copied with this user group
+COPY --from=builder --chown=nextjs:nodejs /app/entrypoint.sh ./entrypoint.sh
+
 USER nextjs
 
 EXPOSE 3000
 
 ENV PORT 3000
+
+# Permisions to execute script
+RUN ["chmod", "+x", "./entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 
 CMD ["node", "server.js"]

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -8,5 +8,5 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        DISABLE_USAGE_COLLECTION: "false"
+    environment:
+      - DISABLE_USAGE_COLLECTION=false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# We use this script to replace all the NEXT_PUBLIC_DISABLE_USAGE_COLLECTION env from "NEXT_PUBLIC_DISABLE_USAGE_COLLECTION"
+# to true/false, user could input this variable from docker-compose env config
+
+echo "DISABLE_USAGE_COLLECTION=$DISABLE_USAGE_COLLECTION"
+test -n "$NEXT_PUBLIC_DISABLE_USAGE_COLLECTION"
+
+find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#NEXT_PUBLIC_DISABLE_USAGE_COLLECTION#$DISABLE_USAGE_COLLECTION#g"
+
+echo "Starting Nextjs"
+exec "$@"


### PR DESCRIPTION
Because

- We need to let user input disable_usage_collection with env variable

This commit

- refactor docker-compose and implement entrypoint script
