### PR TITLE
fix(pipeline-builder): fix pipeline-builder not correctly handle smart hint information

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintInfoCard.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintInfoCard.tsx
@@ -5,6 +5,7 @@ import { Icons, Tag } from "@instill-ai/design-system";
 import { SmartHintWarning } from "../../type";
 
 export const SmartHintInfoCard = ({
+  fieldKey,
   title,
   instillAcceptFormats,
   className,
@@ -13,6 +14,7 @@ export const SmartHintInfoCard = ({
   supportTemplate,
   smartHintWarning,
 }: {
+  fieldKey: Nullable<string>;
   title: Nullable<string>;
   instillAcceptFormats: string[];
   supportReference: boolean;
@@ -65,7 +67,7 @@ export const SmartHintInfoCard = ({
                 to reference other value. For example:
               </p>
               <p className="rounded border border-semantic-bg-line bg-semantic-bg-base-bg px-2 py-1 text-semantic-fg-secondary product-body-text-3-regular">
-                {`{start.${title}}`}
+                {`{start.${fieldKey}}`}
               </p>
             </div>
           </div>
@@ -86,7 +88,7 @@ export const SmartHintInfoCard = ({
                 to compose your template. For example:
               </p>
               <p className="rounded border border-semantic-bg-line bg-semantic-bg-base-bg px-2 py-1 text-semantic-fg-secondary product-body-text-3-regular">
-                {`This is a template, {{start.${title}}}`}
+                {`This is a template, {{start.${fieldKey}}}`}
               </p>
             </div>
           </div>

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -22,6 +22,7 @@ import { useValidateReferenceAndTemplate } from "./useValidateReferenceAndTempla
 
 export const TextArea = ({
   form,
+  fieldKey,
   path,
   title,
   description,
@@ -34,6 +35,7 @@ export const TextArea = ({
   size,
   isHidden,
 }: {
+  fieldKey: Nullable<string>;
   instillAcceptFormats: string[];
   shortDescription?: string;
   disabled?: boolean;
@@ -209,6 +211,7 @@ export const TextArea = ({
                 {supportReference || supportTemplate ? (
                   <React.Fragment>
                     <SmartHintInfoCard
+                      fieldKey={fieldKey}
                       title={title}
                       instillAcceptFormats={instillAcceptFormats}
                       className="absolute left-0 top-0 w-[var(--radix-popover-trigger-width)] -translate-x-[calc(var(--radix-popover-trigger-width)+10px)] rounded border border-semantic-bg-line bg-semantic-bg-primary shadow-md"
@@ -236,6 +239,7 @@ export const TextArea = ({
                   </React.Fragment>
                 ) : (
                   <SmartHintInfoCard
+                    fieldKey={fieldKey}
                     title={title}
                     instillAcceptFormats={instillAcceptFormats}
                     error={error}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -21,6 +21,7 @@ import { AutoFormFieldBaseProps, SmartHintWarning } from "../../type";
 import { useValidateReferenceAndTemplate } from "./useValidateReferenceAndTemplate";
 
 export const TextField = ({
+  fieldKey,
   form,
   path,
   title,
@@ -34,6 +35,7 @@ export const TextField = ({
   size,
   isHidden,
 }: {
+  fieldKey: Nullable<string>;
   instillAcceptFormats: string[];
   shortDescription?: string;
   disabled?: boolean;
@@ -211,6 +213,7 @@ export const TextField = ({
                 {supportReference || supportTemplate ? (
                   <React.Fragment>
                     <SmartHintInfoCard
+                      fieldKey={fieldKey}
                       title={title}
                       instillAcceptFormats={instillAcceptFormats}
                       className="absolute left-0 top-0 w-[var(--radix-popover-trigger-width)] -translate-x-[calc(var(--radix-popover-trigger-width)+10px)] rounded border border-semantic-bg-line bg-semantic-bg-primary shadow-md"
@@ -238,6 +241,7 @@ export const TextField = ({
                   </React.Fragment>
                 ) : (
                   <SmartHintInfoCard
+                    fieldKey={fieldKey}
                     title={title}
                     instillAcceptFormats={instillAcceptFormats}
                     error={error}

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
@@ -78,7 +78,7 @@ export const FieldHead = ({
                           variant="lightBlue"
                           size="sm"
                           className="!rounded !px-2 !py-0.5"
-                        >{`{${path}}`}</Tag>{" "}
+                        >{`{}`}</Tag>{" "}
                         to reference this field&rsquo;s value.
                       </p>
                     </div>
@@ -94,11 +94,11 @@ export const FieldHead = ({
                           variant="lightBlue"
                           size="sm"
                           className="!rounded !px-2 !py-0.5"
-                        >{`{{${path}}}`}</Tag>{" "}
+                        >{`{{}}`}</Tag>{" "}
                         to build the template which use this value. For example
                       </p>
                       <p className="rounded border border-semantic-bg-line bg-semantic-bg-base-bg px-2 py-1 text-semantic-fg-secondary product-body-text-3-regular">
-                        {`This is a template use this value, {{start.${title}}}`}
+                        {`This is a template use this value, {{start.${path}}}`}
                       </p>
                     </div>
                   </div>

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -187,6 +187,7 @@ export function pickRegularFieldsFromInstillFormTree(
     if (enableSmartHint) {
       return (
         <SmartHintFields.TextArea
+          fieldKey={tree.fieldKey}
           key={tree.path}
           path={tree.path}
           form={form}
@@ -238,7 +239,7 @@ export function pickRegularFieldsFromInstillFormTree(
   if (enableSmartHint) {
     return (
       <SmartHintFields.TextField
-        key={tree.path}
+        fieldKey={tree.fieldKey}
         path={tree.path}
         form={form}
         title={title}


### PR DESCRIPTION
Because

- fix pipeline-builder not correctly handle smart hint information

This commit

- fix pipeline-builder not correctly handle smart hint information
