### PR TITLE
fix: `async` function(s) should be awaited

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
@@ -130,7 +130,7 @@ export const FlowControl = (props: FlowControlProps) => {
       };
 
       try {
-        updateUserPipeline.mutateAsync({
+        await updateUserPipeline.mutateAsync({
           payload,
           accessToken,
         });

--- a/packages/toolkit/src/view/pipeline/view-pipeline/EditMetadataDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/EditMetadataDialog.tsx
@@ -56,7 +56,7 @@ export const EditMetadataDialog = ({
     };
 
     try {
-      updateUserPipeline.mutateAsync({ payload, accessToken });
+      await updateUserPipeline.mutateAsync({ payload, accessToken });
       setOpen(false);
       toast({
         size: "small",

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
@@ -52,7 +52,7 @@ export const Readme = ({
 
       setHasUnsavedChanges(true);
 
-      timer.current = window.setTimeout(() => {
+      timer.current = window.setTimeout(async () => {
         try {
           const md = serialize(editor.schema, editor.getJSON());
 
@@ -61,7 +61,7 @@ export const Readme = ({
             readme: md,
           };
 
-          updateUserPipeline.mutateAsync({ payload, accessToken });
+          await updateUserPipeline.mutateAsync({ payload, accessToken });
 
           toast({
             size: "small",


### PR DESCRIPTION
Because

- There are places where `Promise`(s) are not awaited. Probably not intended?

This commit

- Add missing `await`, so the message shown in the toasts is reflecting the correct state of the system.

You might want to add <https://typescript-eslint.io/rules/no-floating-promises/> to avoid this error in the future.