### PR TITLE
chore: rename Visual Data Preparation to Versatile Data Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-Visual Data Preparation (VDP) console
+Versatile Data Pipeline (VDP) console
 
 # About VDP Console
 
-The VDP console is written in Nextjs, Typescript, TailwindCSS and it runs a docker container with the VDP backend. (You could try the full setup with our [VDP repo](https://github.com/instill-ai/vdp))
+The VDP console is written in Nextjs, Typescript, TailwindCSS and it runs a docker container with the VDP backend. Interested in trying it out? Check out [here](https://github.com/instill-ai/vdp) to run it locally.
 
 The mission of the console is simple, to provide an unified, clean, and intuitive user experience of VDP, you could set up the full pipeline just by using the browser and investigate every information of your pipelines or connectors on it.
 

--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -11,10 +11,10 @@ const PageHead = ({ title }: PageHeadProps) => {
   const router = useRouter();
   const meta = {
     type: "website",
-    siteName: "Instill AI - Visual Data Preparation (VDP)",
-    title: title ? title : "Instill AI - Visual Data Preparation (VDP)",
+    siteName: "Instill AI - Versatile Data Pipeline (VDP)",
+    title: title ? title : "Instill AI - Versatile Data Pipeline (VDP)",
     pageDescription:
-      "Visual Data Preparation (VDP) is an open-source visual data ETL tool to streamline the end-to-end visual data processing pipeline",
+      "Versatile Data Pipeline (VDP) is an open-source unstructured data ETL tool to streamline the end-to-end unstructured data processing pipeline",
   };
 
   const canonicalURL =

--- a/src/lib/instill/mgmt/mocks.ts
+++ b/src/lib/instill/mgmt/mocks.ts
@@ -30,7 +30,7 @@ export const mockMgmtRoles: SingleSelectOption[] = [
     value: "Analytics Engineer",
   },
   {
-    label: "Hobbyist (I love Vision AI!)",
+    label: "Hobbyist (I love AI!)",
     value: "Hobbyist",
   },
 ];


### PR DESCRIPTION
Because

- instead of Visual Data Preparation, VDP is Versatile Data Pipeline now. We realise that as a general ETL infrastructure, VDP is capable of processing all kinds of unstructured data, and we should not limit its usage to only visual data. That's why we replace the word Visual with Versatile. Besides, the term Data Preparation is a bit misleading, users often think it has something to do with data labelling or cleaning. The term Data Pipeline is definitely more precise to capture the core concept of VDP.
 
This commit

- update to Versatile Data Pipeline
