### PR TITLE
Update triggerPipelineSnippets

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippets.ts
+++ b/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippets.ts
@@ -5,8 +5,8 @@ export const core = `curl -X POST {vdp-pipeline-base-url}/vdp/v1alpha/{pipeline-
 --data \'{input-array}'
 `;
 
-export const cloud = `curl -X POST {vdp-pipeline-base-url}/vdp/v1alpha/{pipeline-name}/trigger' \\
---header 'Content-Type: application/json' \\ 
+export const cloud = `curl -X POST '{vdp-pipeline-base-url}/vdp/v1alpha/{pipeline-name}/trigger' \\
+--header 'Content-Type: application/json' \\
 --header 'Authorization: Bearer <api_token>' \\
 --data \ '{input-array}'
 `;


### PR DESCRIPTION
Because

- The trigger snippet on the console pipeline canvas is invalid and this PR fixes the issue

This commit

- closes https://github.com/instill-ai/community/issues/447
