### PR TITLE
fix(auto-gen-form): fix end component didn't correctly handle the key naming rule

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -18,6 +18,7 @@ import { onInputChange } from "./onInputChange";
 import { onInputKeydown } from "./onInputKeydown";
 import { SmartHintList } from "./SmartHintList";
 import { SmartHintWarning } from "../../type";
+import { useValidateReferenceAndTemplate } from "./useValidateReferenceAndTemplate";
 
 export const TextArea = ({
   form,
@@ -67,6 +68,12 @@ export const TextArea = ({
     setSmartHintEnabledPos(null);
     setCurrentCursorPos(null);
   }
+
+  useValidateReferenceAndTemplate({
+    hints: smartHints,
+    fieldValue,
+    setSmartHintWarning,
+  });
 
   const filteredHints = useFilteredHints({
     smartHints,

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
@@ -271,6 +271,7 @@ const baseFields: Array<keyof InstillJSONSchema> = [
   "instillUIOrder",
   "instillEditOnNodeFields",
   "instillUiMultiline",
+  "instillPatternErrorMessage",
 ];
 
 function pickBaseFields(

--- a/packages/toolkit/src/lib/use-instill-form/type.ts
+++ b/packages/toolkit/src/lib/use-instill-form/type.ts
@@ -16,6 +16,7 @@ export type InstillCustomProps = {
   instillUiMultiline?: boolean;
   instillEditOnNodeFields?: string[];
   instillCredentialField?: boolean;
+  instillPatternErrorMessage?: string;
 };
 
 type InstillJsonSchemaProps = {

--- a/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/EndNode.tsx
@@ -56,6 +56,9 @@ const CreateEndOperatorInputSchema: InstillJSONSchema = {
         {
           type: "string",
           instillUpstreamType: "value",
+          pattern: "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$",
+          instillPatternErrorMessage:
+            "The key should be lowercase without any space or special character besides the hyphen, and should be less than 63 characters.",
         },
       ],
       instillUpstreamTypes: ["value"],


### PR DESCRIPTION
Because

- fix end component didn't correctly handle the key naming rule

This commit

- fix end component didn't correctly handle the key naming rule
