### PR TITLE
refactor: make sure readme is correct

### DIFF
--- a/src/components/ui/ModelInstanceReadmeCard/ModelInstanceReadmeCard.tsx
+++ b/src/components/ui/ModelInstanceReadmeCard/ModelInstanceReadmeCard.tsx
@@ -32,7 +32,7 @@ const ModelInstanceReadmeCard: FC<ModelInstanceReadmeCardProps> = ({
             position="m-auto"
           />
         </div>
-      ) : markdown ? (
+      ) : markdown && markdown !== "" ? (
         <div className="markdown-body">
           <ReactMarkdown remarkPlugins={[remarkFrontmatter]}>
             {markdown}


### PR DESCRIPTION
Because

- #136 

This commit

- Make sure readme will correctly render `content=""`
- close #136