### PR TITLE
fix(pipeline-builder): disabled delete nodes and edges by clicking backspace

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/Flow.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/Flow.tsx
@@ -118,6 +118,8 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
                   return true;
                 });
               }}
+              // Disabled delete nodes and edges by backespace
+              deleteKeyCode={null}
               onEdgesDelete={() => {
                 if (pipelineIsReadOnly) return;
 


### PR DESCRIPTION
Because

- disabled delete nodes and edges by clicking backspace

This commit

- disabled delete nodes and edges by clicking backspace
