### PR TITLE
refactor: rename padding top, bottom, right and left to single padding prop

### DIFF
--- a/src/components/ui/TableCells/CellBase/CellBase.tsx
+++ b/src/components/ui/TableCells/CellBase/CellBase.tsx
@@ -1,25 +1,13 @@
-import { FC } from "react";
-import cn from "clsx";
+import { ReactNode } from "react";
+import { Nullable } from "@/types/general";
 
 export type CellBaseProps = {
-  paddingTop: string;
-  paddingLeft: string;
-  paddingRight: string;
-  paddingBottom: string;
+  padding: Nullable<string>;
+  children?: ReactNode;
 };
 
-const CellBase: FC<CellBaseProps> = ({
-  children,
-  paddingTop,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-}) => {
-  return (
-    <td className={cn(paddingTop, paddingBottom, paddingLeft, paddingRight)}>
-      {children}
-    </td>
-  );
+const CellBase = ({ children, padding }: CellBaseProps) => {
+  return <td className={padding ? padding : undefined}>{children}</td>;
 };
 
 export default CellBase;

--- a/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
+++ b/src/components/ui/TableCells/ConnectionTypeCell/ConnectionTypeCell.tsx
@@ -15,21 +15,13 @@ const ConnectionTypeCell = ({
   connectorDefinition,
   connectorName,
   width,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
+  padding,
   cellType,
   lineClamp,
 }: ConnectionTypeCellProps) => {
   if (cellType === "shrink") {
     return (
-      <CellBase
-        paddingTop={paddingTop}
-        paddingLeft={paddingLeft}
-        paddingRight={paddingRight}
-        paddingBottom={paddingBottom}
-      >
+      <CellBase padding={padding}>
         <div className={cn("py-2.5", width)}>
           <div className="flex flex-row gap-x-2.5">
             <Image
@@ -59,12 +51,7 @@ const ConnectionTypeCell = ({
     );
   } else {
     return (
-      <CellBase
-        paddingTop={paddingTop}
-        paddingLeft={paddingLeft}
-        paddingRight={paddingRight}
-        paddingBottom={paddingBottom}
-      >
+      <CellBase padding={padding}>
         <div className={cn("py-2.5", width)}>
           <div className="flex flex-col gap-y-[6px]">
             <div className="flex flex-row gap-x-[5px]">

--- a/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
+++ b/src/components/ui/TableCells/InstanceCell/InstanceCell.tsx
@@ -26,10 +26,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
   cellType,
   instances,
   type,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
+  padding,
 }) => {
   let icon: ReactNode;
   const iconHeight = "h-5";
@@ -68,12 +65,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
   return (
     <>
       {cellType === "shrink" ? (
-        <CellBase
-          paddingTop={paddingTop}
-          paddingLeft={paddingLeft}
-          paddingRight={paddingRight}
-          paddingBottom={paddingBottom}
-        >
+        <CellBase padding={padding}>
           <div className={cn("flex", width)}>
             <InstanceInnerList
               items={instances}
@@ -85,12 +77,7 @@ const InstanceCell: FC<InstanceCellProps> = ({
           </div>
         </CellBase>
       ) : (
-        <CellBase
-          paddingTop={paddingTop}
-          paddingLeft={paddingLeft}
-          paddingRight={paddingRight}
-          paddingBottom={paddingBottom}
-        >
+        <CellBase padding={padding}>
           <div
             className={cn("flex flex-col", width, {
               "gap-y-3": instances.length > 0,

--- a/src/components/ui/TableCells/ModeCell/ModeCell.tsx
+++ b/src/components/ui/TableCells/ModeCell/ModeCell.tsx
@@ -10,14 +10,7 @@ export type ModeCellProps = CellBaseProps & {
   mode: PipelineMode;
 };
 
-const ModeCell: FC<ModeCellProps> = ({
-  width,
-  mode,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
-}) => {
+const ModeCell: FC<ModeCellProps> = ({ width, mode, padding }) => {
   let modeIcon: ReactElement;
   const iconWidth = "w-5";
   const iconHeight = "h-5";
@@ -52,12 +45,7 @@ const ModeCell: FC<ModeCellProps> = ({
   }
 
   return (
-    <CellBase
-      paddingTop={paddingTop}
-      paddingLeft={paddingLeft}
-      paddingRight={paddingRight}
-      paddingBottom={paddingBottom}
-    >
+    <CellBase padding={padding}>
       <div className={cn("flex gap-x-2 mr-auto", width)}>
         {modeIcon}
         <p className="text-instillGrey90 text-instill-body">

--- a/src/components/ui/TableCells/ModelDefinitionCell/ModelDefinitionCell.tsx
+++ b/src/components/ui/TableCells/ModelDefinitionCell/ModelDefinitionCell.tsx
@@ -14,10 +14,7 @@ export type ModelDefintionCellProps = {
 } & CellBaseProps;
 
 const ModelDefintionCell: FC<ModelDefintionCellProps> = ({
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
+  padding,
   modelDefinition,
   width,
 }) => {
@@ -84,12 +81,7 @@ const ModelDefintionCell: FC<ModelDefintionCellProps> = ({
   }
 
   return (
-    <CellBase
-      paddingTop={paddingTop}
-      paddingLeft={paddingLeft}
-      paddingRight={paddingRight}
-      paddingBottom={paddingBottom}
-    >
+    <CellBase padding={padding}>
       <div className={cn("flex flex-row gap-x-2", width)}>
         {definitionIcon}
         <p className="my-auto flex text-instillGrey90 text-instill-body">

--- a/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
+++ b/src/components/ui/TableCells/ModelsCell/ModelsCell.tsx
@@ -11,10 +11,7 @@ export type ModelsCellProps = CellBaseProps & {
 };
 
 const ModelsCell: FC<ModelsCellProps> = ({
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
+  padding,
   width,
   modelInstances,
 }) => {
@@ -38,12 +35,7 @@ const ModelsCell: FC<ModelsCellProps> = ({
   };
 
   return (
-    <CellBase
-      paddingBottom={paddingBottom}
-      paddingLeft={paddingLeft}
-      paddingTop={paddingTop}
-      paddingRight={paddingRight}
-    >
+    <CellBase padding={padding}>
       <div className={cn("flex flex-col gap-y-4", width)}>
         {Object.entries(groupByModel).map(([key, value]) => (
           <div key={key} className="flex flex-col gap-y-2">

--- a/src/components/ui/TableCells/NameCell/NameCell.tsx
+++ b/src/components/ui/TableCells/NameCell/NameCell.tsx
@@ -22,10 +22,7 @@ const NameCell: FC<NameCellProps> = ({
   width,
   updatedAt,
   name,
-  paddingBottom,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
+  padding,
   link,
   lineClamp,
   displayUpdateTime,
@@ -65,12 +62,7 @@ const NameCell: FC<NameCellProps> = ({
   );
 
   return (
-    <CellBase
-      paddingTop={paddingTop}
-      paddingLeft={paddingLeft}
-      paddingRight={paddingRight}
-      paddingBottom={paddingBottom}
-    >
+    <CellBase padding={padding}>
       {link ? (
         <Link href={link}>
           <a>

--- a/src/components/ui/Tables/DestinationsTable/DestinationsTable.tsx
+++ b/src/components/ui/Tables/DestinationsTable/DestinationsTable.tsx
@@ -70,10 +70,7 @@ const DestinationsTable: FC<DestinationsTableProps> = ({
               width="w-[234px]"
               state={destination.connector.state}
               updatedAt={destination.connector.update_time}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft="pl-5"
-              paddingRight=""
+              padding="pl-5 py-5"
               link={`/destinations/${destination.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={true}
@@ -84,25 +81,19 @@ const DestinationsTable: FC<DestinationsTableProps> = ({
               connectorName={destination.id}
               cellType="shrink"
               width="w-[234px]"
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
+              padding="py-5"
             />
             <InstanceCell
               cellType="expand"
               width="w-80"
               type="pipeline"
+              padding="py-5 pr-[15px]"
               instances={destination.pipelines.map((e) => {
                 return {
                   name: e.id,
                   state: e.state,
                 };
               })}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight="pr-[15px]"
             />
           </TableRow>
         ))}

--- a/src/components/ui/Tables/ModelsTable/ModelsTable.tsx
+++ b/src/components/ui/Tables/ModelsTable/ModelsTable.tsx
@@ -59,11 +59,8 @@ const ModelsTable: FC<ModelsTableProps> = ({
               name={model.id}
               width="w-[269px]"
               state="STATE_ONLINE"
+              padding="py-5 pl-5"
               updatedAt={model.update_time}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft="pl-5"
-              paddingRight=""
               link={`/models/${model.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={true}
@@ -72,25 +69,17 @@ const ModelsTable: FC<ModelsTableProps> = ({
             <ModelDefinitionCell
               width="w-[269px]"
               modelDefinition={model.model_definition}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
+              padding="py-5"
             />
             <InstanceCell
               type="model"
               cellType="expand"
               width="w-[269px]"
-              instances={model.instances.map((instance) => {
-                return {
-                  name: instance.id,
-                  state: instance.state,
-                };
-              })}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight="pr-5"
+              padding="py-5 pr-5"
+              instances={model.instances.map((instance) => ({
+                name: instance.id,
+                state: instance.state,
+              }))}
             />
           </TableRow>
         ))}

--- a/src/components/ui/Tables/PipelineTable/PipelineTable.tsx
+++ b/src/components/ui/Tables/PipelineTable/PipelineTable.tsx
@@ -42,34 +42,25 @@ const PipelineTable: FC<PipelineTableProps> = ({
           <ConnectionTypeCell
             cellType="expand"
             width="w-[269px]"
+            padding="py-5 pl-[15px]"
             connectorDefinition={
               pipeline.recipe.source.source_connector_definition
             }
             connectorName={pipeline.recipe.source.id}
-            paddingBottom="pb-5"
-            paddingTop="pt-5"
-            paddingLeft=""
-            paddingRight="pl-[15px]"
           />
           <ModelsCell
             modelInstances={pipeline.recipe.models}
             width="w-[269px]"
-            paddingBottom="pb-5"
-            paddingTop="pt-5"
-            paddingLeft=""
-            paddingRight=""
+            padding="py-5"
           />
           <ConnectionTypeCell
             cellType="expand"
             width="w-[269px]"
+            padding="py-5 pr-[15px]"
             connectorDefinition={
               pipeline.recipe.destination.destination_connector_definition
             }
             connectorName={pipeline.recipe.destination.id}
-            paddingBottom="pb-5"
-            paddingTop="pt-5"
-            paddingLeft=""
-            paddingRight="pr-[15px]"
           />
         </TableRow>
       </TableBody>

--- a/src/components/ui/Tables/PipelinesTable/PipelinesTable.tsx
+++ b/src/components/ui/Tables/PipelinesTable/PipelinesTable.tsx
@@ -71,23 +71,13 @@ const PipelinesTable: FC<PipelinesTableProps> = ({
               width="w-[191px]"
               updatedAt={pipeline.update_time}
               state={pipeline.state}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft="pl-[15px]"
-              paddingRight=""
+              padding="py-5 pl-[15px]"
               link={`/pipelines/${pipeline.id}`}
               lineClamp="line-clamp-2"
               displayUpdateTime={true}
               displayStateIndicator={true}
             />
-            <ModeCell
-              width="w-[100px]"
-              mode={pipeline.mode}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
-            />
+            <ModeCell width="w-[100px]" mode={pipeline.mode} padding="py-5" />
             <ConnectionTypeCell
               width="w-[125px]"
               connectorDefinition={
@@ -95,10 +85,7 @@ const PipelinesTable: FC<PipelinesTableProps> = ({
               }
               connectorName={pipeline.recipe.source.id}
               cellType="shrink"
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
+              padding="py-5"
               lineClamp="line-clamp-2"
             />
             <InstanceCell
@@ -115,10 +102,7 @@ const PipelinesTable: FC<PipelinesTableProps> = ({
                   state: model.state,
                 };
               })}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
+              padding="py-5"
             />
             <ConnectionTypeCell
               width="w-[125px]"
@@ -127,10 +111,7 @@ const PipelinesTable: FC<PipelinesTableProps> = ({
                 pipeline.recipe.destination.destination_connector_definition
               }
               connectorName={pipeline.recipe.destination.id}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight="pr-5"
+              padding="py-5 pr-5"
               lineClamp="line-clamp-2"
             />
           </TableRow>

--- a/src/components/ui/Tables/SourcesTable/SourcesTable.tsx
+++ b/src/components/ui/Tables/SourcesTable/SourcesTable.tsx
@@ -70,10 +70,7 @@ const SourcesTable: FC<SourcesTableProps> = ({
               width="w-[234px]"
               state="STATE_ONLINE"
               updatedAt={source.connector.update_time}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft="pl-5"
-              paddingRight=""
+              padding="py-5 pl-5"
               link={`/sources/${source.id}`}
               lineClamp="line-clamp-1"
               displayUpdateTime={true}
@@ -84,25 +81,19 @@ const SourcesTable: FC<SourcesTableProps> = ({
               connectorName={source.id}
               cellType="shrink"
               width="w-[234px]"
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight=""
+              padding="py-5"
             />
             <InstanceCell
               cellType="expand"
               width="w-80"
               type="pipeline"
+              padding="py-5 pr-[15px]"
               instances={source.pipelines.map((e) => {
                 return {
                   name: e.id,
                   state: e.state,
                 };
               })}
-              paddingBottom="pb-5"
-              paddingTop="pt-5"
-              paddingLeft=""
-              paddingRight="pr-[15px]"
             />
           </TableRow>
         ))}


### PR DESCRIPTION
Because

- Table's padding props are too redundant

This commit

-  rename padding top, bottom, right and left to single padding prop
