### PR TITLE
refactor: rename workflow name

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: ci-unit-test
+name: Unit Test
 
 on:
   push:


### PR DESCRIPTION
Because

- Make the naming of the github workflow consistent

This commit

- Rename the workflow name of this repo
