### PR TITLE
ci(integration-test): remove outdated connector-backend test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [pipeline-backend, connector-backend, controller-vdp]
+        component: [pipeline-backend, controller-vdp]
     uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}


### PR DESCRIPTION
Because

- we've retired the connector-backend

This commit

- remove outdated connector-backend test
