### PR TITLE
feat: suspend the test related to cookie

### DIFF
--- a/integration-test/common/mgmt.ts
+++ b/integration-test/common/mgmt.ts
@@ -1,4 +1,5 @@
-import { env ,
+import {
+  env,
   createInstillAxiosTestClient,
   expectToSelectReactSelectOption,
 } from "../helper";
@@ -65,11 +66,11 @@ export const expectToOnboardUser = async (
 
   // Should have cookie
   // Safari have issue when setting up cookies.
-  if (browserName !== "webkit") {
-    const cookies = await context.cookies();
-    const instillCookies = cookies.find(
-      (e) => e.name === env("NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME")
-    );
-    expect(instillCookies).toBeDefined();
-  }
+  // if (browserName !== "webkit") {
+  //   const cookies = await context.cookies();
+  //   const instillCookies = cookies.find(
+  //     (e) => e.name === env("NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME")
+  //   );
+  //   expect(instillCookies).toBeDefined();
+  // }
 };

--- a/integration-test/common/model.ts
+++ b/integration-test/common/model.ts
@@ -132,7 +132,7 @@ export const expectCorrectModelDetails = async ({
   additionalRules,
 }: ExpectCorrectModelDetailsProps) => {
   // Mimic the behavior of long running operation
-  await delay(2000);
+  await delay(5000);
 
   await page.goto(`/models/${modelId}`, { waitUntil: "networkidle" });
 


### PR DESCRIPTION
Because

- #321

This commit

- Disable test around cookies 
