### PR TITLE
fix(pipeline-builder): fix pipeline builder not correctly handle deep nested object referenced link

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromReferences.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromReferences.tsx
@@ -291,7 +291,9 @@ function checkReferenceIsAvailable(
   const firstThreeLayersOfReferenceValueWithoutArray =
     referenceValueWithoutArray.split(".").slice(0, 3).join(".");
 
-  if (availableReference === firstThreeLayersOfReferenceValueWithoutArray) {
+  if (
+    firstThreeLayersOfReferenceValueWithoutArray.includes(availableReference)
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Because

- fix pipeline builder not correctly handle deep nested object referenced link

This commit

- fix pipeline builder not correctly handle deep nested object referenced link
