### PR TITLE
fix: fix TASK_VISUAL_QUESTION_ANSWERING model task typo

### DIFF
--- a/packages/design-system/src/ui-helpers/getModelInstanceTaskToolkit.tsx
+++ b/packages/design-system/src/ui-helpers/getModelInstanceTaskToolkit.tsx
@@ -122,7 +122,7 @@ export const getModelInstanceTaskToolkit = (task: string) => {
         getIcon: (iconStyle: IconStyle) => {
           return <div className={cn(iconStyle.width, iconStyle.height)} />;
         },
-        label: "Visual Qestion Answering",
+        label: "Visual Question Answering",
       };
 
     case "TASK_TEXT_GENERATION_CHAT":


### PR DESCRIPTION
Because

- fix TASK_VISUAL_QUESTION_ANSWERING model task typo

This commit

- fix TASK_VISUAL_QUESTION_ANSWERING model task typo
