### PR TITLE
chore: refactor top bar navigation to make it dry, add default query options for react-query

### DIFF
--- a/apps/console/src/components/top-bar/Topbar.tsx
+++ b/apps/console/src/components/top-bar/Topbar.tsx
@@ -11,6 +11,7 @@ import {
 import { TopbarLink } from "./TopbarLink";
 import { EntityAvatar, useUserMe } from "@instill-ai/toolkit";
 import { useAccessToken } from "lib/useAccessToken";
+import { tobBarData } from "./topBarData";
 
 export type TopbarProps = {
   logo: ReactElement;
@@ -46,43 +47,18 @@ export const Topbar = ({ logo, children, className }: TopbarProps) => {
           <React.Fragment>
             {me.isSuccess ? (
               <React.Fragment>
-                <TopbarLink
-                  href={`/${me.data.id}/pipelines`}
-                  icon={
-                    <Icons.Pipeline className="h-6 w-6 stroke-semantic-fg-primary" />
-                  }
-                  name="Pipelines"
-                  hightlighted={router.pathname.split("/")[2] === "pipelines"}
-                  className="mx-1 my-2 px-4"
-                />
-                <TopbarLink
-                  href={`/${me.data.id}/connectors`}
-                  icon={
-                    <Icons.IntersectSquare className="h-6 w-6 stroke-semantic-fg-primary" />
-                  }
-                  name="Connectors"
-                  hightlighted={router.pathname.split("/")[2] === "connectors"}
-                  className="mx-1 my-2 px-4"
-                />
-                <TopbarLink
-                  href={`/${me.data.id}/models`}
-                  icon={
-                    <Icons.Cube01 className="h-6 w-6 stroke-semantic-fg-primary" />
-                  }
-                  name="Model Hub"
-                  hightlighted={router.pathname.split("/")[2] === "model"}
-                  className="mx-1 my-2 px-4"
-                />
-
-                <TopbarLink
-                  href={`/${me.data.id}/dashboard`}
-                  icon={
-                    <Icons.BarChartSquare02 className="h-6 w-6 stroke-semantic-fg-primary" />
-                  }
-                  name="Dashboard"
-                  hightlighted={router.pathname.split("/")[2] === "dashboard"}
-                  className="mx-1 my-2 px-4"
-                />
+                {tobBarData.map(({ pathName, name, Icon }) => (
+                  <TopbarLink
+                    key={pathName}
+                    href={`/${me.data.id}/${pathName}`}
+                    icon={
+                      <Icon className="h-6 w-6 stroke-semantic-fg-primary" />
+                    }
+                    name={name}
+                    hightlighted={router.pathname.split("/")[2] === pathName}
+                    className="mx-1 my-2 px-4"
+                  />
+                ))}
               </React.Fragment>
             ) : (
               <div className="flex h-[217px] w-full items-center justify-center">

--- a/apps/console/src/components/top-bar/topBarData.tsx
+++ b/apps/console/src/components/top-bar/topBarData.tsx
@@ -9,7 +9,7 @@ export const tobBarData = [
     {
         pathName: 'connectors',
         Icon: Icons.IntersectSquare,
-        name: 'IntersectSquare'
+        name: 'Connectors'
     },
     {
         pathName: 'models',

--- a/apps/console/src/components/top-bar/topBarData.tsx
+++ b/apps/console/src/components/top-bar/topBarData.tsx
@@ -1,0 +1,24 @@
+import { Icons } from "@instill-ai/design-system";
+
+export const tobBarData = [
+    {
+        pathName: 'pipelines',
+        Icon: Icons.Pipeline,
+        name: 'Pipelines'
+    },
+    {
+        pathName: 'connectors',
+        Icon: Icons.IntersectSquare,
+        name: 'IntersectSquare'
+    },
+    {
+        pathName: 'models',
+        Icon: Icons.Cube01,
+        name: 'Model Hub'
+    },
+    {
+        pathName: 'dashboard',
+        Icon: Icons.BarChartSquare02,
+        name: 'Dashboard'
+    },
+]

--- a/apps/console/src/pages/_app.tsx
+++ b/apps/console/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import {
   ReactQueryDevtools,
   useInstillStore,
   useCreateResourceFormStore,
+  DefaultOptions
 } from "@instill-ai/toolkit";
 import "../styles/global.css";
 import "../styles/github-markdown.css";
@@ -27,8 +28,14 @@ import { ErrorBoundary } from "../components";
 import { Toaster, useToast } from "@instill-ai/design-system";
 
 export const queryCache = new QueryCache();
+export const defaultOptions: DefaultOptions = {
+  queries: {
+    retry: 2,
+    refetchOnWindowFocus: false,
+  },
+}
 
-export const queryClient = new QueryClient({ queryCache });
+export const queryClient = new QueryClient({ defaultOptions, queryCache });
 
 /* eslint-disable-next-line @typescript-eslint/ban-types */
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
@@ -108,10 +115,10 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
 
   return (
     <React.Fragment>
-      {/* 
-        We use this instead of setting the className on main due to we 
-        are using radix-ui Dialog. These Dialogs are created on demand 
-        and appended under body, they won't have the css variables if 
+      {/*
+        We use this instead of setting the className on main due to we
+        are using radix-ui Dialog. These Dialogs are created on demand
+        and appended under body, they won't have the css variables if
         we appends it on main
       */}
       <style jsx global>

--- a/apps/console/src/pages/_app.tsx
+++ b/apps/console/src/pages/_app.tsx
@@ -30,7 +30,6 @@ import { Toaster, useToast } from "@instill-ai/design-system";
 export const queryCache = new QueryCache();
 export const defaultOptions: DefaultOptions = {
   queries: {
-    retry: 2,
     refetchOnWindowFocus: false,
   },
 }

--- a/apps/console/src/pages/index.tsx
+++ b/apps/console/src/pages/index.tsx
@@ -32,14 +32,13 @@ const MainPage: NextPageWithLayout<MainPageProps> = ({ cookies }) => {
   useEffect(() => {
     if (!router.isReady || !cookies) return;
 
-    const cookieList = parse(cookies);
-
     if (user.isError) {
       router.push("/login");
       return;
     }
 
     if (user.isSuccess) {
+      const cookieList = parse(cookies);
       if (cookieList["instill-ai-user"]) {
         router.push(`/${user.data.id}/pipelines`);
       } else {

--- a/packages/toolkit/src/lib/amplitude/AmplitudeContext.ts
+++ b/packages/toolkit/src/lib/amplitude/AmplitudeContext.ts
@@ -13,4 +13,6 @@ const defaultAmplitudeCtxValue: AmplitudeCtxValue = {
 
 export const AmplitudeCtx = React.createContext(defaultAmplitudeCtxValue);
 
+AmplitudeCtx.displayName = 'AmplitudeContext'
+
 export const useAmplitudeCtx = () => React.useContext(AmplitudeCtx);

--- a/packages/toolkit/src/lib/react-query-service/index.ts
+++ b/packages/toolkit/src/lib/react-query-service/index.ts
@@ -22,4 +22,5 @@ export type {
   DehydratedState,
   UseQueryResult,
   UseMutationResult,
+  DefaultOptions,
 } from "@tanstack/react-query";


### PR DESCRIPTION
This commit

- Adds default options in `tanstack/react-query` config to prevent re-fetch on window focus. (I don't know if this is the required behavior for this app, but it's a good practice to have defaults and override it when required)

- Refactors Top Bar menu to use loop for menu items/links
