### PR TITLE
chore(env): update env name NEXT_PUBLIC_DISABLE_USAGE_COLLECTION

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ NEXT_PUBLIC_DISABLE_CREATE_UPDATE_DELETE_RESOURCE=false
 NEXT_PUBLIC_LIST_PAGE_SIZE=6
 
 # When you set this to true, console will disable usage collection
-NEXT_PUBLIC_DISABLE_USAGE_COLLECTION=false
+NEXT_PUBLIC_USAGE_COLLECTION_ENABLED=true
 
 # When set to true, the onboarding cookie can only be set on a https domain
 # If you are using http, you need to set this to false

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -53,7 +53,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
       env("NEXT_PUBLIC_CONSOLE_EDITION") !== "local-ce:dev" &&
       !amplitudeIsInit
     ) {
-      if (env("NEXT_PUBLIC_DISABLE_USAGE_COLLECTION")) {
+      if (env("NEXT_PUBLIC_USAGE_COLLECTION_ENABLED")) {
         setAmplitudeIsInit(false);
       } else {
         initAmplitude(trackingToken.data);


### PR DESCRIPTION
Because

- We want to unify the naming rule of the configuration

This commit

- update env name NEXT_PUBLIC_DISABLE_USAGE_COLLECTION to NEXT_PUBLIC_USAGE_COLLECTION_ENABLED
