### PR TITLE
feat: run build when test in the workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Run build
+        run: pnpm build


### PR DESCRIPTION
Because

- We want to test whether the whole app can build

This commit

- run build when test in the workflow
