### PR TITLE
fix: fix wrongly display organization link when user doesnt belong to any org

### DIFF
--- a/packages/toolkit/src/components/UserProfileCard.tsx
+++ b/packages/toolkit/src/components/UserProfileCard.tsx
@@ -76,7 +76,7 @@ export const UserProfileCard = ({
             </p>
           </div>
           <Separator orientation="horizontal" className="my-4" />
-          {organizations ? (
+          {organizations && organizations.length !== 0 ? (
             <React.Fragment>
               <div className="flex flex-col gap-y-2">
                 <p className="text-semantic-fg-primary product-body-text-2-semibold">


### PR DESCRIPTION
Because

-  fix wrongly display organization link when user doesnt belong to any org

This commit

-  fix wrongly display organization link when user doesnt belong to any org
