### PR TITLE
chore: unused import `PageBase`

### DIFF
--- a/apps/console/src/pages/404.tsx
+++ b/apps/console/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { NotFoundView, PageBase } from "@instill-ai/toolkit";
+import { NotFoundView } from "@instill-ai/toolkit";
 import { NextPageWithLayout } from "./_app";
 import { ConsoleCorePageHead } from "components";
 


### PR DESCRIPTION
Because

- `PageBase` is not used.

This commit

- Remove the usage of `PageBase` in `404.tsx`
