### PR TITLE
feat: add hg model id field at model_instance page

### DIFF
--- a/integration-test/common/model.ts
+++ b/integration-test/common/model.ts
@@ -117,7 +117,7 @@ export type ExpectCorrectModelDetailsProps = {
     | "STATE_UNSPECIFIED"
     | "STATE_ERROR";
   modelTask: string;
-  additionalRule?: () => Promise<void>;
+  additionalRules?: () => Promise<void>;
 };
 
 export const expectCorrectModelDetails = async ({
@@ -127,7 +127,7 @@ export const expectCorrectModelDetails = async ({
   modelInstanceTag,
   modelState,
   modelTask,
-  additionalRule,
+  additionalRules,
 }: ExpectCorrectModelDetailsProps) => {
   await page.goto(`/models/${modelId}`, { waitUntil: "networkidle" });
 
@@ -166,7 +166,7 @@ export const expectCorrectModelDetails = async ({
     expect(await stateToggle.isChecked()).not.toBeTruthy();
   }
 
-  if (additionalRule) await additionalRule();
+  if (additionalRules) await additionalRules();
 };
 
 export const expectToDeployModel = async (

--- a/integration-test/model-huggingface.spec.ts
+++ b/integration-test/model-huggingface.spec.ts
@@ -84,6 +84,13 @@ test.describe.serial("Hugging face model", () => {
       modelInstanceTag,
       modelState: "STATE_ONLINE",
       modelTask: "CLASSIFICATION",
+      additionalRules: async () => {
+        const huggingFaceModelIdField = page.locator(
+          "input#huggingface-model-id"
+        );
+        expect(await huggingFaceModelIdField.isEditable()).toBeFalsy();
+        await expect(huggingFaceModelIdField).toHaveValue(huggingFaceId);
+      },
     });
   });
 

--- a/src/components/model/ConfigureModelInstanceForm.tsx
+++ b/src/components/model/ConfigureModelInstanceForm.tsx
@@ -74,7 +74,7 @@ const ConfigureModelInstanceForm = ({
         {modelInstance.model_definition === "model-definitions/huggingface" ? (
           <>
             <BasicTextField
-              id="huggingface-id"
+              id="huggingface-model-id"
               label="HuggingFace model ID"
               description="The name of a public HuggingFace model ID, e.g. `google/vit-base-patch16-224`."
               value={modelInstance.configuration.repo_id}

--- a/src/components/model/ConfigureModelInstanceForm.tsx
+++ b/src/components/model/ConfigureModelInstanceForm.tsx
@@ -26,6 +26,8 @@ const ConfigureModelInstanceForm = ({
       status: null,
     });
 
+  console.log(modelInstance);
+
   return (
     <FormBase
       padding={null}
@@ -64,6 +66,18 @@ const ConfigureModelInstanceForm = ({
               label="Cloud storage url"
               description="the cloud storage url, e.g. `gs://public-europe-west2-c-artifacts/vdp/public-models/yolov4`."
               value={modelInstance.configuration.url}
+              disabled={true}
+              required={true}
+            />
+          </>
+        ) : null}
+        {modelInstance.model_definition === "model-definitions/huggingface" ? (
+          <>
+            <BasicTextField
+              id="huggingface-id"
+              label="HuggingFace model ID"
+              description="The name of a public HuggingFace model ID, e.g. `google/vit-base-patch16-224`."
+              value={modelInstance.configuration.repo_id}
               disabled={true}
               required={true}
             />


### PR DESCRIPTION
This commit add HuggingFace model ID field at model_instance page to help user better navigate the model details (close #299)
