### PR TITLE
fix: fix operator component node icon path is not correct

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/Flow.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/Flow.tsx
@@ -102,8 +102,7 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
               edges={edges}
               onNodesDelete={() => {
                 if (pipelineIsReadOnly) return;
-                updatePipelineRecipeIsDirty((prev) => {
-                  if (prev) return prev;
+                updatePipelineRecipeIsDirty(() => {
                   return true;
                 });
               }}
@@ -112,8 +111,7 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
               onEdgesDelete={() => {
                 if (pipelineIsReadOnly) return;
 
-                updatePipelineRecipeIsDirty((prev) => {
-                  if (prev) return prev;
+                updatePipelineRecipeIsDirty(() => {
                   return true;
                 });
               }}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
@@ -289,7 +289,7 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
       <NodeHead nodeIsCollapsed={nodeIsCollapsed}>
         <div className="mr-auto flex flex-row gap-x-1">
           <ImageWithFallback
-            src={`/icons/instill-ai/${data.component?.operator_definition?.icon}`}
+            src={`/icons/${data.component?.operator_definition?.icon}`}
             width={16}
             height={16}
             alt={`${data.component?.operator_definition?.title}-icon`}


### PR DESCRIPTION
Because

- operator component node icon path is not correct

This commit

- fix operator component node icon path is not correct
