### PR TITLE
feat: add model instance's readme card

### DIFF
--- a/src/components/ui/ModelInstanceReadmeCard/ModelInstanceReadmeCard.tsx
+++ b/src/components/ui/ModelInstanceReadmeCard/ModelInstanceReadmeCard.tsx
@@ -1,0 +1,28 @@
+import { FC } from "react";
+import cn from "clsx";
+
+export type ModelInstanceReadmeCardProps = {
+  marginBottom: string;
+};
+
+const ModelInstanceReadmeCard: FC<ModelInstanceReadmeCardProps> = ({
+  marginBottom,
+}) => {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[200px] w-full flex-col border border-instillGrey20 bg-white",
+        marginBottom
+      )}
+    >
+      <h3 className="mx-auto mt-auto text-instillGrey90 text-instill-h3">
+        There is no Model card
+      </h3>
+      <p className="mx-auto mb-auto text-instillGrey50 text-instill-body">
+        You can add a README.md to discribe the model.
+      </p>
+    </div>
+  );
+};
+
+export default ModelInstanceReadmeCard;

--- a/src/components/ui/ModelInstanceReadmeCard/index.ts
+++ b/src/components/ui/ModelInstanceReadmeCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ModelInstanceReadmeCard";
+export * from "./ModelInstanceReadmeCard";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -23,6 +23,8 @@ import type { ModelInstanceTaskLabelProps } from "./ModelInstanceTaskLabel";
 import ModelInstanceTaskLabel from "./ModelInstanceTaskLabel";
 import type { PageTitleProps } from "./PageTitle";
 import PageTitle from "./PageTitle";
+import ModelInstanceReadmeCard from "./ModelInstanceReadmeCard";
+import type { ModelInstanceReadmeCardProps } from "./ModelInstanceReadmeCard";
 
 export type {
   StateIndicatorProps,
@@ -34,6 +36,7 @@ export type {
   TableLoadingProgressProps,
   ModelInstanceTaskLabelProps,
   PageTitleProps,
+  ModelInstanceReadmeCardProps,
 };
 
 export {
@@ -52,6 +55,7 @@ export {
   TableLoadingProgress,
   ModelInstanceTaskLabel,
   PageTitle,
+  ModelInstanceReadmeCard,
 };
 
 export * from "./TableHeads";

--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -27,6 +27,7 @@ import {
   ModelInstanceTaskLabel,
   PipelinesTable,
   PageTitle,
+  ModelInstanceReadmeCard,
 } from "@/components/ui";
 import {
   ConfigureModelForm,
@@ -311,6 +312,7 @@ const ModelDetailsPage: FC & {
       <h3 className="mb-5 text-black text-instill-h3">Settings</h3>
       {modelInstances.isLoading ? null : selectedModelInstances ? (
         <>
+          <ModelInstanceReadmeCard marginBottom="mb-5" />
           <ConfigureModelInstanceForm
             modelInstance={selectedModelInstances}
             marginBottom="mb-10"


### PR DESCRIPTION
Because

- The model instance's readme card is missing

This commit

- add ModelInstanceReadmeCard
- close #70 