### PR TITLE
feat: extend the time span of our user cookie

### DIFF
--- a/src/pages/api/set-user-cookie.ts
+++ b/src/pages/api/set-user-cookie.ts
@@ -25,7 +25,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         cookie_token: body.token,
       }),
       domain: req.headers.origin ? new URL(req.headers.origin).hostname : null,
-      maxAge: 60 * 60 * 24 * 2,
+      maxAge: 60 * 60 * 24 * 30,
       httpOnly: process.env.NODE_ENV === "production" ? true : false,
     };
 


### PR DESCRIPTION
Currently, our cookie only exists for 2 days. In order to make the onboarding process much more consistent. We want to extend the time span of our user cookie to 30 days.