### PR TITLE
chore: replace pipeline readme with pipeline description on /pipelines/pid page

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
@@ -126,8 +126,8 @@ export const Readme = ({
     <div className="flex w-full flex-1 flex-col">
       <EditorContent
         className={cn(
-          "mb-2 h-full w-full bg-transparent",
-          hasUnsavedChanges ? "rounded-sm border-2 border-semantic-bg-line" : ""
+          "mb-2 h-full w-full border-2 border-transparent bg-transparent",
+          hasUnsavedChanges ? "rounded-sm border-semantic-bg-line" : ""
         )}
         editor={editor}
       />

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -57,7 +57,7 @@ export const ViewPipeline = ({
             className="h-[378px] w-full"
           />
           <div className="w-full bg-semantic-bg-base-bg px-3 py-2 text-semantic-fg-primary product-body-text-1-semibold">
-            Pipeline Readme
+            Pipeline Description
           </div>
           <Readme
             isOwner={isOwner}


### PR DESCRIPTION
Because

- replace pipeline readme with pipeline description on /pipelines/pid page

This commit

- replace pipeline readme with pipeline description on /pipelines/pid page
