### PR TITLE
ci(workflow): make disk free of GA hosted runner

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -82,7 +82,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: true
           swap-storage: true
 


### PR DESCRIPTION
Because

- We have to clean github action hosted runner so can run console image

This commit

- make disk free of GA hosted runner
