### PR TITLE
chore: remove the expire data in the API token table

### DIFF
--- a/packages/toolkit/src/view/settings/api-tokens/APITokenTable.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/APITokenTable.tsx
@@ -79,34 +79,6 @@ export const APITokenTable = (props: APITokenTableProps) => {
       },
     },
     {
-      accessorKey: "expire_time",
-      header: ({ column }) => {
-        return (
-          <div className="text-center">
-            <Button
-              className="gap-x-2 py-0"
-              variant="tertiaryGrey"
-              size="sm"
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            >
-              <span className="min-w-[130px]">Expire Time</span>
-              <SortIcon type={column.getIsSorted()} />
-            </Button>
-          </div>
-        );
-      },
-
-      cell: ({ row }) => {
-        return (
-          <div className="truncate text-center text-semantic-fg-secondary product-body-text-3-regular">
-            {formatDate(row.getValue("expire_time"))}
-          </div>
-        );
-      },
-    },
-    {
       accessorKey: "uid",
       header: () => <div className="max-w-[100px] text-center"></div>,
       cell: ({ row }) => {


### PR DESCRIPTION
Because

- remove the expire data in the API token table

This commit

- remove the expire data in the API token table
