### PR TITLE
fix(pipeline-builder): fix the wrong icon path on the pipeline-builder's node component

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.78.0",
+  "version": "0.78.1-rc.0",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
@@ -289,7 +289,7 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
       <NodeHead nodeIsCollapsed={nodeIsCollapsed}>
         <div className="mr-auto flex flex-row gap-x-1">
           <ImageWithFallback
-            src={`/icons/instill-ai/${data.component?.operator_definition?.icon}`}
+            src={`/icons/${data.component?.operator_definition?.icon}`}
             width={16}
             height={16}
             alt={`${data.component?.operator_definition?.title}-icon`}


### PR DESCRIPTION
Because

- fix the wrong icon path on the pipeline-builder's node component

This commit

- fix the wrong icon path on the pipeline-builder's node component
