### PR TITLE
fix: don't specific domain when set cookie

### DIFF
--- a/src/pages/api/set-user-cookie.ts
+++ b/src/pages/api/set-user-cookie.ts
@@ -25,7 +25,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       value: JSON.stringify({
         cookie_token: body.token,
       }),
-      domain: req.headers.origin ? new URL(req.headers.origin).hostname : null,
+      domain: null,
       maxAge: 60 * 60 * 24 * 30,
       httpOnly: process.env.NODE_ENV === "production" ? true : false,
     };


### PR DESCRIPTION
Because

- cookie domain setting is troublesome

This commit

- don't specific domain when set cookie
