### PR TITLE
feat(pipeline-builder): support group by format for component output reference hints

### DIFF
--- a/apps/console/src/pages/login.tsx
+++ b/apps/console/src/pages/login.tsx
@@ -78,7 +78,7 @@ const LoginPage: NextPageWithLayout = () => {
   }
 
   async function changePassword(
-    data: z.infer<typeof ChangePasswordFormSchema>
+    data: z.infer<typeof ChangePasswordFormSchema>,
   ) {
     if (!accessToken) {
       return;

--- a/packages/toolkit/src/components/ReferenceHintTag.tsx
+++ b/packages/toolkit/src/components/ReferenceHintTag.tsx
@@ -1,6 +1,6 @@
 import cn from "clsx";
 import * as React from "react";
-import { Icons } from "@instill-ai/design-system";
+import { Icons, Tooltip } from "@instill-ai/design-system";
 
 export const ReferenceHintTagRoot = ({
   children,
@@ -49,9 +49,39 @@ export const ReferenceHintTagLabel = ({
   className?: string;
 }) => {
   return (
-    <p className={cn("font-sans text-[11px] font-medium", className)}>
-      {children}
-    </p>
+    <Tooltip.Provider>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <p
+            className={cn(
+              "max-w-[240px] truncate font-sans text-[11px] font-medium",
+              className
+            )}
+          >
+            {children}
+          </p>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            sideOffset={5}
+            side="top"
+            className="max-w-[300px] rounded-sm bg-semantic-bg-primary !px-3 !py-2"
+          >
+            <div className="flex flex-col text-left">
+              <p className="bg-semantic-bg-primary product-body-text-4-semibold">
+                {children}
+              </p>
+            </div>
+            <Tooltip.Arrow
+              className="fill-semantic-bg-primary"
+              offset={10}
+              width={9}
+              height={6}
+            />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
   );
 };
 

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/GroupByFormatField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/GroupByFormatField.tsx
@@ -1,0 +1,37 @@
+import { ReferenceHintTag } from "../../../../components";
+import { ComponentOutoutReferenceHint } from "../../type";
+
+export const GroupByFormatField = ({
+  hints,
+  instillFormat,
+  componentID,
+}: {
+  hints: ComponentOutoutReferenceHint[];
+  instillFormat: string;
+  componentID?: string;
+}) => {
+  return (
+    <div className="flex w-full flex-col">
+      <p className="mb-1 text-semantic-fg-secondary product-body-text-4-medium">
+        {`[${instillFormat}]`}
+      </p>
+      <div className="flex w-full flex-row flex-wrap gap-2">
+        {hints.map((hint) => (
+          <ReferenceHintTag.Root key={hint.path}>
+            <ReferenceHintTag.Label className="!text-semantic-accent-default">
+              {componentID
+                ? hint.isObjectArrayChild
+                  ? `${componentID}.` +
+                    hint.path.replace(
+                      hint.objectArrayParentPath,
+                      `${hint.objectArrayParentPath}[index]`
+                    )
+                  : `${componentID}.` + hint.path
+                : hint.path}
+            </ReferenceHintTag.Label>
+          </ReferenceHintTag.Root>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/ListField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/ListField.tsx
@@ -14,11 +14,11 @@ export const ListField = ({
   description?: string;
 }) => {
   return (
-    <div className="flex flex-col">
-      <p className="mb-2 text-semantic-fg-secondary product-body-text-4-medium">
+    <div className="flex flex-col gap-y-1">
+      <p className="text-semantic-fg-secondary product-body-text-4-medium">
         {`${title} [${instillFormat}]`}
       </p>
-      <div className="mb-1 flex">
+      <div className="flex">
         <ReferenceHintTag.Root>
           <ReferenceHintTag.Label className="text-semantic-accent-default">
             {componentID ? `${componentID}.` + path : path}

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/index.ts
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output-reference-hints/index.ts
@@ -1,7 +1,9 @@
+import { GroupByFormatField } from "./GroupByFormatField";
 import { ListField } from "./ListField";
 import { ObjectArrayField } from "./ObjectArrayField";
 
 export const ComponentOutputReferenceHints = {
+  GroupByFormatField,
   ListField,
   ObjectArrayField,
 };

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
@@ -9,6 +9,7 @@ import {
   useInstillStore,
 } from "../../..";
 import { Icons, Tag, Tooltip } from "@instill-ai/design-system";
+import { ReferenceHintTag } from "../../../../components";
 
 const selector = (store: InstillStore) => ({
   isOwner: store.isOwner,
@@ -151,19 +152,12 @@ export const FieldHead = ({
           >
             <div className="overflow-hidden">
               <div className="flex">
-                <div className="flex flex-shrink flex-row items-center gap-x-1 rounded-full bg-semantic-accent-bg px-2 py-0.5">
-                  <div>
-                    <Icons.ReferenceIconCheck
-                      className={cn(
-                        "h-[9px] w-[18px] transition-colors duration-500",
-                        disabledReferenceHint
-                          ? "stroke-semantic-fg-secondary"
-                          : "stroke-semantic-accent-default"
-                      )}
-                    />
-                  </div>
-                  <p className="font-sans text-[10px] font-medium text-semantic-accent-default">{`start.${path}`}</p>
-                </div>
+                <ReferenceHintTag.Root>
+                  <ReferenceHintTag.Icon type="check" />
+                  <ReferenceHintTag.Label className="text-semantic-accent-default">
+                    {`start.${path}`}
+                  </ReferenceHintTag.Label>
+                </ReferenceHintTag.Root>
               </div>
             </div>
           </div>

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/UploadFileInput.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/UploadFileInput.tsx
@@ -18,10 +18,10 @@ export const UploadFileInput = React.forwardRef<
     <label
       htmlFor={id}
       className={cn(
-        "flex rounded-full px-2 py-0.5 font-sans text-xs font-medium text-semantic-accent-default hover:bg-semantic-accent-bg-alt",
+        "flex rounded-full px-2 py-0.5 font-sans text-xs font-medium text-semantic-accent-default hover:bg-semantic-accent-bg",
         disabled
           ? "cursor-not-allowed bg-semantic-bg-secondary"
-          : "cursor-pointer bg-semantic-accent-bg"
+          : "cursor-pointer underline"
       )}
     >
       {title}

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentsFromReferenceHints.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentsFromReferenceHints.tsx
@@ -52,6 +52,18 @@ export function pickComponentsFromReferenceHints(
         />
       );
     });
+  } else {
+    const groupedHints = groupBy(hints, (hint) => hint.instillFormat);
+
+    Object.entries(groupedHints).forEach(([instillFormat, hints]) => {
+      fields.push(
+        <ComponentOutputReferenceHints.GroupByFormatField
+          instillFormat={instillFormat}
+          hints={hints}
+          componentID={componentID}
+        />
+      );
+    });
   }
 
   return fields;

--- a/packages/toolkit/src/lib/use-instill-form/useComponentOutputReferenceHintFields.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useComponentOutputReferenceHintFields.tsx
@@ -3,18 +3,22 @@ import * as React from "react";
 import { InstillJSONSchema } from "./type";
 import { Nullable } from "../type";
 import { transformInstillJSONSchemaToFormTree } from "./transform";
-import { pickComponentsFromReferenceHints } from "./pick/pickComponentsFromReferenceHints";
+import {
+  PickComponentsFromReferenceHintsOptions,
+  pickComponentsFromReferenceHints,
+} from "./pick/pickComponentsFromReferenceHints";
 import { transformInstillFormTreeToReferenceHints } from "./transform/transformInstillFormTreeToReferenceHints";
 
 export type UseComponentOutputReferenceHintFieldsOptions = {
   componentID: string;
-};
+} & Pick<PickComponentsFromReferenceHintsOptions, "mode">;
 
 export function useComponentOutputReferenceHintFields(
   schema: Nullable<InstillJSONSchema>,
   options?: UseComponentOutputReferenceHintFieldsOptions
 ) {
   const componentID = options?.componentID ?? undefined;
+  const mode = options?.mode ?? "list";
 
   const fields = React.useMemo(() => {
     if (!schema) {
@@ -23,10 +27,13 @@ export function useComponentOutputReferenceHintFields(
 
     const outputFormTree = transformInstillJSONSchemaToFormTree(schema);
     const hints = transformInstillFormTreeToReferenceHints(outputFormTree);
-    const fields = pickComponentsFromReferenceHints(hints, { componentID });
+    const fields = pickComponentsFromReferenceHints(hints, {
+      componentID,
+      mode,
+    });
 
     return fields;
-  }, [schema, componentID]);
+  }, [schema, componentID, mode]);
 
   return fields;
 }

--- a/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputReferenceHints.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputReferenceHints.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { ScrollArea } from "@instill-ai/design-system";
 import {
   InstillJSONSchema,
@@ -5,6 +6,7 @@ import {
   useComponentOutputReferenceHintFields,
 } from "../../../lib";
 import { ReferenceHintTag } from "../../../components";
+import { PickComponentsFromReferenceHintsOptions } from "../../../lib/use-instill-form/pick/pickComponentsFromReferenceHints";
 
 export const ComponentOutputReferenceHints = ({
   componentID,
@@ -13,8 +15,14 @@ export const ComponentOutputReferenceHints = ({
   componentID: string;
   outputSchema: Nullable<InstillJSONSchema>;
 }) => {
+  const [mode, setMode] =
+    React.useState<Required<PickComponentsFromReferenceHintsOptions["mode"]>>(
+      "list"
+    );
+
   const hintFields = useComponentOutputReferenceHintFields(outputSchema, {
     componentID,
+    mode,
   });
 
   return (
@@ -24,11 +32,11 @@ export const ComponentOutputReferenceHints = ({
       </p>
 
       <ScrollArea.Root
-        className="nodrag nowheel h-full"
-        viewPortClassName="max-h-[400px]"
+        className="nodrag nowheel h-full w-[calc(var(--pipeline-builder-node-available-width)-24px)]"
+        viewPortClassName="max-h-[400px] w-full"
       >
-        <div className="flex flex-col rounded bg-semantic-bg-primary p-4">
-          <div className="mb-2 flex">
+        <div className="flex w-full flex-col rounded bg-semantic-bg-primary p-4">
+          <div className="mb-2 flex flex-row items-center justify-between">
             <ReferenceHintTag.Root className="!bg-semantic-bg-primary !px-0">
               <ReferenceHintTag.Icon
                 type="check"
@@ -38,6 +46,19 @@ export const ComponentOutputReferenceHints = ({
                 references
               </ReferenceHintTag.Label>
             </ReferenceHintTag.Root>
+            <button
+              className="rounded px-1.5 py-0.5 text-xs font-medium text-semantic-fg-disabled hover:bg-semantic-bg-base-bg"
+              onClick={() =>
+                setMode((prev) => {
+                  if (prev === "list") {
+                    return "groupByFormat";
+                  }
+                  return "list";
+                })
+              }
+            >
+              {mode === "list" ? "list" : "group"}
+            </button>
           </div>
           <div className="flex flex-col gap-y-2">{hintFields}</div>
         </div>


### PR DESCRIPTION
Because

- support group by format for component output reference hints

This commit

- support group by format for component output reference hints
