### PR TITLE
fix: fix pipeline deps wrong syntax 

### DIFF
--- a/src/lib/pipeline-builder/constructPipelineRecipe.tsx
+++ b/src/lib/pipeline-builder/constructPipelineRecipe.tsx
@@ -20,12 +20,12 @@ export function constructPipelineRecipe(
           images: `[${connections
             .map((edge) => `*${edge.source}.images`)
             .join(",")}]`,
-          structured_data: `[${connections
+          structured_data: `{${connections
             .map((edge) => `**${edge.source}.structured_data`)
-            .join(",")}]`,
-          metadata: `[${connections
+            .join(",")}}`,
+          metadata: `{${connections
             .map((edge) => `**${edge.source}.metadata`)
-            .join(",")}]`,
+            .join(",")}}`,
         },
       };
     }),

--- a/src/lib/pipeline-builder/parseDependencyComponents.ts
+++ b/src/lib/pipeline-builder/parseDependencyComponents.ts
@@ -7,6 +7,8 @@ export function parseDependencyComponents(string: string) {
   const dependencies = string
     .replaceAll("[", "")
     .replaceAll("]", "")
+    .replaceAll("{", "")
+    .replaceAll("}", "")
     .replaceAll("**", "")
     .replaceAll("*", "")
     .split(",")


### PR DESCRIPTION
Because

- The structured_data and metadata syntax should not be wrapped by `[]`

This commit

-  fix pipeline deps wrong syntax 