### PR TITLE
fix: fix images action condition setup-node issue

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup node env
+        if: github.event_name == 'release'
         uses: actions/setup-node@v3
         with:
           node-version: 14


### PR DESCRIPTION
Because

- setup-node is lacking the release condition

This commit

- Fix above issue
