### PR TITLE
fix: fix missing title and typo when deploy model instance

### DIFF
--- a/src/components/forms/model/CreateModelForm/CreateModelForm.tsx
+++ b/src/components/forms/model/CreateModelForm/CreateModelForm.tsx
@@ -488,7 +488,7 @@ const CreateNewModelFlow: FC = () => {
                 <SingleSelect
                   id="modelInstanceId"
                   name="modelInstanceId"
-                  label="Source type"
+                  label="Model Instances"
                   additionalMessageOnLabel={null}
                   options={modelInstanceOptions ? modelInstanceOptions : []}
                   value={selectedModelInstanceOption}

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -315,6 +315,7 @@ const ModelDetailsPage: FC & {
             modelInstance={selectedModelInstances}
             marginBottom="mb-10"
           />
+          <h3 className="mb-5 text-black text-instill-h3">Testings</h3>
           <TestModelInstanceForm modelInstance={selectedModelInstances} />
         </>
       ) : null}


### PR DESCRIPTION
Because

- Missing title at model instance page
- There has a typo when deploy model instance

This commit

- Fix above issue