### PR TITLE
chore: increase the duration of error toast notification

### DIFF
--- a/packages/toolkit/src/lib/toastInstillError.ts
+++ b/packages/toolkit/src/lib/toastInstillError.ts
@@ -17,12 +17,14 @@ export function toastInstillError({
       variant: "alert-error",
       size: "large",
       description: getInstillApiErrorMessage(error),
+      duration: 15000,
     });
   } else {
     toast({
       title,
       variant: "alert-error",
       size: "large",
+      duration: 15000,
     });
   }
 }


### PR DESCRIPTION
Because

- increase the duration of error toast notification

This commit

- increase the duration of error toast notification
