### PR TITLE
fix: fix integration-test not correctly import expect

### DIFF
--- a/integration-test/integration-test.list.ts
+++ b/integration-test/integration-test.list.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 test("placeholder", async () => {
   expect(true).toBeTruthy();


### PR DESCRIPTION
Because

- fix integration-test not correctly import expect

This commit

- fix integration-test not correctly import expect