### PR TITLE
feat: stabilize async model deploying test

### DIFF
--- a/integration-test/common/model.ts
+++ b/integration-test/common/model.ts
@@ -133,7 +133,7 @@ export const expectCorrectModelDetails = async ({
   additionalRules,
 }: ExpectCorrectModelDetailsProps) => {
   // Mimic the behavior of long running operation
-  await delay(2000);
+  await delay(5000);
 
   await page.goto(`/models/${modelId}`, { waitUntil: "networkidle" });
 


### PR DESCRIPTION
Because

- The model e2e test is still flaky

This commit

- This PR stabilize async model deploying test further
