### PR TITLE
feat: add InstanceSegmentationIcon into label

### DIFF
--- a/src/components/ui/ModelInstanceTaskLabel.tsx
+++ b/src/components/ui/ModelInstanceTaskLabel.tsx
@@ -4,6 +4,7 @@ import cn from "clsx";
 import { Nullable } from "@/types/general";
 import {
   ImageClassificationIcon,
+  InstanceSegmentationIcon,
   KeypointDetectionIcon,
   ObjectDetectionIcon,
   OpticalCharacterRecognitionIcon,
@@ -48,6 +49,10 @@ const ModelInstanceTaskLabel = ({
       modelInstanceTaskIcon = (
         <OpticalCharacterRecognitionIcon {...iconStyle} />
       );
+      break;
+
+    case "TASK_INSTANCE_SEGMENTATION":
+      modelInstanceTaskIcon = <InstanceSegmentationIcon {...iconStyle} />;
       break;
 
     default:


### PR DESCRIPTION
Because

- instance segmentation icon is missing in model label

This commit

- add InstanceSegmentationIcon into label
- close #325 