### PR TITLE
fix: fix pipelines table margin bottom issue

### DIFF
--- a/src/components/ui/Tables/PipelinesTable.tsx
+++ b/src/components/ui/Tables/PipelinesTable.tsx
@@ -96,7 +96,7 @@ export const PipelinesTable = ({
           />
         ) : (
           <TableContainer
-            marginBottom={marginBottom}
+            marginBottom={null}
             tableLayout="table-auto"
             borderCollapse="border-collapse"
           >


### PR DESCRIPTION
Because

- pipeline table's margin bottom is wrong

This commit

- fix pipelines table margin bottom issue
