### PR TITLE
fix(model-hub): fix model namespace is wrong in instill-core's /models/<model_id> page

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@instill-ai/design-system": "^0.55.2",
     "@instill-ai/design-tokens": "^0.3.2",
-    "@instill-ai/toolkit": "^0.68.0-rc.167",
+    "@instill-ai/toolkit": "^0.68.0-rc.169",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^0.3.2
     version: 0.3.2(tailwindcss@3.3.1)
   '@instill-ai/toolkit':
-    specifier: ^0.68.0-rc.167
-    version: 0.68.0-rc.167(@instill-ai/design-system@0.55.2)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^0.68.0-rc.169
+    version: 0.68.0-rc.169(@instill-ai/design-system@0.55.2)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-checkbox':
     specifier: ^1.0.3
     version: 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -2375,8 +2375,8 @@ packages:
       tailwindcss: 3.3.1(postcss@8.4.14)
     dev: false
 
-  /@instill-ai/toolkit@0.68.0-rc.167(@instill-ai/design-system@0.55.2)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-O5BkKiF4S+/zeg+oWnUJL0SYS6LBhICjCZMgLdMpURUqb+mpu0+/MSG0fbmDD8j7Hm3uGJYol36Gxcdf3gQgug==}
+  /@instill-ai/toolkit@0.68.0-rc.169(@instill-ai/design-system@0.55.2)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uepj1zBLoeyay/WXzWgp0DJBnMU4K8ui01rgHXZdIcXQ1yPsILiOHQcg4nt1l5zZNFNA3oWOvFros0mzifMbuw==}
     peerDependencies:
       '@instill-ai/design-system': 0.55.2
       '@instill-ai/design-tokens': 0.3.2

--- a/src/pages/[entity]/model-hub/[id].tsx
+++ b/src/pages/[entity]/model-hub/[id].tsx
@@ -40,6 +40,7 @@ const ModelDetailsPage: NextPageWithLayout = () => {
             className="mb-5"
           />
         }
+        modelNamespace="admin"
       />
     </>
   );


### PR DESCRIPTION
Because

- model namespace is wrong in instill-core's /models/<model_id> page

This commit

- fix model namespace is wrong in instill-core's /models/<model_id> page
