### PR TITLE
fix: fix ts config typo

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
       "@/hooks/*": ["hooks/*"],
       "@/utils": ["utils"],
       "@/utils/*": ["utils/*"],
-      "@/style": ["styles"],
-      "@/style/*": ["styles/*"],
+      "@/styles": ["styles"],
+      "@/styles/*": ["styles/*"],
 
       // We didn't support import directly from "@/services"
       "@/services/*": ["services/*"],


### PR DESCRIPTION
Because

- ts-config has typo

This commit

- fix ts config typo