### PR TITLE
fix: fix pipeline builder not correctly hide data connector's free form

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/connector-node/ConnectorNode.tsx
@@ -484,7 +484,9 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
           data.component.definition_name !== "connector-definitions/pinecone" &&
           data.component.definition_name !== "connector-definitions/gcs" &&
           data.component.definition_name !==
-            "connector-definitions/google-search" ? (
+            "connector-definitions/google-search" &&
+          data.component.definition_name !== "connector-definitions/redis" &&
+          data.component.definition_name !== "connector-definitions/website" ? (
             <DataConnectorFreeForm
               nodeID={id}
               component={data.component}


### PR DESCRIPTION
Because

- fix pipeline builder not correctly hide data connector's free form

This commit

- fix pipeline builder not correctly hide data connector's free form