### PR TITLE
refactor: adapt new model readme data structure

### DIFF
--- a/src/lib/instill/model/types.ts
+++ b/src/lib/instill/model/types.ts
@@ -73,6 +73,6 @@ export type ModelInstanceReadme = {
   name: string;
   size: number;
   type: string;
-  contents: string;
+  content: string;
   encoding: string;
 };

--- a/src/services/model/useModelInstanceReadme.ts
+++ b/src/services/model/useModelInstanceReadme.ts
@@ -19,7 +19,7 @@ const useModelInstanceReadme = (modelInstanceName: Nullable<string>) => {
         modelInstanceName
       );
 
-      return Promise.resolve(window.atob(modelInstanceReadme.contents));
+      return Promise.resolve(window.atob(modelInstanceReadme.content));
     },
     {
       enabled: modelInstanceName ? true : false,


### PR DESCRIPTION
Because

- #129 

This commit

- Adapt new model readme data structure
- close #129
