### PR TITLE
feat: add SemanticSegmentationIcon to model label

### DIFF
--- a/src/components/ui/ModelInstanceTaskLabel.tsx
+++ b/src/components/ui/ModelInstanceTaskLabel.tsx
@@ -8,6 +8,7 @@ import {
   KeypointDetectionIcon,
   ObjectDetectionIcon,
   OpticalCharacterRecognitionIcon,
+  SemanticSegmentationIcon,
 } from "@instill-ai/design-system";
 
 export type ModelInstanceTaskLabelProps = {
@@ -53,6 +54,10 @@ const ModelInstanceTaskLabel = ({
 
     case "TASK_INSTANCE_SEGMENTATION":
       modelInstanceTaskIcon = <InstanceSegmentationIcon {...iconStyle} />;
+      break;
+
+    case "TASK_SEMANTIC_SEGMENTATION":
+      modelInstanceTaskIcon = <SemanticSegmentationIcon {...iconStyle} />;
       break;
 
     default:


### PR DESCRIPTION
Because

- The console should support SemanticSegmentationIcon

This commit

- Support SemanticSegmentationIcon in model label
- close #325