### PR TITLE
fix: fix markdown editor of pipeline description can not show ol and ul

### DIFF
--- a/apps/console/src/styles/github-markdown.css
+++ b/apps/console/src/styles/github-markdown.css
@@ -312,6 +312,7 @@
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;
+  
 }
 
 .markdown-body ol ol,
@@ -323,7 +324,7 @@
 .markdown-body ul ol ol,
 .markdown-body ol ul ol,
 .markdown-body ol ol ol {
-  list-style-type: lower-alpha;
+  list-style-type: lower-roman;
 }
 
 .markdown-body dd {
@@ -611,6 +612,14 @@
 .markdown-body h6 code {
   padding: 0 .2em;
   font-size: inherit;
+}
+
+.markdown-body ul {
+  list-style-type: disc;
+}
+
+.markdown-body ol {
+  list-style-type: decimal;
 }
 
 .markdown-body ul.no-list,

--- a/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveRemoveUndefinedAndNullFromArray.test.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveRemoveUndefinedAndNullFromArray.test.ts
@@ -19,7 +19,6 @@ test("should remove undefined and null from array", () => {
   const result = recursiveRemoveUndefinedAndNullFromArray(array);
 
   expect(result).toEqual([1, 2, 3, 4, 5]);
-  expect(result !== array).toBe(true);
 });
 
 test("should remove undefined and null from array inside a object", () => {
@@ -30,5 +29,4 @@ test("should remove undefined and null from array inside a object", () => {
   const result = recursiveRemoveUndefinedAndNullFromArray(object);
 
   expect(result).toEqual({ a: [1, 2, 3, 4, 5] });
-  expect(result !== object).toBe(true);
 });


### PR DESCRIPTION
Because

- markdown editor of pipeline description can not show ol and ul

This commit

- fix markdown editor of pipeline description can not show ol and ul