### PR TITLE
chore(license): update VDP license to ELv2 and MIT

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ NEXT_PUBLIC_API_VERSION=v1alpha
 # This is for the cookie name we set to ensure usage collection, you can ignore this env
 NEXT_PUBLIC_INSTILL_AI_USER_COOKIE_NAME=instill-ai-user
 
-# The edition of the console. If you are using our open source console, you don't need to change it
+# The edition of the console. If you are using our source available console, you don't need to change it
 NEXT_PUBLIC_CONSOLE_EDITION=local-ce:dev
 
 # The endpoint to indicate the base url of api-gateway

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,57 @@
+The Versatile Data Pipeline (VDP) project uses a polyrepo structure with multiple licenses.
+
+The license for a piece of source code is defined with the following prioritized rules:
+1. LICENSE present in the file
+2. LICENSE file in the same directory as the file
+3. First LICENSE file found in the parent directories up to the top level
+4. By default to the Elastic License 2.0 (ELv2)
+
+If you have any question regarding licenses, just visit our [License](https://www.instill.tech/docs/vdp/license) or [contact us](mailto:hello@instill.tech).
+
+------------------------------------------------------------------------------------
+Elastic License 2.0 (ELv2)
+
+**Acceptance**
+By using the software, you agree to all of the terms and conditions below.
+
+**Copyright License**
+The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the software, in each case subject to the limitations and conditions below
+
+**Limitations**
+You may not provide the software to third parties as a hosted or managed service, where the service provides users with access to any substantial set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality in the software, and you may not remove or obscure any functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices of the licensor in the software. Any use of the licensor’s trademarks is subject to applicable law.
+
+**Patents**
+The licensor grants you a license, under any patent claims the licensor can license, or becomes able to license, to make, have made, use, sell, offer for sale, import and have imported the software, in each case subject to the limitations and conditions in this license. This license does not cover any patent claims that you cause to be infringed by modifications or additions to the software. If you or your company make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+**Notices**
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the software prominent notices stating that you have modified the software.
+
+**No Other Rights**
+These terms do not imply any licenses other than those expressly granted in these terms.
+
+**Termination**
+If you use the software in violation of these terms, such use is not licensed, and your licenses will automatically terminate. If the licensor provides you with a notice of your violation, and you cease all violation of this license no later than 30 days after you receive that notice, your licenses will be reinstated retroactively. However, if you violate these terms after such reinstatement, any additional violation of these terms will cause your licenses to terminate automatically and permanently.
+
+**No Liability**
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.
+
+**Definitions**
+The *licensor* is the entity offering these terms, and the *software* is the software the licensor makes available under these terms, including any portion of it.
+
+*you* refers to the individual or entity agreeing to these terms.
+
+*your company* is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. *control* means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+*your licenses* are all the licenses granted to you for the software under these terms.
+
+*use* means anything you do with the software requiring one of your licenses.
+
+*trademark* means trademarks, service marks, and similar rights.
+
+------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ During the local development, our whole backends use self-signed certification. 
 Once the release PR is merged to the `main` branch, the [release-please-action](https://github.com/google-github-actions/release-please-action) will tag and release a version correspondingly.
 
 The images are pushed to Docker Hub [repository](https://hub.docker.com/r/instill/console).
+
+## License
+
+See the [LICENSE](./LICENSE) file for licensing information.

--- a/integration-test/model-github.spec.ts
+++ b/integration-test/model-github.spec.ts
@@ -10,7 +10,7 @@ export function handleGithubModelTest() {
   const modelId = `github-model-${Math.floor(Math.random() * 10000)}`;
   const modelSource = "GitHub";
   const modelDescription = "Github test model";
-  const modelRepo = "instill-ai/model-mobilenetv2";
+  const modelRepo = "instill-ai/model-mobilenetv2-dvc";
   const modelTag = "v1.0-cpu";
 
   // This set of test are easily failed due to the timeout, latency issue of

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "repository": "https://github.com/instill-ai/console.git",
   "author": "Instill AI",
-  "license": "Apache-2.0",
+  "license": "Elastic License 2.0",
   "private": false,
   "scripts": {
     "docker-build": "docker build -f Dockerfile -t instill-console .",

--- a/src/components/OnboardingForm.tsx
+++ b/src/components/OnboardingForm.tsx
@@ -267,7 +267,7 @@ export const OnboardingForm = () => {
           label="Newsletter subscription"
           value={fieldValues.newsletterSubscription || false}
           required={true}
-          description="Receive the latest news from Instill AI for open source updates, community highlights, blog posts, useful tutorials and more! You can unsubscribe any time."
+          description="Receive the latest news from Instill AI for product updates, community highlights, blog posts, useful tutorials and more! You can unsubscribe any time."
           onChange={(event) =>
             handleFieldChange("newsletterSubscription", event)
           }

--- a/src/components/PageHead.tsx
+++ b/src/components/PageHead.tsx
@@ -14,7 +14,7 @@ export const PageHead = ({ title }: PageHeadProps) => {
     siteName: "Instill AI - Versatile Data Pipeline (VDP)",
     title: title ? title : "Instill AI - Versatile Data Pipeline (VDP)",
     pageDescription:
-      "Versatile Data Pipeline (VDP) is an open-source unstructured data ETL tool to streamline the end-to-end unstructured data processing pipeline",
+      "Versatile Data Pipeline (VDP) is a data ETL tool to streamline the end-to-end unstructured data processing pipeline",
   };
 
   const canonicalURL =


### PR DESCRIPTION
Because

- our mission is to make AI accessible to everyone. The best way to achieve this is to make VDP free to use and source available to everyone, while ensuring we safely create a sustainable business. Therefore, we chose ELv2 since it is very permissive. On the one hand, this allows us to provide users with free access to our source code, the permission to modify it. On the other hand, we've released Instill Cloud, a fully-managed public cloud service built upon VDP that offers additional features. With the license, we don't have to worry about our project being taken by some other companies for monetization.

This commit

- add LICENSE
- update integration test GitHub repository