### PR TITLE
fix: fix user profile wrongly use org_name as user_name

### DIFF
--- a/packages/toolkit/src/view/profile/user-profile/UserProfile.tsx
+++ b/packages/toolkit/src/view/profile/user-profile/UserProfile.tsx
@@ -58,7 +58,7 @@ export const UserProfile = () => {
         {user.isSuccess ? (
           <UserProfileBio
             id={user.data.id}
-            name={user.data.org_name}
+            name={`${user.data.first_name} ${user.data.last_name}`}
             bio={user.data.profile_data?.bio}
             avatar={user.data.profile_avatar ?? null}
             userMemberships={null}


### PR DESCRIPTION
Because

- fix user profile wrongly use org_name as user_name

This commit

- fix user profile wrongly use org_name as user_name
