### PR TITLE
feat: update how we test model detail page

### DIFF
--- a/integration-test/model-artivc.spec.ts
+++ b/integration-test/model-artivc.spec.ts
@@ -81,6 +81,9 @@ test.describe.serial("Artivc model", () => {
       modelId,
       modelDescription,
       modelInstanceTag: "v1.0-cpu",
+      modelInstanceTagOptionLocator: page.locator(
+        "#react-select-modelInstanceTag-option-0"
+      ),
       modelState: "STATE_ONLINE",
       modelTask: "CLASSIFICATION",
       additionalRules: async () => {

--- a/integration-test/model-github.spec.ts
+++ b/integration-test/model-github.spec.ts
@@ -79,8 +79,11 @@ test.describe.serial("GitHub model", () => {
       page,
       modelId,
       modelDescription,
-      modelInstanceTag: "v1.0-gpu", // Because we don't have a way to indicate which instance just created.
-      modelState: "STATE_OFFLINE",
+      modelInstanceTag: "v1.0-cpu",
+      modelInstanceTagOptionLocator: page.locator(
+        "#react-select-modelInstanceTag-option-1"
+      ),
+      modelState: "STATE_ONLINE",
       modelTask: "CLASSIFICATION",
     });
   });

--- a/integration-test/model-huggingface.spec.ts
+++ b/integration-test/model-huggingface.spec.ts
@@ -82,6 +82,9 @@ test.describe.serial("Hugging face model", () => {
       modelId,
       modelDescription,
       modelInstanceTag,
+      modelInstanceTagOptionLocator: page.locator(
+        "#react-select-modelInstanceTag-option-0"
+      ),
       modelState: "STATE_ONLINE",
       modelTask: "CLASSIFICATION",
       additionalRules: async () => {

--- a/integration-test/model-local.spec.ts
+++ b/integration-test/model-local.spec.ts
@@ -83,6 +83,9 @@ test.describe.serial("Local model", () => {
       modelId,
       modelDescription,
       modelInstanceTag,
+      modelInstanceTagOptionLocator: page.locator(
+        "#react-select-modelInstanceTag-option-0"
+      ),
       modelState: "STATE_ONLINE",
       modelTask: "CLASSIFICATION",
     });


### PR DESCRIPTION
Because

- We need to adapt model-backend long run operation

This commit

- update how we test model detail page
- Make sure we select the right model instance