### PR TITLE
fix(smart-hint): fix smart hint can't correctly handle empty string

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
@@ -4,6 +4,7 @@ import { ScrollArea } from "@instill-ai/design-system";
 import { SmartHint } from "../../../use-smart-hint";
 import { onClickSmartHint } from "./onClickSmartHint";
 import { ControllerRenderProps } from "react-hook-form";
+import { Nullable } from "../../../type";
 
 export const SmartHintList = ({
   field,
@@ -15,6 +16,7 @@ export const SmartHintList = ({
   highlightedHintIndex,
   setHighlightedHintIndex,
   inputRef,
+  smartHintEnabledPos,
 }: {
   field: ControllerRenderProps<
     {
@@ -30,6 +32,7 @@ export const SmartHintList = ({
   highlightedHintIndex: number;
   setHighlightedHintIndex: React.Dispatch<React.SetStateAction<number>>;
   inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement>;
+  smartHintEnabledPos: Nullable<number>;
 }) => {
   return (
     <ScrollArea.Root viewPortRef={smartHintsScrollAreaViewportRef}>
@@ -54,6 +57,7 @@ export const SmartHintList = ({
                       smartHint: hint,
                       setEnableSmartHints,
                       inputRef,
+                      smartHintEnabledPos,
                     });
                   }}
                   onMouseEnter={() => {

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -171,6 +171,7 @@ export const TextArea = ({
                         setHighlightedHintIndex,
                         inputRef,
                         smartHintsScrollAreaViewportRef,
+                        smartHintEnabledPos,
                       });
                     }}
                   />
@@ -210,6 +211,7 @@ export const TextArea = ({
                       highlightedHintIndex={highlightedHintIndex}
                       setHighlightedHintIndex={setHighlightedHintIndex}
                       inputRef={inputRef}
+                      smartHintEnabledPos={smartHintEnabledPos}
                     />
                   </React.Fragment>
                 ) : (

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -172,6 +172,7 @@ export const TextField = ({
                           setHighlightedHintIndex,
                           inputRef,
                           smartHintsScrollAreaViewportRef,
+                          smartHintEnabledPos,
                         });
                       }}
                     />
@@ -212,6 +213,7 @@ export const TextField = ({
                       highlightedHintIndex={highlightedHintIndex}
                       setHighlightedHintIndex={setHighlightedHintIndex}
                       inputRef={inputRef}
+                      smartHintEnabledPos={smartHintEnabledPos}
                     />
                   </React.Fragment>
                 ) : (

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onClickSmartHint.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onClickSmartHint.tsx
@@ -8,6 +8,7 @@ export function onClickSmartHint({
   field,
   smartHint,
   setEnableSmartHints,
+  smartHintEnabledPos,
 }: {
   inputRef: React.MutableRefObject<
     Nullable<HTMLInputElement | HTMLTextAreaElement>
@@ -20,15 +21,18 @@ export function onClickSmartHint({
   >;
   smartHint: SmartHint;
   setEnableSmartHints: React.Dispatch<React.SetStateAction<boolean>>;
+  smartHintEnabledPos: Nullable<number>;
 }) {
   if (inputRef.current) {
     const cursorPosition = inputRef.current.selectionStart;
     const value = field.value ?? "";
-    const newValue = `${value.slice(0, cursorPosition)}${
+
+    const newValue = `${value.slice(0, smartHintEnabledPos ?? 0 + 1)}${
       smartHint.path
     }${value.slice(cursorPosition)}`;
 
     field.onChange(newValue);
     setEnableSmartHints(false);
+    inputRef.current.focus();
   }
 }

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { SmartHint } from "../../../use-smart-hint";
 import { ControllerRenderProps } from "react-hook-form";
+import { Nullable } from "../../../type";
 
 export function onInputKeydown({
   field,
@@ -14,6 +15,7 @@ export function onInputKeydown({
   initSmartHintState,
   enableSmartHints,
   setEnableSmartHints,
+  smartHintEnabledPos,
 }: {
   field: ControllerRenderProps<
     {
@@ -31,6 +33,7 @@ export function onInputKeydown({
   smartHintsScrollAreaViewportRef: React.RefObject<HTMLDivElement>;
   inputRef: React.RefObject<HTMLInputElement | HTMLTextAreaElement>;
   initSmartHintState: () => void;
+  smartHintEnabledPos: Nullable<number>;
 }) {
   switch (event.key) {
     case "ArrowDown": {
@@ -76,7 +79,8 @@ export function onInputKeydown({
           if (inputRef.current) {
             const cursorPosition = inputRef.current.selectionStart;
             const value = field.value ?? "";
-            const newValue = `${value.slice(0, cursorPosition)}${
+
+            const newValue = `${value.slice(0, smartHintEnabledPos ?? 0 + 1)}${
               filteredHints[highlightedHintIndex].path
             }${value.slice(cursorPosition)}`;
 

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -50,6 +50,8 @@ export function pickComponentOutputFieldsFromInstillFormTree(
           {tree.fieldKey || tree.path}
         </p>
         {tree.properties.map((property) => {
+          console.log(property);
+
           return pickComponentOutputFieldsFromInstillFormTree({
             ...props,
             tree: property,

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
@@ -198,11 +198,17 @@ export function transformInstillJSONSchemaToZod({
       } else {
         switch (instillUpstreamValue.type) {
           case "string": {
-            instillZodSchema = z
-              .string({
+            if (isRequired) {
+              instillZodSchema = z
+                .string({
+                  errorMap: customErrorMap,
+                })
+                .min(1, "This field is required");
+            } else {
+              instillZodSchema = z.string({
                 errorMap: customErrorMap,
-              })
-              .min(1, "This field is required");
+              });
+            }
             break;
           }
           case "boolean": {
@@ -215,7 +221,11 @@ export function transformInstillJSONSchemaToZod({
             // set the initial zod schema to string and then validate it with
             // superRefine.
 
-            instillZodSchema = z.string().min(1, "This field is required");
+            if (isRequired) {
+              instillZodSchema = z.string().min(1, "This field is required");
+            } else {
+              instillZodSchema = z.string();
+            }
             break;
           }
         }
@@ -380,11 +390,18 @@ export function transformInstillJSONSchemaToZod({
 
   switch (targetSchema.type) {
     case "string": {
-      instillZodSchema = z
-        .string({
+      if (isRequired) {
+        instillZodSchema = z
+          .string({
+            errorMap: customErrorMap,
+          })
+          .min(1, "This field is required");
+      } else {
+        instillZodSchema = z.string({
           errorMap: customErrorMap,
-        })
-        .min(1, "This field is required");
+        });
+      }
+
       break;
     }
     case "boolean": {
@@ -397,7 +414,11 @@ export function transformInstillJSONSchemaToZod({
       // set the initial zod schema to string and then validate it with
       // superRefine.
 
-      instillZodSchema = z.string().min(1, "This field is required");
+      if (isRequired) {
+        instillZodSchema = z.string().min(1, "This field is required");
+      } else {
+        instillZodSchema = z.string();
+      }
       break;
     }
   }

--- a/packages/toolkit/src/lib/use-instill-form/useComponentOutputFields.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useComponentOutputFields.tsx
@@ -25,6 +25,8 @@ export function useComponentOutputFields(props: UseComponentOutputFieldsProps) {
 
     const outputFormTree = transformInstillJSONSchemaToFormTree(props.schema);
 
+    console.log(outputFormTree);
+
     const fields = pickComponentOutputFieldsFromInstillFormTree({
       ...props,
       tree: outputFormTree,


### PR DESCRIPTION
Because

- fix smart hint can't correctly handle empty string

This commit

- fix smart hint can't correctly handle empty string
