### PR TITLE
feat(pipeline-builder): adapt new component input structure 

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@instill-ai/design-system": "^0.55.6",
     "@instill-ai/design-tokens": "^0.3.2",
-    "@instill-ai/toolkit": "^0.68.3-rc.23",
+    "@instill-ai/toolkit": "^0.68.3-rc.34",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^0.3.2
     version: 0.3.2(tailwindcss@3.3.1)
   '@instill-ai/toolkit':
-    specifier: ^0.68.3-rc.23
-    version: 0.68.3-rc.23(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^0.68.3-rc.34
+    version: 0.68.3-rc.34(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-checkbox':
     specifier: ^1.0.3
     version: 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -2375,8 +2375,8 @@ packages:
       tailwindcss: 3.3.1(postcss@8.4.14)
     dev: false
 
-  /@instill-ai/toolkit@0.68.3-rc.23(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-khWu7da6PyzqMdMxQ35gGs0Pp9hqmZjyE/1wZW5RpFAdECeCmb4Kad8yoKidsikeJicdXL3g733AMjltLuhrdQ==}
+  /@instill-ai/toolkit@0.68.3-rc.34(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-BUp8Fz3I3kigNHRJwbDH8Gc+RMX2UlDURuTxmfIzhGXRSnPWcqXOYrFsyrO3yh90DmmAAOFuNhf9VHk/Jxdejw==}
     peerDependencies:
       '@instill-ai/design-system': 0.55.6
       '@instill-ai/design-tokens': 0.3.2


### PR DESCRIPTION
Because

- Backend has new component input structure

This commit

- adapt new component input structure 
