### PR TITLE
chore: build console image before pull on CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,6 +77,32 @@ jobs:
           rm --recursive --force "$AGENT_TOOLSDIRECTORY"
           df --human-readable
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Load .env file
+        uses: cardinalby/export-env-action@v2
+        with:
+          envFile: .env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: dropletbot
+          password: ${{ secrets.botDockerHubPassword }}
+
+      - name: Build image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: instill/console:latest
+
       - name: Checkout repo (base)
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Because

- Console image not correctly build

This commit

-  build console image before pull on CI
