### PR TITLE
feat: further stabilize e2e test by removing the clean up function

### DIFF
--- a/integration-test/destination-async.spec.ts
+++ b/integration-test/destination-async.spec.ts
@@ -23,10 +23,6 @@ test.use({
   },
 });
 
-test.afterAll(async () => {
-  await deleteDestination(destinationId);
-});
-
 test.describe.serial("Async destination", () => {
   test("should warn wrong resource ID", async ({ page }) => {
     await page.goto("/destinations/create");

--- a/integration-test/destination-sync.spec.ts
+++ b/integration-test/destination-sync.spec.ts
@@ -11,13 +11,11 @@ const destinationType = "HTTP";
 
 // If there has a destination-http connector, we need to delete it then proceed the test.
 test.beforeAll(async () => {
-  await deleteDestination(destinationId);
-});
-
-// Delete used sync destination connector to avoid conflict or casuing other
-// test to fall.
-test.afterAll(async () => {
-  await deleteDestination(destinationId);
+  try {
+    await deleteDestination(destinationId);
+  } catch (err) {
+    return Promise.reject(err);
+  }
 });
 
 test.describe.serial("Sync destination", () => {

--- a/integration-test/model-artivc.spec.ts
+++ b/integration-test/model-artivc.spec.ts
@@ -106,9 +106,9 @@ test.describe.serial("Artivc model", () => {
 
   // Disable test related to long-running operation
 
-  test.skip("should have proper delete model modal and delete this model", async ({
-    page,
-  }) => {
-    await expectToDeleteModel(page, modelId);
-  });
+  // test.skip("should have proper delete model modal and delete this model", async ({
+  //   page,
+  // }) => {
+  //   await expectToDeleteModel(page, modelId);
+  // });
 });

--- a/integration-test/model-github.spec.ts
+++ b/integration-test/model-github.spec.ts
@@ -96,9 +96,9 @@ test.describe.serial("GitHub model", () => {
 
   // Disable test related to long-running operation
 
-  test.skip("should have proper delete model modal and delete this model", async ({
-    page,
-  }) => {
-    await expectToDeleteModel(page, modelId);
-  });
+  // test.skip("should have proper delete model modal and delete this model", async ({
+  //   page,
+  // }) => {
+  //   await expectToDeleteModel(page, modelId);
+  // });
 });

--- a/integration-test/model-huggingface.spec.ts
+++ b/integration-test/model-huggingface.spec.ts
@@ -105,9 +105,9 @@ test.describe.serial("Hugging face model", () => {
 
   // Disable test related to long-running operation
 
-  test.skip("should have proper delete model modal and delete this model", async ({
-    page,
-  }) => {
-    await expectToDeleteModel(page, modelId);
-  });
+  // test.skip("should have proper delete model modal and delete this model", async ({
+  //   page,
+  // }) => {
+  //   await expectToDeleteModel(page, modelId);
+  // });
 });

--- a/integration-test/model-local.spec.ts
+++ b/integration-test/model-local.spec.ts
@@ -99,9 +99,9 @@ test.describe.serial("Local model", () => {
 
   // Disable test related to long-running operation
 
-  test.skip("should have proper delete model modal and delete this model", async ({
-    page,
-  }) => {
-    await expectToDeleteModel(page, modelId);
-  });
+  // test.skip("should have proper delete model modal and delete this model", async ({
+  //   page,
+  // }) => {
+  //   await expectToDeleteModel(page, modelId);
+  // });
 });

--- a/integration-test/pipeline-async.spec.ts
+++ b/integration-test/pipeline-async.spec.ts
@@ -34,35 +34,8 @@ test.use({
   },
 });
 
-test.afterAll(async () => {
-  try {
-    // We need to clean up destination and source too
-    await deleteDestination("destination-http");
-    await deleteSource("source-http");
-    await deleteModel(modelId);
-  } catch (err) {
-    console.log(err);
-  }
-});
-
 test.describe
   .serial("Async pipeline with new source, destination and local model", () => {
-  test.afterAll(async () => {
-    try {
-      const client = createInstillAxiosTestClient();
-
-      await client.post(
-        `${env(
-          "NEXT_PUBLIC_API_VERSION"
-        )}/models/${modelId}/instances/${modelInstanceTag}/undeploy`
-      );
-      await deleteDestination(destinationId);
-      await deleteSource("source-http");
-    } catch (err) {
-      return Promise.reject(err);
-    }
-  });
-
   test("should create async pipeline", async ({ page }) => {
     await page.goto("/pipelines/create", { waitUntil: "networkidle" });
 
@@ -220,9 +193,7 @@ test.describe
     await expectToUpdatePipelineDescription(page, pipelineId, "");
   });
 
-  // Disable test related to long-running operation
-
-  test.skip("should have proper delete pipeline modal and delete this pipeline", async ({
+  test("should have proper delete pipeline modal and delete this pipeline", async ({
     page,
   }) => {
     await expectToDeletePipeline(page, pipelineId);

--- a/integration-test/pipeline-sync.spec.ts
+++ b/integration-test/pipeline-sync.spec.ts
@@ -28,17 +28,6 @@ test.use({
   },
 });
 
-test.afterAll(async () => {
-  try {
-    // We need to clean up destination and source too
-    await deleteDestination("destination-http");
-    await deleteSource("source-http");
-    await deleteModel(modelId);
-  } catch (err) {
-    console.log(err);
-  }
-});
-
 test.describe
   .serial("Sync pipeline with new source, destination and local model", () => {
   test("should create sync pipeline", async ({ page }) => {
@@ -193,9 +182,7 @@ test.describe
     await expectToUpdatePipelineDescription(page, pipelineId, "");
   });
 
-  // Disable test related to long-running operation
-
-  test.skip("should have proper delete pipeline modal and delete this pipeline", async ({
+  test("should have proper delete pipeline modal and delete this pipeline", async ({
     page,
   }) => {
     await expectToDeletePipeline(page, pipelineId);

--- a/integration-test/source.spec.ts
+++ b/integration-test/source.spec.ts
@@ -1,4 +1,4 @@
-import { env , deleteSource, expectToSelectReactSelectOption } from "./helper";
+import { env, deleteSource, expectToSelectReactSelectOption } from "./helper";
 import { test, expect } from "@playwright/test";
 
 const sourceId = "source-grpc";
@@ -10,11 +10,6 @@ test.beforeAll(async () => {
   } catch (err) {
     return Promise.reject(err);
   }
-});
-
-// We need to clean up source after the test too.
-test.afterAll(async () => {
-  await deleteSource(sourceId);
 });
 
 test.describe.serial("Sync source", () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,6 @@ if (!process.env.NEXT_PUBLIC_CONSOLE_BASE_URL) {
 const config: PlaywrightTestConfig = {
   testDir: "./integration-test",
   globalSetup: require.resolve("./integration-test/helper/global-setup"),
-  globalTeardown: require.resolve("./integration-test/helper/global-teardown"),
   /* Maximum time one test can run for. */
   timeout: 30000,
   expect: {


### PR DESCRIPTION
Because

- Console is the last to test in make file and we test console separately in CI so we don't need to clean up the resource after test 

This commit

- further stabilize e2e test by removing the clean up function
