### PR TITLE
fix: fix toggle model instance will cause re-order model instance dropdown issue

### DIFF
--- a/src/pages/models/[id].tsx
+++ b/src/pages/models/[id].tsx
@@ -83,14 +83,16 @@ const ModelDetailsPage: FC & {
   useEffect(() => {
     if (!modelInstances.isSuccess) return;
 
-    setSelectedModelInstanceOption(
-      modelInstances.isSuccess
-        ? {
-            value: modelInstances.data[0].id,
-            label: modelInstances.data[0].id,
-          }
-        : null
-    );
+    if (!selectedModelInstanceOption) {
+      setSelectedModelInstanceOption(
+        modelInstances.isSuccess
+          ? {
+              value: modelInstances.data[0].id,
+              label: modelInstances.data[0].id,
+            }
+          : null
+      );
+    }
   }, [modelInstances.isSuccess, modelInstances.data]);
 
   const selectedModelInstances = useMemo(() => {
@@ -177,6 +179,10 @@ const ModelDetailsPage: FC & {
     }
 
     return false;
+  }, [selectedModelInstances]);
+
+  useEffect(() => {
+    setHasErrorWhenChangingModelInstanceState(false);
   }, [selectedModelInstances]);
 
   const handleToggleModelInstanceState = useCallback(() => {


### PR DESCRIPTION
Because

- When toggle model instance, it will cause re-ordering the model instance dropdown

This commit

- Fix above issue