### PR TITLE
fix: fix output fields not correctly style on /pipelines/pid page

### DIFF
--- a/packages/toolkit/src/constant/errors.ts
+++ b/packages/toolkit/src/constant/errors.ts
@@ -1,6 +1,10 @@
 const IDInvalidError =
   "The ID should be lowercase without any space or special character besides the underscore or hyphen, it can not start with number or hyphen, and should be less than 32 characters.";
 
+const KeyInvalidError =
+  "The key should be lowercase without any space or special character besides the underscore or hyphen, it can not start with number or hyphen, and should be less than 32 characters.";
+
 export const InstillErrors = {
   IDInvalidError,
+  KeyInvalidError,
 };

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/AudiosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/AudiosField.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import cn from "clsx";
 import { Form, ScrollArea } from "@instill-ai/design-system";
 import { AutoFormFieldBaseProps } from "../../..";
 import { readFileToBinary } from "../../../../view";
@@ -6,6 +7,7 @@ import { FieldHead } from "./FieldHead";
 import { UploadFileInput } from "./UploadFileInput";
 import { AudioListItem } from "./AudioListItem";
 import { StartOperatorFreeFormFieldBaseProps } from "../../type";
+import { cmp } from "semver";
 
 export const AudiosField = ({
   mode,
@@ -84,7 +86,14 @@ export const AudiosField = ({
               ) : null}
             </div>
             {audioFiles.length > 0 ? (
-              <ScrollArea.Root className="nowheel h-[216px] rounded bg-semantic-bg-secondary p-2">
+              <ScrollArea.Root
+                className={cn(
+                  "nowheel h-[216px] rounded-sm p-2",
+                  mode === "build"
+                    ? "bg-semantic-bg-secondary"
+                    : "border border-semantic-bg-line"
+                )}
+              >
                 <div className="flex h-full flex-col gap-y-2">
                   {audioFiles.map((e, i) => (
                     <AudioListItem

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FilesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FilesField.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import cn from "clsx";
 import { Form, ScrollArea } from "@instill-ai/design-system";
 import { AutoFormFieldBaseProps } from "../../..";
 import { readFileToBinary } from "../../../../view";
@@ -83,7 +84,14 @@ export const FilesField = ({
               ) : null}
             </div>
             {uploadedFiles.length > 0 ? (
-              <ScrollArea.Root className="nowheel h-[216px] rounded bg-semantic-bg-secondary p-2">
+              <ScrollArea.Root
+                className={cn(
+                  "nowheel h-[216px] rounded-sm p-2",
+                  mode === "build"
+                    ? "bg-semantic-bg-secondary"
+                    : "border border-semantic-bg-line"
+                )}
+              >
                 <div className="flex h-full flex-col gap-y-2">
                   {uploadedFiles.map((e, i) => (
                     <FileListItem

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ImageField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ImageField.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import cn from "clsx";
 import { Form } from "@instill-ai/design-system";
 import { AutoFormFieldBaseProps, Nullable } from "../../..";
 import { readFileToBinary } from "../../../../view";
@@ -47,13 +48,21 @@ export const ImageField = ({
                   key={`${path}-${imageFile.name}`}
                   src={URL.createObjectURL(imageFile)}
                   alt={`${path}-${imageFile.name}`}
-                  className="h-[150px] w-full object-cover"
+                  className={cn(
+                    "w-full object-contain",
+                    mode === "build" ? "h-[150px]" : "h-[360px]"
+                  )}
                 />
               ) : (
                 <div
                   key={`${path}-image-placeholder`}
-                  className="h-[150px] w-full bg-semantic-bg-secondary"
-                />
+                  className={cn(
+                    "flex w-full items-center justify-center",
+                    mode === "build"
+                      ? "h-[150px] bg-semantic-bg-secondary"
+                      : "h-[260px] rounded-sm border border-semantic-bg-line bg-transparent"
+                  )}
+                ></div>
               )}
             </div>
             <div className="flex">

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ImagesField.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import cn from "clsx";
 import { Form, ScrollArea } from "@instill-ai/design-system";
 import { AutoFormFieldBaseProps, fillArrayWithZeros } from "../../..";
 import { readFileToBinary } from "../../../../view";
@@ -41,7 +42,14 @@ export const ImagesField = ({
               disabledFieldControl={disabledFieldControl}
             />
 
-            <div className="grid w-full grid-flow-row grid-cols-4">
+            <div
+              className={cn(
+                "grid w-full grid-flow-row grid-cols-4",
+                mode === "build"
+                  ? ""
+                  : "rounded-sm border border-semantic-bg-line"
+              )}
+            >
               {imageFiles.length > 0
                 ? fillArrayWithZeros(imageFiles, 8)
                     .slice(0, 8)
@@ -51,19 +59,33 @@ export const ImagesField = ({
                           key={`${path}-${file.name}`}
                           src={URL.createObjectURL(file)}
                           alt={`${path}-${file.name}`}
-                          className="h-[55px] object-cover"
+                          className={cn(
+                            mode === "build"
+                              ? "h-[55px] object-cover"
+                              : "h-[140px] object-contain"
+                          )}
                         />
                       ) : (
                         <div
                           key={`${path}-${i}`}
-                          className="h-[55px] w-full bg-semantic-bg-secondary"
+                          className={cn(
+                            "w-full bg-semantic-bg-secondary",
+                            mode === "build"
+                              ? "h-[55px] object-cover"
+                              : "h-[140px] object-contain"
+                          )}
                         />
                       );
                     })
                 : Array.from({ length: 8 }).map((_, i) => (
                     <div
                       key={`${path}-${i}`}
-                      className="h-[55px] w-full bg-semantic-bg-secondary"
+                      className={cn(
+                        "w-full",
+                        mode === "build"
+                          ? "h-[55px] bg-semantic-bg-secondary object-cover"
+                          : "h-[140px] object-contain"
+                      )}
                     />
                   ))}
             </div>
@@ -108,7 +130,14 @@ export const ImagesField = ({
               ) : null}
             </div>
             {imageFiles.length > 0 ? (
-              <ScrollArea.Root className="nowheel h-[216px] rounded bg-semantic-bg-secondary p-2">
+              <ScrollArea.Root
+                className={cn(
+                  "nowheel h-[216px] rounded-sm p-2",
+                  mode === "build"
+                    ? "bg-semantic-bg-secondary"
+                    : "border border-semantic-bg-line"
+                )}
+              >
                 <div className="flex h-full flex-col gap-y-2">
                   {imageFiles.map((e, i) => (
                     <FileListItem

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
@@ -64,7 +64,7 @@ const CreateEndOperatorInputSchema: InstillJSONSchema = {
           type: "string",
           instillUpstreamType: "value",
           pattern: "^[a-z_][-a-z_0-9]{0,31}$",
-          instillPatternErrorMessage: InstillErrors.IDInvalidError,
+          instillPatternErrorMessage: InstillErrors.KeyInvalidError,
         },
       ],
       instillUpstreamTypes: ["value"],


### PR DESCRIPTION
Because

- We need to have different component output field style between demo pages like /pipeline/pid and the builder page

This commit

- fix output fields not correctly style on /pipelines/pid page