### PR TITLE
refactor: remove model state indicator

### DIFF
--- a/src/components/ui/TableCells/NameCell/NameCell.tsx
+++ b/src/components/ui/TableCells/NameCell/NameCell.tsx
@@ -14,6 +14,7 @@ export type NameCellProps = {
   link: Nullable<string>;
   lineClamp: Nullable<string>;
   displayUpdateTime: boolean;
+  displayStateIndicator: boolean;
 } & CellBaseProps;
 
 const NameCell: FC<NameCellProps> = ({
@@ -28,18 +29,23 @@ const NameCell: FC<NameCellProps> = ({
   link,
   lineClamp,
   displayUpdateTime,
+  displayStateIndicator,
 }) => {
   const time = getHumanReadableStringFromTime(updatedAt, Date.now());
 
   const CellItem = () => (
     <div className={cn("flex flex-row gap-x-2.5", width)}>
-      <div className="flex h-8 w-8">
-        <StateIndicator
-          state={state}
-          width="w-[18px]"
-          height="h-[18px]"
-          position="m-auto"
-        />
+      <div
+        className={cn("flex", displayStateIndicator ? "h-8 w-8" : "h-4 w-4")}
+      >
+        {displayStateIndicator ? (
+          <StateIndicator
+            state={state}
+            width="w-[18px]"
+            height="h-[18px]"
+            position="m-auto"
+          />
+        ) : null}
       </div>
       <div className="flex flex-col gap-y-2">
         <h3 className={cn("text-instill-h3", lineClamp)}>{name}</h3>

--- a/src/components/ui/TableHeads/ModelTableHead/ModelTableHead.tsx
+++ b/src/components/ui/TableHeads/ModelTableHead/ModelTableHead.tsx
@@ -1,28 +1,13 @@
 import { FC } from "react";
-import StateOverview from "../../StateOverview";
 import TableHeadBase from "../TableHeadBase";
 
-export type ModelTableHeadProps = {
-  errorCounts: number;
-  offlineCounts: number;
-  onlineCounts: number;
-};
+// export type ModelTableHeadProps = {};
 
-const ModelTableHead: FC<ModelTableHeadProps> = ({
-  errorCounts,
-  offlineCounts,
-  onlineCounts,
-}) => {
+const ModelTableHead: FC = () => {
   const ModelHeadItem = [
     {
-      key: "model-state-overview-head",
-      item: (
-        <StateOverview
-          errorCounts={errorCounts}
-          offlineCounts={offlineCounts}
-          onlineCounts={onlineCounts}
-        />
-      ),
+      key: "model-name",
+      item: <></>,
     },
     {
       key: "model-source-head",

--- a/src/components/ui/TableHeads/index.ts
+++ b/src/components/ui/TableHeads/index.ts
@@ -5,7 +5,6 @@ import type { ConnectorTableHeadProps } from "./ConnectorTableHead";
 import PipelineOverviewTableHead from "./PipelineOverviewTableHead";
 import SourcePipelinesTableHead from "./SourcePipelinesTableHead";
 import ModelTableHead from "./ModelTableHead";
-import type { ModelTableHeadProps } from "./ModelTableHead";
 
 export {
   PipelinesTableHead,
@@ -14,8 +13,4 @@ export {
   SourcePipelinesTableHead,
   ModelTableHead,
 };
-export type {
-  PipelinesTableHeadProps,
-  ConnectorTableHeadProps,
-  ModelTableHeadProps,
-};
+export type { PipelinesTableHeadProps, ConnectorTableHeadProps };

--- a/src/components/ui/Tables/DestinationsTable/DestinationsTable.tsx
+++ b/src/components/ui/Tables/DestinationsTable/DestinationsTable.tsx
@@ -77,6 +77,7 @@ const DestinationsTable: FC<DestinationsTableProps> = ({
               link={`/destinations/${destination.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={true}
+              displayStateIndicator={true}
             />
             <ConnectionTypeCell
               definitionName={

--- a/src/components/ui/Tables/ModelsTable/ModelsTable.tsx
+++ b/src/components/ui/Tables/ModelsTable/ModelsTable.tsx
@@ -50,11 +50,7 @@ const ModelsTable: FC<ModelsTableProps> = ({
       tableLayout="table-auto"
       borderCollapse="border-collapse"
     >
-      <ModelTableHead
-        onlineCounts={stateOverviewCounts?.online || 0}
-        offlineCounts={stateOverviewCounts?.offline || 0}
-        errorCounts={stateOverviewCounts?.error || 0}
-      />
+      <ModelTableHead />
       <TableBody>
         {models.map((model) => (
           <TableRow
@@ -74,6 +70,7 @@ const ModelsTable: FC<ModelsTableProps> = ({
               link={`/models/${model.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={false}
+              displayStateIndicator={false}
             />
             <ModelDefinitionCell
               width="w-[269px]"

--- a/src/components/ui/Tables/PipelinesTable/PipelinesTable.tsx
+++ b/src/components/ui/Tables/PipelinesTable/PipelinesTable.tsx
@@ -78,6 +78,7 @@ const PipelinesTable: FC<PipelinesTableProps> = ({
               link={`/pipelines/${pipeline.id}`}
               lineClamp="line-clamp-2"
               displayUpdateTime={false}
+              displayStateIndicator={true}
             />
             <ModeCell
               width="w-[100px]"

--- a/src/components/ui/Tables/SourcesTable/SourcesTable.tsx
+++ b/src/components/ui/Tables/SourcesTable/SourcesTable.tsx
@@ -77,6 +77,7 @@ const SourcesTable: FC<SourcesTableProps> = ({
               link={`/sources/${source.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={true}
+              displayStateIndicator={true}
             />
             <ConnectionTypeCell
               definitionName={


### PR DESCRIPTION
Because

- It's confusing that model has state

This commit

- Remove model state indicator at models table
