### PR TITLE
feat: [INS-267] mock onboarded cookie

### DIFF
--- a/integration-test/helper/login.setup.ts
+++ b/integration-test/helper/login.setup.ts
@@ -1,10 +1,20 @@
+import { env } from "@/utils";
 import { test } from "@playwright/test";
-import { expectToOnboardUser } from "../common/mgmt";
 
-test("should successfully fill in the onboarding form and submit", async ({
-  page,
-}) => {
-  await expectToOnboardUser(page);
+test("mock onboarded cookie", async ({ page }) => {
+  console.log(env("NEXT_PUBLIC_CONSOLE_BASE_URL"));
+  await page.context().addCookies([
+    {
+      name: env("NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME") as string,
+      value: JSON.stringify({
+        cookie_token: "76e2c0f9-fa5c-4a4b-bf10-6db6a7373825",
+      }),
+      url: env("NEXT_PUBLIC_CONSOLE_BASE_URL"),
+      sameSite: "Lax",
+      secure: false,
+      httpOnly: true,
+    },
+  ]);
   await page
     .context()
     .storageState({ path: "integration-test/.auth/user.json" });


### PR DESCRIPTION
Because

- the onboarded cookie can not set on http://console:3000 when in the integration-test

This commit

- mock onboarded cookie
