### PR TITLE
chore: replace advanced configurations with more in pipeline-builder's node

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/OpenAdvancedConfigurationButton.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/OpenAdvancedConfigurationButton.tsx
@@ -5,9 +5,9 @@ export const OpenAdvancedConfigurationButton = (
     <button
       {...props}
       type="button"
-      className="text-semantic-accent-default underline product-body-text-4-semibold"
+      className="text-semantic-accent-default !underline product-body-text-4-semibold hover:text-semantic-accent-hover"
     >
-      Advanced configuration
+      More
     </button>
   );
 };


### PR DESCRIPTION


Because

- replace advanced configurations with more in pipeline-builder's node

This commit

- replace advanced configurations with more in pipeline-builder's node
