### PR TITLE
fix(pipeline-builder): fix output object viewer not correctly open when it's empty

### DIFF
--- a/packages/toolkit/src/components/ObjectViewer.tsx
+++ b/packages/toolkit/src/components/ObjectViewer.tsx
@@ -29,7 +29,6 @@ export const ObjectViewer = ({ value }: { value: Nullable<string> }) => {
         theme={githubDark}
         editable={false}
         maxHeight="225px"
-        minHeight="120px"
         basicSetup={{
           highlightActiveLineGutter: false,
           highlightActiveLine: false,

--- a/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputs.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputs.tsx
@@ -59,7 +59,7 @@ export const ComponentOutputs = ({
         className="nodrag nowheel h-full"
         viewPortClassName="max-h-[400px]"
       >
-        <div className="flex flex-col gap-y-1 rounded bg-semantic-bg-primary py-2">
+        <div className="flex flex-col gap-y-1 rounded bg-semantic-bg-primary">
           {componentOutputFields}
         </div>
       </ScrollArea.Root>

--- a/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
@@ -287,6 +287,14 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
       !testModeTriggerResponse.metadata.traces[id].outputs ||
       testModeTriggerResponse.metadata.traces[id].outputs.length === 0
     ) {
+      if (isOpenBottomBarOutput) {
+        return (
+          <div className="w-full">
+            <ObjectViewer value="" />
+          </div>
+        );
+      }
+
       return null;
     }
 

--- a/packages/toolkit/src/view/pipeline-builder/components/operator-node/OperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/operator-node/OperatorNode.tsx
@@ -277,6 +277,13 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
       !testModeTriggerResponse.metadata.traces[id].outputs ||
       testModeTriggerResponse.metadata.traces[id].outputs.length === 0
     ) {
+      if (isOpenBottomBarOutput) {
+        return (
+          <div className="w-full">
+            <ObjectViewer value="" />
+          </div>
+        );
+      }
       return null;
     }
 


### PR DESCRIPTION
Because

- fix output object viewer not correctly open when it's empty

This commit

- fix output object viewer not correctly open when it's empty
