### PR TITLE
fix: fix empty input setup button is not working in /pipelines/pid page

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -232,7 +232,9 @@ export const InOutPut = () => {
                 variant="tertiaryColour"
                 size="md"
                 onClick={() => {
-                  `/${entityObject.entity}/pipelines/${entityObject.id}/builder`;
+                  router.push(
+                    `/${entityObject.entity}/pipelines/${entityObject.id}/builder`
+                  );
                 }}
               >
                 Setup


### PR DESCRIPTION
Because

- fix empty input setup button is not working in /pipelines/pid page

This commit

- fix empty input setup button is not working in /pipelines/pid page
