### PR TITLE
feat(pipeline-builder): make right-panel float on top of canvas to have bigger working space

### DIFF
--- a/apps/console/src/styles/global.css
+++ b/apps/console/src/styles/global.css
@@ -37,4 +37,7 @@
   --pipeline-builder-node-available-width: 332px;
   --pipeline-builder-node-padding-x: 12px;
   --pipeline-builder-node-padding-y: 10px;
+  --pipeline-builder-controller-padding: 32px;
+  --pipeline-builder-top-right-controler-height: 40px;
+  --pipeline-builder-minimap-height: 150px;
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.76.1",
+  "version": "0.77.0-rc.1",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/Flow.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/Flow.tsx
@@ -47,7 +47,6 @@ const selector = (store: InstillStore) => ({
   onEdgesChange: store.onEdgesChange,
   onConnect: store.onConnect,
   updatePipelineRecipeIsDirty: store.updatePipelineRecipeIsDirty,
-  testModeEnabled: store.testModeEnabled,
   updateSelectedConnectorNodeId: store.updateSelectedConnectorNodeId,
   updateCurrentAdvancedConfigurationNodeID:
     store.updateCurrentAdvancedConfigurationNodeID,
@@ -84,7 +83,6 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
       onNodesChange,
       onEdgesChange,
       updatePipelineRecipeIsDirty,
-      testModeEnabled,
       updateSelectedConnectorNodeId,
       updateCurrentAdvancedConfigurationNodeID,
       pipelineIsReadOnly,
@@ -98,15 +96,7 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
           accessToken={accessToken}
         />
         <div className="relative flex h-full w-full flex-1">
-          <div
-            ref={ref}
-            className={cn(
-              "h-full w-full flex-1 border-[10px]",
-              testModeEnabled
-                ? "border-semantic-warning-bg"
-                : "border-transparent"
-            )}
-          >
+          <div ref={ref} className="h-full w-full flex-1">
             <ReactFlow
               key={pipelineName}
               nodes={nodes}
@@ -202,7 +192,10 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
                 className="!bg-semantic-bg-alt-primary"
                 size={3}
               />
-              <MiniMap id={pipelineName ?? undefined} />
+              <MiniMap
+                className="h-[var(--pipeline-builder-minimap-height)]"
+                id={pipelineName ?? undefined}
+              />
             </ReactFlow>
           </div>
           {isLoading ? (

--- a/packages/toolkit/src/view/pipeline/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelineBuilderMainView.tsx
@@ -137,8 +137,10 @@ export const PipelineBuilderMainView = (
         />
         <div
           className={cn(
-            "flex w-[456px] transform flex-col overflow-y-scroll bg-semantic-bg-primary p-6 duration-500",
-            currentAdvancedConfigurationNodeID ? "mr-0" : "-mr-[456px]"
+            "fixed left-full w-[450px] transform overflow-y-scroll rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-6 shadow-sm duration-500",
+            "h-[calc(100vh-var(--topbar-height)-var(--pipeline-builder-bottom-bar-height)-var(--pipeline-builder-minimap-height)-var(--pipeline-builder-top-right-controler-height)-calc(4*var(--pipeline-builder-controller-padding)))]",
+            "top-[calc(var(--topbar-height)+var(--pipeline-builder-top-right-controler-height)+calc(2*var(--pipeline-builder-controller-padding)))]",
+            currentAdvancedConfigurationNodeID ? "-translate-x-[450px]" : ""
           )}
         >
           <RightPanel />


### PR DESCRIPTION
Because

- make right-panel float on top of canvas to have bigger working space

This commit

- make right-panel float on top of canvas to have bigger working space
