### PR TITLE
feat: add pr-semantic workflow

### DIFF
--- a/.github/workflows/pr-semantic.yml
+++ b/.github/workflows/pr-semantic.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because

- We want to do the semantic title check for PR

This commit

- add pr-semantic workflow
- close #330 
