### PR TITLE
Fix syntax highlighting in `instill-auto-form.md`

### DIFF
--- a/docs/instill-auto-form.md
+++ b/docs/instill-auto-form.md
@@ -21,7 +21,7 @@ The solution is to avoid using a literal type and instead use a string type. Thi
 
 ## The object value filter on TextField
 
-```TypeScript
+```tsx
 <Input.Root>
   <Input.Core
     {...field}


### PR DESCRIPTION
Because

- The code block is in tsx but labeled as `ts`.

This commit

- `TypeScript` > `tsx`
