### PR TITLE
fix: stabilize the onboarding test

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -13,14 +13,14 @@ We maintain another container `Dockerfile.playwright` specifically for test usag
 ### How to test at local
 
 - In VDP folder: `git pull --rebase` to pull the up-to-date code.
-- In VDP folder: `make build PROFILE=all` 
+- In VDP folder: `make build-latest PROFILE=all` 
 - In console folder: `pnpm dev` to setup local dev server
 - If you want to test in your host (Run the app with pnpm dev in the console folder) 
-  - In VDP folder: `make dev PROFILE=console ITMODE=true`
+  - In VDP folder: `make latest PROFILE=console ITMODE=true`
   - In console folder: `pnpm dev`
   - In console folder: `pnpm integration-test`
 - If you want to test in the docker-container (Run the app with VDP) 
-  - In VDP folder: `make dev PROFILE=all ITMODE=true CONSOLE_BASE_URL_HOST=console CONSOLE_BASE_API_GATEWAY_URL_HOST=api-gateway`
+  - In VDP folder: `make latest PROFILE=all ITMODE=true CONSOLE_BASE_URL_HOST=console CONSOLE_BASE_API_GATEWAY_URL_HOST=api-gateway`
   - In console folder: `pnpm docker-build-test`
   - In console folder: `pnpm docker-run-test`
 

--- a/integration-test/onboarding.spec.ts
+++ b/integration-test/onboarding.spec.ts
@@ -23,7 +23,7 @@ export function handleOnboardingTest() {
     expect(await emailSubscriptionField.isChecked()).toBeTruthy();
   });
 
-  test("should disable start button, if email input format is not correct", async ({
+  test("should display error label, if email input format is not correct", async ({
     page,
   }) => {
     await page.goto("/onboarding", { waitUntil: "networkidle" });

--- a/integration-test/onboarding.spec.ts
+++ b/integration-test/onboarding.spec.ts
@@ -46,6 +46,7 @@ export function handleOnboardingTest() {
       hasText: "Invalid email address",
     });
 
+    // Wait until the error label is visible
     await Promise.all([emailErrorLabel.isVisible(), await startButton.click()]);
   });
 

--- a/integration-test/onboarding.spec.ts
+++ b/integration-test/onboarding.spec.ts
@@ -46,9 +46,7 @@ export function handleOnboardingTest() {
       hasText: "Invalid email address",
     });
 
-    await startButton.click();
-
-    expect(emailErrorLabel).toHaveCount(1);
+    await Promise.all([emailErrorLabel.isVisible(), await startButton.click()]);
   });
 
   test("should successfully fill in the onboarding form and submit", async ({

--- a/package.json
+++ b/package.json
@@ -124,12 +124,12 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "yarn prettier:fix",
+      "pnpm prettier:fix",
       "eslint --cache --fix",
       "jest --bail --findRelatedTests"
     ],
     "*.stories.{ts,tsx}": [
-      "yarn prettier:fix",
+      "pnpm prettier:fix",
       "eslint --cache --fix"
     ]
   },


### PR DESCRIPTION
Because

- The onboarding test - `should display error label, if email input format is not correct` is flaky

This commit

- stabilize the onboarding test
