### PR TITLE
fix(smart-hint): Fix smart hint wrongly hint user to use the same component's output

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -30,6 +30,7 @@ export const TextArea = ({
   instillAcceptFormats,
   isRequired,
   instillUpstreamTypes,
+  componentID,
 }: {
   form: GeneralUseFormReturn;
   path: string;
@@ -40,6 +41,7 @@ export const TextArea = ({
   disabled?: boolean;
   isRequired?: boolean;
   instillUpstreamTypes: string[];
+  componentID?: string;
 }) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =
@@ -81,6 +83,7 @@ export const TextArea = ({
     currentCursorPos,
     smartHintEnabledPos,
     fieldValue,
+    componentID,
   });
 
   const supportTemplate = instillUpstreamTypes.includes("template");

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -30,6 +30,7 @@ export const TextField = ({
   instillAcceptFormats,
   isRequired,
   instillUpstreamTypes,
+  componentID,
 }: {
   form: GeneralUseFormReturn;
   path: string;
@@ -40,6 +41,7 @@ export const TextField = ({
   disabled?: boolean;
   isRequired?: boolean;
   instillUpstreamTypes: string[];
+  componentID?: string;
 }) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =
@@ -80,6 +82,7 @@ export const TextField = ({
     currentCursorPos,
     smartHintEnabledPos,
     fieldValue,
+    componentID,
   });
 
   const supportTemplate = instillUpstreamTypes.includes("template");

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/useFilteredHints.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/useFilteredHints.tsx
@@ -12,12 +12,14 @@ export function useFilteredHints({
   currentCursorPos,
   smartHintEnabledPos,
   fieldValue,
+  componentID,
 }: {
   smartHints: SmartHint[];
   instillAcceptFormats: string[];
   currentCursorPos: Nullable<number>;
   smartHintEnabledPos: Nullable<number>;
   fieldValue: string;
+  componentID?: string;
 }) {
   const filteredHints: SmartHint[] = React.useMemo(() => {
     if (!smartHints || smartHints.length === 0) {
@@ -35,10 +37,28 @@ export function useFilteredHints({
       searchCode = fieldValue.substring(smartHintEnabledPos, currentCursorPos);
 
       if (searchCode) {
-        return allHints.filter((hint) =>
-          hint.path.startsWith(searchCode as string)
-        );
+        return allHints.filter((hint) => {
+          if (componentID) {
+            const hintPath = hint.path.split(".");
+            if (componentID === hintPath[0]) {
+              return false;
+            }
+          }
+
+          return hint.path.startsWith(searchCode as string);
+        });
       }
+    }
+
+    if (componentID) {
+      return allHints.filter((hint) => {
+        const hintPath = hint.path.split(".");
+        if (componentID === hintPath[0]) {
+          return false;
+        }
+
+        return true;
+      });
     }
 
     return allHints;
@@ -48,6 +68,7 @@ export function useFilteredHints({
     currentCursorPos,
     smartHintEnabledPos,
     fieldValue,
+    componentID,
   ]);
 
   return filteredHints;

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -11,6 +11,7 @@ export type PickRegularFieldsFromInstillFormTreeOptions = {
   // By default we will choose title from title field in JSON schema
   chooseTitleFrom?: "title" | "key";
   enableSmartHint?: boolean;
+  componentID?: string;
 };
 
 export function pickRegularFieldsFromInstillFormTree(
@@ -26,6 +27,7 @@ export function pickRegularFieldsFromInstillFormTree(
   const checkIsHiddenByTree = options?.checkIsHiddenByTree ?? undefined;
   const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
   const enableSmartHint = options?.enableSmartHint ?? false;
+  const componentID = options?.componentID ?? "";
 
   let title = tree.title ?? tree.fieldKey ?? null;
 
@@ -178,6 +180,7 @@ export function pickRegularFieldsFromInstillFormTree(
           instillAcceptFormats={tree.instillAcceptFormats ?? []}
           isRequired={tree.isRequired}
           instillUpstreamTypes={tree.instillUpstreamTypes ?? []}
+          componentID={componentID}
         />
       );
     }
@@ -222,6 +225,7 @@ export function pickRegularFieldsFromInstillFormTree(
         instillAcceptFormats={tree.instillAcceptFormats ?? []}
         isRequired={tree.isRequired}
         instillUpstreamTypes={tree.instillUpstreamTypes ?? []}
+        componentID={componentID}
       />
     );
   }

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
@@ -20,6 +20,7 @@ export type UseInstillFormOptions = {
   disabledAll?: boolean;
   checkIsHidden?: CheckIsHidden;
   enableSmartHint?: boolean;
+  componentID?: string;
 } & Pick<PickRegularFieldsFromInstillFormTreeOptions, "chooseTitleFrom">;
 
 export function useInstillForm(
@@ -31,6 +32,7 @@ export function useInstillForm(
   const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
   const checkIsHidden = options?.checkIsHidden ?? undefined;
   const enableSmartHint = options?.enableSmartHint ?? false;
+  const componentID = options?.componentID ?? "";
 
   const [formTree, setFormTree] = React.useState<InstillFormTree | null>(null);
   const [ValidatorSchema, setValidatorSchema] = React.useState<z.ZodTypeAny>(
@@ -120,6 +122,7 @@ export function useInstillForm(
         disabledAll,
         chooseTitleFrom,
         enableSmartHint,
+        componentID,
       }
     );
 

--- a/packages/toolkit/src/lib/useResourceAdditionalForm.tsx
+++ b/packages/toolkit/src/lib/useResourceAdditionalForm.tsx
@@ -5,10 +5,22 @@ import { Nullable } from "vitest";
 import * as z from "zod";
 import { Form, Input, Textarea } from "@instill-ai/design-system";
 
-export const ResourceAdditionalFormSchema = z.object({
-  id: z.string(),
-  description: z.string().nullable().optional(),
-});
+export const ResourceAdditionalFormSchema = z
+  .object({
+    id: z.string(),
+    description: z.string().nullable().optional(),
+  })
+  .superRefine((val, ctx) => {
+    const regexPattern = new RegExp("^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$");
+    if (!regexPattern.test(val.id)) {
+      return ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "The ID should be lowercase without any space or special character besides the hyphen, and should be less than 63 characters.",
+        path: ["id"],
+      });
+    }
+  });
 
 export const useResourceAdditionalForm = ({
   data,

--- a/packages/toolkit/src/view/ai/AIComponentAutoForm.tsx
+++ b/packages/toolkit/src/view/ai/AIComponentAutoForm.tsx
@@ -18,6 +18,7 @@ export type AIComponentAutoFormProps = {
   connectorDefinition: ConnectorDefinition;
   configuration: GeneralRecord;
   disabledAll?: boolean;
+  componentID?: string;
 };
 
 const selector = (store: InstillStore) => ({

--- a/packages/toolkit/src/view/blockchain/BlockchainComponentAutoForm.tsx
+++ b/packages/toolkit/src/view/blockchain/BlockchainComponentAutoForm.tsx
@@ -19,6 +19,7 @@ export type BlockchainComponentAutoFormProps = {
   connectorDefinition: ConnectorDefinition;
   configuration: GeneralRecord;
   disabledAll?: boolean;
+  componentID?: string;
 };
 
 const selector = (store: InstillStore) => ({

--- a/packages/toolkit/src/view/data/DataComponentAutoForm.tsx
+++ b/packages/toolkit/src/view/data/DataComponentAutoForm.tsx
@@ -19,6 +19,7 @@ export type DataComponentAutoFormProps = {
   connectorDefinition: ConnectorDefinition;
   configuration: GeneralRecord;
   disabledAll?: boolean;
+  componentID?: string;
 };
 
 const selector = (store: InstillStore) => ({

--- a/packages/toolkit/src/view/pipeline-builder/RightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/RightPanel.tsx
@@ -63,6 +63,7 @@ export const RightPanel = () => {
             connectorDefinition={
               selectedConnectorNode.data.component.connector_definition
             }
+            componentID={selectedConnectorNodeId ?? undefined}
           />
         ) : null}
         {selectedConnectorNode &&
@@ -75,6 +76,7 @@ export const RightPanel = () => {
             connectorDefinition={
               selectedConnectorNode.data.component.connector_definition
             }
+            componentID={selectedConnectorNodeId ?? undefined}
           />
         ) : null}
         {selectedConnectorNode &&
@@ -89,6 +91,7 @@ export const RightPanel = () => {
               connectorDefinition={
                 selectedConnectorNode.data.component.connector_definition
               }
+              componentID={selectedConnectorNodeId ?? undefined}
             />
           ) : null
         ) : null}

--- a/packages/toolkit/src/view/resource/ResourceComponentForm.tsx
+++ b/packages/toolkit/src/view/resource/ResourceComponentForm.tsx
@@ -10,6 +10,7 @@ export type ResourceComponentFormProps = {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   onSubmit: (data: any) => void;
   checkIsHidden?: CheckIsHidden;
+  componentID?: string;
 };
 
 export const ResourceComponentForm = ({
@@ -18,6 +19,7 @@ export const ResourceComponentForm = ({
   onSubmit,
   disabledAll,
   checkIsHidden,
+  componentID,
 }: ResourceComponentFormProps) => {
   const { form, fields } = useInstillForm(
     connectorDefinition.spec.component_specification,
@@ -27,6 +29,7 @@ export const ResourceComponentForm = ({
       chooseTitleFrom: "key",
       checkIsHidden,
       enableSmartHint: true,
+      componentID,
     }
   );
 


### PR DESCRIPTION

Because

-  Fix smart hint wrongly hint user to use the same component's output

This commit

-  Fix smart hint wrongly hint user to use the same component's output