### PR TITLE
fix: Typo in component configuration

### DIFF
--- a/packages/design-system/src/new-ui/Separator/Separator.stories.tsx
+++ b/packages/design-system/src/new-ui/Separator/Separator.stories.tsx
@@ -18,7 +18,7 @@ export const WithText: Story = {
     <div className="relative w-full">
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-semantic-bg-primary px-2">
         <p className="text-semantic-fg-primary product-body-text-1-regular">
-          Configration
+          Configuration
         </p>
       </div>
       <Separator orientation="horizontal" />

--- a/packages/toolkit/src/view/pipeline-builder/RightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/RightPanel.tsx
@@ -42,7 +42,7 @@ export const RightPanel = () => {
       <div className="relative mb-6 w-full">
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-semantic-bg-primary px-2">
           <p className="text-semantic-fg-secondary product-body-text-3-medium">
-            Configration
+            Configuration
           </p>
         </div>
         <Separator orientation="horizontal" />


### PR DESCRIPTION
Because

- Component panel shows "configration" (typo)

This commit

- Fixes the typo

Found while polishing public pipelines:
![CleanShot 2024-01-17 at 08 54 19](https://github.com/instill-ai/console/assets/3977183/9d5f3d2f-f373-4888-8fed-a5020094f25a)