### PR TITLE
fix: fix typos

### DIFF
--- a/src/components/pipeline/CreatePipelineForm/SetupDestinationStep/UseExistingDestinationFlow.tsx
+++ b/src/components/pipeline/CreatePipelineForm/SetupDestinationStep/UseExistingDestinationFlow.tsx
@@ -99,7 +99,7 @@ const UseExistingDestinationFlow: FC<UseExistingDestinationFlowProps> = ({
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
       <h3 className="text-black text-instill-h3">
-        Select a existing destination
+        Select an existing destination
       </h3>
       <SingleSelect
         id="existingDestinationId"

--- a/src/components/pipeline/CreatePipelineForm/SetupSourceStep/UseExistingSourceFlow.tsx
+++ b/src/components/pipeline/CreatePipelineForm/SetupSourceStep/UseExistingSourceFlow.tsx
@@ -102,7 +102,7 @@ const UseExistingSourceFlow: FC<UseExistingSourceFlowProps> = ({
   return (
     <div className="flex flex-1 flex-col gap-y-5 p-5">
       <h3 className="text-black text-instill-h3">
-        Select a existing online source
+        Select an existing online source
       </h3>
       <SingleSelect
         id="existingSourceId"


### PR DESCRIPTION
Because

- #259 

This commit

- Fix "Select a existing" -> Select an existing" (close #259)
