### PR TITLE
fix: fix run button on /pipelines/pid page not correctly align

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -230,7 +230,7 @@ export const InOutPut = ({ visitorCta }: InOutPutProps) => {
             >
               Run
               {isTriggering ? (
-                <LoadingSpin className="!text-semantic-accent-default" />
+                <LoadingSpin className="!h-4 !w-4 !text-semantic-accent-default" />
               ) : (
                 <Icons.Play className="h-4 w-4 stroke-semantic-accent-default" />
               )}


### PR DESCRIPTION
Because

- fix run button on /pipelines/pid page not correctly align

This commit

- fix run button on /pipelines/pid page not correctly align