### PR TITLE
chore: remove unnecessary `error:any`, narrow to `unknown`

### DIFF
--- a/packages/toolkit/src/lib/toastInstillError.ts
+++ b/packages/toolkit/src/lib/toastInstillError.ts
@@ -9,9 +9,7 @@ export function toastInstillError({
 }: {
   title: string;
   toast: UseToastReturn["toast"];
-
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  error: any;
+  error: unknown;
 }) {
   if (isAxiosError(error)) {
     toast({


### PR DESCRIPTION
Because

- We have ts with strict mode on (`strict: true`), which enables [useUnknownInCatchVariables](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables).`useUnknownInCatchVariables` makes `error`'s default type = `unknown`. Therefore, we do not need to allow `toastInstillError` accept `any` so it will be (mis)-used in somewhere else then the `catch` block.

This commit

- Change `error:any` to `error:unkown`, narrow the type to prevent misuse. Also remove `/* eslint-disable-next-line @typescript-eslint/no-explicit-any */`
