### PR TITLE
feat(auto-gen-form): User can view the readable title in resource form instead of the key used by backend

### DIFF
--- a/apps/instill-form-playground/src/pages/index.tsx
+++ b/apps/instill-form-playground/src/pages/index.tsx
@@ -16,32 +16,10 @@ export default function Home() {
   const [data, setData] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string | null>(null);
 
-  const { form, fields, ValidatorSchema, formTree } = useInstillForm({
+  const { form, fields, ValidatorSchema, formTree } = useInstillForm(
     schema,
-    data: null,
-    // checkIsHiddenByFormTree: (tree) => {
-    //   if (tree._type === "formCondition") {
-    //     return false;
-    //   }
-
-    //   if (tree.instillEditOnNode) {
-    //     return false;
-    //   } else {
-    //     return true;
-    //   }
-    // },
-    // checkIsHiddenBySchema: (schema) => {
-    //   if (schema.oneOf) {
-    //     return false;
-    //   }
-
-    //   if (schema.instillEditOnNode) {
-    //     return false;
-    //   } else {
-    //     return true;
-    //   }
-    // },
-  });
+    null
+  );
 
   return (
     <div className="flex flex-1 min-h-screen min-w-[100vh] flex-col">

--- a/packages/toolkit/src/lib/use-instill-form/components/OneOfConditionField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/OneOfConditionField.tsx
@@ -24,9 +24,9 @@ export const OneOfConditionField = ({
     React.SetStateAction<Nullable<SelectedConditionMap>>
   >;
   conditionComponents: Record<string, React.ReactNode>;
+  title: Nullable<string>;
   description?: string;
   additionalDescription?: string;
-  title?: string;
   disabled?: boolean;
 }) => {
   const [prevSelectedConditionMap, setPrevSelectedConditionMap] =
@@ -46,8 +46,6 @@ export const OneOfConditionField = ({
       form.reset(formValues);
     }
   }, [prevSelectedConditionMap, selectedConditionMap]);
-
-  console.log("value", form.getValues());
 
   return (
     <div key={path} className="flex flex-col">

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickFieldComponentFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickFieldComponentFromInstillFormTree.tsx
@@ -10,23 +10,33 @@ import {
 } from "../components";
 import { GeneralUseFormReturn } from "../../type";
 
-export function pickFieldComponentFromInstillFormTree({
-  form,
-  tree,
-  selectedConditionMap,
-  setSelectedConditionMap,
-  disabledAll,
-  checkIsHiddenByFormTree,
-}: {
-  form: GeneralUseFormReturn;
-  tree: InstillFormTree;
-  selectedConditionMap: SelectedConditionMap | null;
+export type PickFieldComponentFromInstillFormTreeOptions = {
+  disabledAll?: boolean;
+  checkIsHiddenByTree?: (tree: InstillFormTree) => boolean;
+
+  // By default we will choose title from title field in JSON schema
+  chooseTitleFrom?: "title" | "key";
+};
+
+export function pickFieldComponentFromInstillFormTree(
+  tree: InstillFormTree,
+  form: GeneralUseFormReturn,
+  selectedConditionMap: SelectedConditionMap | null,
   setSelectedConditionMap: React.Dispatch<
     React.SetStateAction<SelectedConditionMap | null>
-  >;
-  disabledAll?: boolean;
-  checkIsHiddenByFormTree?: (tree: InstillFormTree) => boolean;
-}): React.ReactNode {
+  >,
+  options?: PickFieldComponentFromInstillFormTreeOptions
+): React.ReactNode {
+  const disabledAll = options?.disabledAll ?? false;
+  const checkIsHiddenByTree = options?.checkIsHiddenByTree ?? undefined;
+  const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
+
+  let title = tree.title ?? tree.fieldKey ?? null;
+
+  if (chooseTitleFrom === "key") {
+    title = tree.fieldKey ?? null;
+  }
+
   if (tree._type === "formGroup") {
     return tree.fieldKey ? (
       <div
@@ -37,33 +47,39 @@ export function pickFieldComponentFromInstillFormTree({
           {tree.fieldKey || tree.path}
         </p>
         {tree.properties.map((property) => {
-          return pickFieldComponentFromInstillFormTree({
+          return pickFieldComponentFromInstillFormTree(
+            property,
             form,
-            tree: property,
             selectedConditionMap,
             setSelectedConditionMap,
-            disabledAll,
-            checkIsHiddenByFormTree,
-          });
+            {
+              disabledAll,
+              checkIsHiddenByTree,
+              chooseTitleFrom,
+            }
+          );
         })}
       </div>
     ) : (
       <React.Fragment key={tree.path || tree.fieldKey}>
         {tree.properties.map((property) => {
-          return pickFieldComponentFromInstillFormTree({
+          return pickFieldComponentFromInstillFormTree(
+            property,
             form,
-            tree: property,
             selectedConditionMap,
             setSelectedConditionMap,
-            disabledAll,
-            checkIsHiddenByFormTree,
-          });
+            {
+              disabledAll,
+              checkIsHiddenByTree,
+              chooseTitleFrom,
+            }
+          );
         })}
       </React.Fragment>
     );
   }
 
-  if (checkIsHiddenByFormTree && checkIsHiddenByFormTree(tree)) {
+  if (checkIsHiddenByTree && checkIsHiddenByTree(tree)) {
     return null;
   }
 
@@ -72,14 +88,17 @@ export function pickFieldComponentFromInstillFormTree({
       Object.entries(tree.conditions).map(([k, v]) => {
         return [
           k,
-          pickFieldComponentFromInstillFormTree({
-            tree: v,
+          pickFieldComponentFromInstillFormTree(
+            v,
             form,
             selectedConditionMap,
             setSelectedConditionMap,
-            disabledAll,
-            checkIsHiddenByFormTree,
-          }),
+            {
+              disabledAll,
+              checkIsHiddenByTree,
+              chooseTitleFrom,
+            }
+          ),
         ];
       })
     );
@@ -103,7 +122,7 @@ export function pickFieldComponentFromInstillFormTree({
         setSelectedConditionMap={setSelectedConditionMap}
         key={constField.path}
         conditionComponents={conditionComponents}
-        title={constField.fieldKey ?? undefined}
+        title={title}
         additionalDescription={tree.additionalDescription}
         disabled={disabledAll}
       />
@@ -114,14 +133,17 @@ export function pickFieldComponentFromInstillFormTree({
     return (
       <React.Fragment key={tree.path || tree.fieldKey}>
         {tree.properties.map((property) => {
-          return pickFieldComponentFromInstillFormTree({
+          return pickFieldComponentFromInstillFormTree(
+            property,
             form,
-            tree: property,
             selectedConditionMap,
             setSelectedConditionMap,
-            disabledAll,
-            checkIsHiddenByFormTree,
-          });
+            {
+              disabledAll,
+              checkIsHiddenByTree,
+              chooseTitleFrom,
+            }
+          );
         })}
       </React.Fragment>
     );
@@ -136,7 +158,7 @@ export function pickFieldComponentFromInstillFormTree({
       <BooleanField
         key={tree.path}
         path={tree.path}
-        title={tree.fieldKey ?? tree.title ?? null}
+        title={title}
         form={form}
         description={tree.description}
         additionalDescription={tree.additionalDescription}
@@ -151,7 +173,7 @@ export function pickFieldComponentFromInstillFormTree({
         key={tree.path}
         path={tree.path}
         form={form}
-        title={tree.fieldKey ?? tree.title ?? null}
+        title={title}
         options={tree.enum}
         description={tree.description}
         additionalDescription={tree.additionalDescription}
@@ -166,7 +188,7 @@ export function pickFieldComponentFromInstillFormTree({
         key={tree.path}
         path={tree.path}
         form={form}
-        title={tree.fieldKey ?? tree.title ?? null}
+        title={title}
         description={tree.description}
         additionalDescription={tree.additionalDescription}
         disabled={disabledAll}
@@ -180,7 +202,7 @@ export function pickFieldComponentFromInstillFormTree({
         key={tree.path}
         path={tree.path}
         form={form}
-        title={tree.fieldKey ?? tree.title ?? null}
+        title={title}
         description={tree.description}
         additionalDescription={tree.additionalDescription}
         disabled={disabledAll}
@@ -193,7 +215,7 @@ export function pickFieldComponentFromInstillFormTree({
       key={tree.path}
       path={tree.path}
       form={form}
-      title={tree.fieldKey ?? tree.title ?? null}
+      title={title}
       description={tree.description}
       additionalDescription={tree.additionalDescription}
       disabled={disabledAll}

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.test.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.test.ts
@@ -51,9 +51,7 @@ test("should transform basic JSON schema to formTree", () => {
     },
   };
 
-  const formTree = transformInstillJSONSchemaToFormTree({
-    targetSchema: schema,
-  });
+  const formTree = transformInstillJSONSchemaToFormTree(schema);
 
   const expectedFormTree: InstillFormTree = {
     title: "Simple JSON",
@@ -483,9 +481,7 @@ test("should transform real InstillJSONSchema to formTree", () => {
     type: "object",
   };
 
-  const formTree = transformInstillJSONSchemaToFormTree({
-    targetSchema: schema,
-  });
+  const formTree = transformInstillJSONSchemaToFormTree(schema);
 
   const expectedFormTree: InstillFormTree = {
     title: "OpenAI Component",
@@ -1745,9 +1741,7 @@ test("should transform formArray JSON schema to formTree", () => {
     },
   };
 
-  const formTree = transformInstillJSONSchemaToFormTree({
-    targetSchema: schema,
-  });
+  const formTree = transformInstillJSONSchemaToFormTree(schema);
 
   const expectedFormTree: InstillFormTree = {
     _type: "formGroup",
@@ -1941,9 +1935,7 @@ test("should transform basic JSON schema without anyOf to formTree", () => {
     ],
   };
 
-  const formTree = transformInstillJSONSchemaToFormTree({
-    targetSchema: schema,
-  });
+  const formTree = transformInstillJSONSchemaToFormTree(schema);
 
   expect(formTree).toStrictEqual(expected);
 });

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
@@ -8,18 +8,20 @@ import {
   InstillJSONSchemaDefinition,
 } from "../type";
 
-export function transformInstillJSONSchemaToFormTree({
-  targetSchema,
-  key,
-  path,
-  parentSchema,
-}: {
-  targetSchema: InstillJSONSchemaDefinition;
+export type TransformInstillJSONSchemaToFormTreeOptions = {
   key?: string;
   path?: string;
   parentSchema?: InstillJSONSchema;
-}): InstillFormTree {
+};
+
+export function transformInstillJSONSchemaToFormTree(
+  targetSchema: InstillJSONSchemaDefinition,
+  options?: TransformInstillJSONSchemaToFormTreeOptions
+): InstillFormTree {
   let isRequired = false;
+  const key = options?.key;
+  const path = options?.path;
+  const parentSchema = options?.parentSchema;
 
   if (
     key &&
@@ -57,12 +59,14 @@ export function transformInstillJSONSchemaToFormTree({
 
         return [
           constValue,
-          transformInstillJSONSchemaToFormTree({
-            targetSchema: { type: targetSchema.type, ...condition },
-            parentSchema,
-            key,
-            path,
-          }),
+          transformInstillJSONSchemaToFormTree(
+            { type: targetSchema.type, ...condition },
+            {
+              parentSchema,
+              key,
+              path,
+            }
+          ),
         ];
       })
     );
@@ -95,12 +99,14 @@ export function transformInstillJSONSchemaToFormTree({
     !Array.isArray(targetSchema.items) &&
     targetSchema.items.type === "object"
   ) {
-    const propertyFormTree = transformInstillJSONSchemaToFormTree({
-      targetSchema: targetSchema.items,
-      parentSchema: targetSchema,
-      key,
-      path,
-    }) as InstillFormGroupItem;
+    const propertyFormTree = transformInstillJSONSchemaToFormTree(
+      targetSchema.items,
+      {
+        parentSchema: targetSchema,
+        key,
+        path,
+      }
+    ) as InstillFormGroupItem;
 
     return {
       ...pickBaseFields(targetSchema),
@@ -115,8 +121,7 @@ export function transformInstillJSONSchemaToFormTree({
   if (targetSchema.properties) {
     const properties = Object.entries(targetSchema.properties || []).map(
       ([key, schema]) =>
-        transformInstillJSONSchemaToFormTree({
-          targetSchema: schema,
+        transformInstillJSONSchemaToFormTree(schema, {
           parentSchema: targetSchema,
           key,
           path: path ? `${path}.${key}` : key,

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
@@ -9,23 +9,31 @@ import {
 } from "./transform";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { pickFieldComponentFromInstillFormTree } from "./pick";
+import {
+  PickFieldComponentFromInstillFormTreeOptions,
+  pickFieldComponentFromInstillFormTree,
+} from "./pick";
 import { useInstillSelectedConditionMap } from "./useInstillSelectedConditionMap";
 import { GeneralRecord } from "../type";
 
-export function useInstillForm({
-  schema,
-  data,
-  disabledAll,
-  checkIsHiddenByFormTree,
-  checkIsHiddenBySchema,
-}: {
-  schema: InstillJSONSchema | null;
-  data: GeneralRecord | null;
+export type UseInstillFormOptions = {
   disabledAll?: boolean;
-  checkIsHiddenByFormTree?: (tree: InstillFormTree) => boolean;
   checkIsHiddenBySchema?: (schema: InstillJSONSchema) => boolean;
-}) {
+} & Pick<
+  PickFieldComponentFromInstillFormTreeOptions,
+  "checkIsHiddenByTree" | "chooseTitleFrom"
+>;
+
+export function useInstillForm(
+  schema: InstillJSONSchema | null,
+  data: GeneralRecord | null,
+  {
+    disabledAll,
+    checkIsHiddenByTree,
+    checkIsHiddenBySchema,
+    chooseTitleFrom,
+  }: UseInstillFormOptions
+) {
   const [formTree, setFormTree] = React.useState<InstillFormTree | null>(null);
 
   const [selectedConditionMap, setSelectedConditionMap] =
@@ -46,9 +54,8 @@ export function useInstillForm({
   React.useEffect(() => {
     if (!schema) return;
 
-    const _formTree = transformInstillJSONSchemaToFormTree({
+    const _formTree = transformInstillJSONSchemaToFormTree(schema, {
       parentSchema: schema,
-      targetSchema: schema,
     });
 
     setFormTree(_formTree);
@@ -92,24 +99,28 @@ export function useInstillForm({
     }
 
     return {
-      fields: pickFieldComponentFromInstillFormTree({
+      fields: pickFieldComponentFromInstillFormTree(
+        formTree,
         form,
-        tree: formTree,
         selectedConditionMap,
         setSelectedConditionMap,
-        checkIsHiddenByFormTree,
-        disabledAll,
-      }),
+        {
+          checkIsHiddenByTree,
+          disabledAll,
+          chooseTitleFrom,
+        }
+      ),
       formTree,
     };
   }, [
     schema,
     formTree,
-    checkIsHiddenByFormTree,
+    checkIsHiddenByTree,
     form,
     selectedConditionMap,
     setSelectedConditionMap,
     disabledAll,
+    chooseTitleFrom,
   ]);
 
   return {

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
@@ -27,13 +27,13 @@ export type UseInstillFormOptions = {
 export function useInstillForm(
   schema: InstillJSONSchema | null,
   data: GeneralRecord | null,
-  {
-    disabledAll,
-    checkIsHiddenByTree,
-    checkIsHiddenBySchema,
-    chooseTitleFrom,
-  }: UseInstillFormOptions
+  options?: UseInstillFormOptions
 ) {
+  const disabledAll = options?.disabledAll ?? false;
+  const checkIsHiddenBySchema = options?.checkIsHiddenBySchema ?? undefined;
+  const checkIsHiddenByTree = options?.checkIsHiddenByTree ?? undefined;
+  const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
+
   const [formTree, setFormTree] = React.useState<InstillFormTree | null>(null);
 
   const [selectedConditionMap, setSelectedConditionMap] =

--- a/packages/toolkit/src/view/resource/ResourceComponentForm.tsx
+++ b/packages/toolkit/src/view/resource/ResourceComponentForm.tsx
@@ -17,11 +17,14 @@ export const ResourceComponentForm = ({
   onSubmit,
   disabledAll,
 }: ResourceComponentFormProps) => {
-  const { form, fields } = useInstillForm({
-    schema: connectorDefinition.spec.component_specification,
-    data: configuration,
-    disabledAll,
-  });
+  const { form, fields } = useInstillForm(
+    connectorDefinition.spec.component_specification,
+    configuration,
+    {
+      disabledAll,
+      chooseTitleFrom: "key",
+    }
+  );
 
   return (
     <Form.Root {...form}>

--- a/packages/toolkit/src/view/resource/ResourceResourceForm.tsx
+++ b/packages/toolkit/src/view/resource/ResourceResourceForm.tsx
@@ -37,11 +37,14 @@ export const ResourceResourceForm = ({
 }: ResourceResourceFormProps) => {
   const [isSaving, setIsSaving] = React.useState(false);
 
-  const { form, fields, ValidatorSchema } = useInstillForm({
-    schema: definition.spec.resource_specification,
-    data: resource?.configuration ?? null,
-    disabledAll,
-  });
+  const { form, fields, ValidatorSchema } = useInstillForm(
+    definition.spec.resource_specification,
+    resource?.configuration ?? null,
+    {
+      disabledAll,
+      chooseTitleFrom: "title",
+    }
+  );
 
   const { form: resourceAdditionalForm, fields: resourceAdditionalFormFields } =
     useResourceAdditionalForm({


### PR DESCRIPTION
Because

- User can view the readable title in resource form instead of the key used by backend

This commit

- User can view the readable title in resource form instead of the key used by backend
