### PR TITLE
feat: support blocking user from cloning others connectors

### DIFF
--- a/packages/toolkit/src/components/ClonePipelineDialog.tsx
+++ b/packages/toolkit/src/components/ClonePipelineDialog.tsx
@@ -115,7 +115,10 @@ export const ClonePipelineDialog = ({
 
     const payload: CreateUserPipelinePayload = {
       id: data.id,
-      recipe: getRawPipelineRecipeFromPipelineRecipe(pipeline.recipe),
+      recipe: getRawPipelineRecipeFromPipelineRecipe(
+        pipeline.recipe,
+        pipeline.owner_name === me.data.name ? false : true
+      ),
       metadata: pipeline.metadata,
       sharing,
     };

--- a/packages/toolkit/src/view/pipeline-builder/lib/getRawPipelineRecipeFromPipelineRecipe.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getRawPipelineRecipeFromPipelineRecipe.ts
@@ -1,13 +1,14 @@
 import { PipelineRecipe, RawPipelineRecipe } from "../../../lib";
 
 export function getRawPipelineRecipeFromPipelineRecipe(
-  recipe: PipelineRecipe
+  recipe: PipelineRecipe,
+  removeResourceName = false
 ): RawPipelineRecipe {
   const raw: RawPipelineRecipe = {
     ...recipe,
     components: recipe.components.map((component) => ({
       ...component,
-      resource_name: component.resource_name ?? "",
+      resource_name: removeResourceName ? "" : component.resource_name ?? "",
       connector_definition: undefined,
       resource: undefined,
       operator_definition: undefined,


### PR DESCRIPTION
Because

- We don't want users to be able to clone others connectors

This commit

- support blocking user from cloning others connectors
