### PR TITLE
feat: extend the delay when test model details page

### DIFF
--- a/integration-test/common/model.ts
+++ b/integration-test/common/model.ts
@@ -132,7 +132,7 @@ export const expectCorrectModelDetails = async ({
   additionalRules,
 }: ExpectCorrectModelDetailsProps) => {
   // Mimic the behavior of long running operation
-  await delay(5000);
+  await delay(10000);
 
   await page.goto(`/models/${modelId}`, { waitUntil: "networkidle" });
 


### PR DESCRIPTION
Because

- model details page is not stable

This commit

-  extend the delay when test model details page to stabilize it
