### PR TITLE
refactor: remove all the data prefix before sources and destination

### DIFF
--- a/e2e/integration/pipeline.spec.ts
+++ b/e2e/integration/pipeline.spec.ts
@@ -60,7 +60,7 @@ test.describe.serial("Simple sync pipeline with local model", () => {
 
     const isOnSetupDestinationStep = await page
       .locator("h2", {
-        hasText: "Set Up Data Destination",
+        hasText: "Set Up Destination",
       })
       .isVisible();
 
@@ -194,7 +194,7 @@ test.describe.serial("Simple sync pipeline with github model", () => {
 
     const isOnSetupDestinationStep = await page
       .locator("h2", {
-        hasText: "Set Up Data Destination",
+        hasText: "Set Up Destination",
       })
       .isVisible();
 

--- a/src/components/forms/connector/destination/ConfigureDestinationForm/ConfigureDestinationForm.tsx
+++ b/src/components/forms/connector/destination/ConfigureDestinationForm/ConfigureDestinationForm.tsx
@@ -192,7 +192,7 @@ const ConfigureDestinationForm: FC<ConfigureDestinationFormProps> = ({
                 <SingleSelect
                   id="destinationDefinition"
                   name="definition"
-                  label="Data destination"
+                  label="Destination"
                   value={selectedDestinationDefinitionOption}
                   options={syncDestinationDefinitionOptions}
                   additionalOnChangeCb={destinationDefinitionOnChangeCb}

--- a/src/components/forms/connector/destination/CreateDestinationForm/CreateDestinationForm.tsx
+++ b/src/components/forms/connector/destination/CreateDestinationForm/CreateDestinationForm.tsx
@@ -417,7 +417,7 @@ const CreateDestinationForm: FC<CreateDestinationFormProps> = ({
           id="description"
           label="Description"
           key="description"
-          description="Fill with a short description of your data destination"
+          description="Fill with a short description of your destination"
           required={false}
           error={
             fieldErrors ? (fieldErrors.description as string) ?? null : null

--- a/src/components/forms/connector/source/ConfigureSourceForm/ConfigureSourceForm.tsx
+++ b/src/components/forms/connector/source/ConfigureSourceForm/ConfigureSourceForm.tsx
@@ -185,7 +185,7 @@ const ConfigureSourceForm: FC<ConfigureSourceFormProps> = ({ source }) => {
                 <SingleSelect
                   id="sourceDefinition"
                   name="sourceDefinition"
-                  label="Data source"
+                  label="Source"
                   disabled={canEdit ? false : true}
                   options={syncSourceDefinitionOptions}
                   required={true}

--- a/src/components/ui/TablePlaceholders/DestinationTablePlaceholder/DestinationTablePlaceholder.tsx
+++ b/src/components/ui/TablePlaceholders/DestinationTablePlaceholder/DestinationTablePlaceholder.tsx
@@ -53,7 +53,7 @@ const DestinationTablePlaceholder: FC<DestinationTablePlaceholderProps> = ({
   return (
     <TablePlaceholderBase
       placeholderItems={placeholderItems}
-      placeholderTitle="No data destination"
+      placeholderTitle="No destination"
       createButtonTitle="Configurate your first destination"
       createButtonLink="/destinations/create"
       marginBottom={marginBottom}

--- a/src/components/ui/TablePlaceholders/SourceTablePlaceholder/SourceTablePlaceholder.tsx
+++ b/src/components/ui/TablePlaceholders/SourceTablePlaceholder/SourceTablePlaceholder.tsx
@@ -56,7 +56,7 @@ const SourceTablePlaceholder: FC<SourceTablePlaceholderProps> = ({
   return (
     <TablePlaceholderBase
       placeholderItems={placeholderItems}
-      placeholderTitle="No data source"
+      placeholderTitle="No source"
       createButtonTitle="Configurate your first source"
       createButtonLink="/sources/create"
       marginBottom={marginBottom}

--- a/src/pages/destinations/[id].tsx
+++ b/src/pages/destinations/[id].tsx
@@ -75,9 +75,7 @@ const DestinationDetailsPage: FC & {
       <PageContentContainer>
         <PageTitle
           title={id ? id.toString() : ""}
-          breadcrumbs={
-            id ? ["Data Destination", id.toString()] : ["Data Destination"]
-          }
+          breadcrumbs={id ? ["Destination", id.toString()] : ["Destination"]}
           enableButton={false}
           marginBottom="mb-[50px]"
         />

--- a/src/pages/destinations/create.tsx
+++ b/src/pages/destinations/create.tsx
@@ -37,7 +37,7 @@ const CreateDestinationPage: FC & {
       <PageContentContainer>
         <PageTitle
           title="Set Up New Destination"
-          breadcrumbs={["Data Destination", "Destination Settings"]}
+          breadcrumbs={["Destination", "Destination Settings"]}
           enableButton={false}
           marginBottom="mb-10"
         />

--- a/src/pages/destinations/index.tsx
+++ b/src/pages/destinations/index.tsx
@@ -46,8 +46,8 @@ const DestinationPage: FC & {
       <PageHead title="destination-connectors" />
       <PageContentContainer>
         <PageTitle
-          title="Data Destination"
-          breadcrumbs={["Data destination"]}
+          title="Destination"
+          breadcrumbs={["Destination"]}
           enableButton={
             destinations.data
               ? destinations.data.length === 0

--- a/src/pages/pipelines/create.tsx
+++ b/src/pages/pipelines/create.tsx
@@ -26,7 +26,7 @@ const CreatePipelinePage: FC & {
         };
       case 1:
         return {
-          title: "Set Up data source",
+          title: "Set Up source",
           breadcrumbs: ["Pipeline", "Source setting"],
         };
       case 2:
@@ -36,7 +36,7 @@ const CreatePipelinePage: FC & {
         };
       case 3:
         return {
-          title: "Set Up Data Destination",
+          title: "Set Up Destination",
           breadcrumbs: ["Pipeline", "Destination setting"],
         };
       case 4:

--- a/src/pages/sources/[id].tsx
+++ b/src/pages/sources/[id].tsx
@@ -75,7 +75,7 @@ const SourceDetailsPage: FC & {
       <PageContentContainer>
         <PageTitle
           title={id ? id.toString() : ""}
-          breadcrumbs={id ? ["Data Source", id.toString()] : ["Data Source"]}
+          breadcrumbs={id ? ["Source", id.toString()] : ["Source"]}
           enableButton={false}
           marginBottom="mb-[50px]"
         />

--- a/src/pages/sources/create.tsx
+++ b/src/pages/sources/create.tsx
@@ -37,7 +37,7 @@ const CreateSourcePage: FC & {
       <PageContentContainer>
         <PageTitle
           title="Set Up New Source"
-          breadcrumbs={["Data Source", "Source Settings"]}
+          breadcrumbs={["Source", "Source Settings"]}
           enableButton={false}
           marginBottom="mb-10"
         />

--- a/src/pages/sources/index.tsx
+++ b/src/pages/sources/index.tsx
@@ -46,8 +46,8 @@ const SourcePage: FC & {
       <PageHead title="source-connectors" />
       <PageContentContainer>
         <PageTitle
-          title="Data Sources"
-          breadcrumbs={["Data sources"]}
+          title="Sources"
+          breadcrumbs={["Sources"]}
           enableButton={
             sources.data ? (sources.data.length === 0 ? false : true) : false
           }


### PR DESCRIPTION
Because

- Data sources -> Sources

This commit

- Remove all the data prefix before sources and destination
