### PR TITLE
feat: stabilize test related to the pipeline details page

### DIFF
--- a/integration-test/common/pipeline.ts
+++ b/integration-test/common/pipeline.ts
@@ -153,7 +153,7 @@ export const expectCorrectPipelineDetails = async ({
 
   // Should have correct title
   const titleField = page.locator("h2", { hasText: id });
-  await expect(titleField).toHaveCount(1);
+  await titleField.waitFor();
 
   // Should have correct mode label
   const modeLabel = page.locator("data-testid=pipeline-mode-label");


### PR DESCRIPTION
Because

- pipeline details page is relatively slow due to the nature of SSR, we need extra timeout here

This commit

- stabilize test related to the pipeline details page
