### PR TITLE
feat: expose node env as build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,12 @@ RUN pnpm run build
 FROM node:16-alpine
 WORKDIR /app
 
-ENV NODE_ENV production
+# You should carefully set this NODE_ENV, we set it to production by default
+ARG NODE_ENV="production"
+ENV NODE_ENV ${NODE_ENV}
+
 # Uncomment the following line in case you want to disable telemetry during runtime.
-# ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED 1
 
 # We need bash to run our entrypoint.sh and env.sh
 RUN apk add --no-cache bash

--- a/src/components/ui/PageHead.tsx
+++ b/src/components/ui/PageHead.tsx
@@ -21,7 +21,7 @@ export const PageHead = ({ title }: PageHeadProps) => {
   const canonicalURL =
     router.asPath === "/"
       ? `${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}`
-      : `${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}/${router.asPath}`;
+      : `${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}${router.asPath}`;
 
   const [hostName, setHostName] = useState<Nullable<string>>(null);
 


### PR DESCRIPTION
Because

- We want to have more flexibility toward our environment

This commit

- expose node env as build args
