### PR TITLE
fix: fix the wrong state in ResourceTable cause the wrong behavior of delete resource dialog

### DIFF
--- a/packages/toolkit/src/components/GeneralDeleteResourceDialog.tsx
+++ b/packages/toolkit/src/components/GeneralDeleteResourceDialog.tsx
@@ -1,35 +1,39 @@
 import * as React from "react";
 import { Button, Dialog, Icons, Input } from "@instill-ai/design-system";
-import { Nullable } from "../lib";
+import { Nullable, useControllableState } from "../lib";
 import { LoadingSpin } from "./LoadingSpin";
 
-export type GenerateDeleteResourceDialogProps = {
+export type GeneralDeleteResourceDialogProps = {
   resourceID: string;
   title: string;
   description: string;
   handleDeleteResource: () => Promise<void>;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   trigger?: React.ReactNode;
 };
 
 // You can use the children props to override the default buttons
 
-export const GenerateDeleteResourceDialog = ({
+export const GeneralDeleteResourceDialog = ({
   resourceID,
   title,
   description,
   handleDeleteResource,
-  open,
+  open: openProp,
   onOpenChange,
   trigger,
-}: GenerateDeleteResourceDialogProps) => {
+}: GeneralDeleteResourceDialogProps) => {
+  const [open = false, setOpen] = useControllableState({
+    prop: openProp,
+    onChange: onOpenChange,
+  });
   const [confirmationCode, setConfirmationCode] =
     React.useState<Nullable<string>>(null);
   const [isDeleting, setIsDeleting] = React.useState(false);
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Trigger asChild>
         {trigger || trigger === null ? (
           trigger
@@ -72,16 +76,11 @@ export const GenerateDeleteResourceDialog = ({
           </Input.Root>
         </div>
         <div className="flex flex-row gap-x-2">
-          <Button
-            variant="secondaryGrey"
-            size="lg"
-            className="!flex-1"
-            onClick={() => {
-              onOpenChange(false);
-            }}
-          >
-            Cancel
-          </Button>
+          {/* <Dialog.Close asChild>
+            <Button variant="secondaryGrey" size="lg" className="!flex-1">
+              Cancel
+            </Button>
+          </Dialog.Close> */}
 
           <Button
             variant="danger"
@@ -90,6 +89,7 @@ export const GenerateDeleteResourceDialog = ({
               try {
                 setIsDeleting(true);
                 await handleDeleteResource();
+                setOpen(false);
                 setIsDeleting(false);
               } catch (error) {
                 console.error(error);

--- a/packages/toolkit/src/components/card-pipeline/Menu.tsx
+++ b/packages/toolkit/src/components/card-pipeline/Menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Button, DropdownMenu, Icons } from "@instill-ai/design-system";
 import { Pipeline } from "../../lib";
-import { ClonePipelineDialog, GenerateDeleteResourceDialog } from "..";
+import { ClonePipelineDialog, GeneralDeleteResourceDialog } from "..";
 
 export type MenuProps = {
   pipeline: Pipeline;
@@ -53,7 +53,7 @@ export const Menu = ({ pipeline, handleDeletePipeline }: MenuProps) => {
         onOpenChange={(open) => setDuplicateDialogIsOpen(open)}
         trigger={null}
       />
-      <GenerateDeleteResourceDialog
+      <GeneralDeleteResourceDialog
         open={deleteDialogIsOpen}
         onOpenChange={(open) => setDeleteDialogIsOpen(open)}
         resourceID={pipeline.id}

--- a/packages/toolkit/src/components/index.ts
+++ b/packages/toolkit/src/components/index.ts
@@ -10,7 +10,7 @@ export * from "./TablePlaceholderBase";
 export * from "./ImageWithFallback";
 export * from "./EntityAvatar";
 export * from "./DeleteResourceModal";
-export * from "./GenerateDeleteResourceDialog";
+export * from "./GeneralDeleteResourceDialog";
 export * from "./StateIcon";
 export * from "./StateLabel";
 export * from "./SortIcon";

--- a/packages/toolkit/src/lib/index.ts
+++ b/packages/toolkit/src/lib/index.ts
@@ -9,6 +9,8 @@ export * from "./store";
 export * from "./table";
 export * from "./tip-tap";
 export * from "./type";
+export * from "./use-callback-ref";
+export * from "./use-controllable-state";
 export * from "./use-instill-form";
 export * from "./use-instill-store";
 export * from "./use-smart-hint";

--- a/packages/toolkit/src/lib/use-callback-ref/index.ts
+++ b/packages/toolkit/src/lib/use-callback-ref/index.ts
@@ -1,0 +1,1 @@
+export * from "./useCallbackRef";

--- a/packages/toolkit/src/lib/use-callback-ref/useCallbackRef.tsx
+++ b/packages/toolkit/src/lib/use-callback-ref/useCallbackRef.tsx
@@ -1,0 +1,26 @@
+/**
+ * A custom hook that converts a callback to a ref to avoid triggering re-renders when passed as a
+ * prop or avoid re-executing effects when passed as a dependency
+ * ref: https://github.com/radix-ui/primitives/blob/main/packages/react/use-callback-ref/src/useCallbackRef.tsx
+ * credit: radix-ui/primitives
+ */
+
+import * as React from "react";
+
+function useCallbackRef<T extends (...args: any[]) => any>(
+  callback: T | undefined
+): T {
+  const callbackRef = React.useRef(callback);
+
+  React.useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // https://github.com/facebook/react/issues/19240
+  return React.useMemo(
+    () => ((...args) => callbackRef.current?.(...args)) as T,
+    []
+  );
+}
+
+export { useCallbackRef };

--- a/packages/toolkit/src/lib/use-controllable-state/index.ts
+++ b/packages/toolkit/src/lib/use-controllable-state/index.ts
@@ -1,0 +1,1 @@
+export * from "./useControllableState";

--- a/packages/toolkit/src/lib/use-controllable-state/useControllableState.tsx
+++ b/packages/toolkit/src/lib/use-controllable-state/useControllableState.tsx
@@ -1,0 +1,69 @@
+/**
+ * This is a helper hook for creating a controlled or uncontrolled state.
+ * ref: https://github.com/radix-ui/primitives/blob/main/packages/react/use-controllable-state/src/useControllableState.tsx
+ * credit: radix-ui/primitives
+ */
+
+import * as React from "react";
+import { useCallbackRef } from "../use-callback-ref";
+
+type UseControllableStateParams<T> = {
+  prop?: T | undefined;
+  defaultProp?: T | undefined;
+  onChange?: (state: T) => void;
+};
+
+type SetStateFn<T> = (prevState?: T) => T;
+
+function useControllableState<T>({
+  prop,
+  defaultProp,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onChange = () => {},
+}: UseControllableStateParams<T>) {
+  const [uncontrolledProp, setUncontrolledProp] = useUncontrolledState({
+    defaultProp,
+    onChange,
+  });
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolledProp;
+  const handleChange = useCallbackRef(onChange);
+
+  const setValue: React.Dispatch<React.SetStateAction<T | undefined>> =
+    React.useCallback(
+      (nextValue) => {
+        if (isControlled) {
+          const setter = nextValue as SetStateFn<T>;
+          const value =
+            typeof nextValue === "function" ? setter(prop) : nextValue;
+          if (value !== prop) handleChange(value as T);
+        } else {
+          setUncontrolledProp(nextValue);
+        }
+      },
+      [isControlled, prop, setUncontrolledProp, handleChange]
+    );
+
+  return [value, setValue] as const;
+}
+
+function useUncontrolledState<T>({
+  defaultProp,
+  onChange,
+}: Omit<UseControllableStateParams<T>, "prop">) {
+  const uncontrolledState = React.useState<T | undefined>(defaultProp);
+  const [value] = uncontrolledState;
+  const prevValueRef = React.useRef(value);
+  const handleChange = useCallbackRef(onChange);
+
+  React.useEffect(() => {
+    if (prevValueRef.current !== value) {
+      handleChange(value as T);
+      prevValueRef.current = value;
+    }
+  }, [value, prevValueRef, handleChange]);
+
+  return uncontrolledState;
+}
+
+export { useControllableState };

--- a/packages/toolkit/src/view/resource/ResourcesTable.tsx
+++ b/packages/toolkit/src/view/resource/ResourcesTable.tsx
@@ -10,7 +10,7 @@ import {
   useInstillStore,
 } from "../../lib";
 import {
-  GenerateDeleteResourceDialog,
+  GeneralDeleteResourceDialog,
   ImageWithFallback,
   SortIcon,
   TableCell,
@@ -25,8 +25,6 @@ export type ResourcesTableProps = {
 
 export const ResourcesTable = (props: ResourcesTableProps) => {
   const { connectors, isError, isLoading } = props;
-  const [deleteConnectorDialogOpen, setDeleteConnectorDialogOpen] =
-    React.useState(false);
   const { toast } = useToast();
   const accessToken = useInstillStore((store) => store.accessToken);
 
@@ -38,8 +36,6 @@ export const ResourcesTable = (props: ResourcesTableProps) => {
         connectorName: connector.name,
         accessToken,
       });
-
-      setDeleteConnectorDialogOpen(false);
 
       toast({
         title: "Successfully delete connector",
@@ -120,9 +116,7 @@ export const ResourcesTable = (props: ResourcesTableProps) => {
       cell: ({ row }) => {
         return accessToken ? (
           <div className="flex justify-center">
-            <GenerateDeleteResourceDialog
-              open={deleteConnectorDialogOpen}
-              onOpenChange={(open) => setDeleteConnectorDialogOpen(open)}
+            <GeneralDeleteResourceDialog
               resourceID={row.original.id}
               title={`Delete ${row.original.id}`}
               description="This action cannot be undone. This will permanently delete the connector."


### PR DESCRIPTION
Because

- We wrongly use the [isOpen, setIsOpen] state outside of the component working area and cause all the delete dialog in the resource table to share a single isOpen state instance. So every time users click delete on a specific resource, they are opening the dialog that belong to the last item on the table

This commit

- fix the wrong state in ResourceTable causes the wrong behavior of the delete resource dialog
