### PR TITLE
chore: disable html report

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? "dot" : "html",
+  reporter: "dot",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     storageState: "playwright-state.json",


### PR DESCRIPTION
In order to not block other CI tests, we disable HTML report of the playwright. 