### PR TITLE
feat: update docs link at sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -126,7 +126,7 @@ export const Sidebar: FC = () => {
         id: "sidebar-documentation",
         type: "link",
         tabName: "Documentation",
-        link: "https://www.instill.tech/docs/start-here/getting-started",
+        link: "https://www.instill.tech/docs",
         startIcon: (
           <ResourceIcon
             color="group-hover:fill-instillBlue10 fill-instillGrey30"


### PR DESCRIPTION
Because

- the docs link at sidebar is out of date

This commit

- update docs link at sidebar