### PR TITLE
feat(pipeline-builder): make the array fields on start node start with only one field

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@instill-ai/design-system": "^0.55.6",
     "@instill-ai/design-tokens": "^0.3.2",
-    "@instill-ai/toolkit": "0.68.3-rc.60",
+    "@instill-ai/toolkit": "0.68.3-rc.69",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-collapsible": "^1.0.2",
     "@radix-ui/react-dialog": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^0.3.2
     version: 0.3.2(tailwindcss@3.3.1)
   '@instill-ai/toolkit':
-    specifier: 0.68.3-rc.60
-    version: 0.68.3-rc.60(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.68.3-rc.69
+    version: 0.68.3-rc.69(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-checkbox':
     specifier: ^1.0.3
     version: 1.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -2375,8 +2375,8 @@ packages:
       tailwindcss: 3.3.1(postcss@8.4.14)
     dev: false
 
-  /@instill-ai/toolkit@0.68.3-rc.60(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-E0PZYQnToBh7SQYprBSHiOxhCPbRoSk8FfU2SEpDHMIyeT4vS3QCD3uCxLZZZNkhMhfVEseEioaRWWT0cGeoYg==}
+  /@instill-ai/toolkit@0.68.3-rc.69(@instill-ai/design-system@0.55.6)(@instill-ai/design-tokens@0.3.2)(@types/react-dom@18.2.0)(@types/react@18.2.0)(next@13.4.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-cSBZ4/fcell36WBYrICtjd0OYJySOxjJM2b4ccLkksY87WKairKVWZv+TFaJpnRFyxedr1leh0R89AzNbxpZDQ==}
     peerDependencies:
       '@instill-ai/design-system': 0.55.6
       '@instill-ai/design-tokens': 0.3.2


### PR DESCRIPTION
Because

- Improve UX

This commit

- Make the array fields on start node start with only one field
