### PR TITLE
refactor: deprecate the usage of some callbacks on ReactQuery mutation

### DIFF
--- a/apps/console/src/components/OnboardingForm.tsx
+++ b/apps/console/src/components/OnboardingForm.tsx
@@ -220,14 +220,16 @@ export const OnboardingForm = () => {
         }),
       });
       await router.push(`/${user.id}/pipelines`);
-      
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Something went wrong when uploading the form"
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Something went wrong when uploading the form";
       setMessageBoxState(() => ({
         activate: true,
         status: "error",
         description: null,
-        message
+        message,
       }));
     }
   }, [

--- a/apps/console/src/components/OnboardingForm.tsx
+++ b/apps/console/src/components/OnboardingForm.tsx
@@ -201,9 +201,7 @@ export const OnboardingForm = () => {
       });
 
       if (amplitudeIsInit) {
-        sendAmplitudeData("submit_onboarding_form", {
-          type: "critical_action",
-        });
+        sendAmplitudeData("submit_onboarding_form");
       }
 
       setMessageBoxState(() => ({

--- a/packages/toolkit/src/view/data/DataResourceForm.tsx
+++ b/packages/toolkit/src/view/data/DataResourceForm.tsx
@@ -213,10 +213,7 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
         });
 
         if (onSubmit) {
-          onSubmit({
-            ...connector,
-            connector_definition: dataDefinition,
-          });
+          onSubmit(connector);
         }
 
         sendAmplitudeData("create_connector", {
@@ -263,10 +260,7 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
       });
 
       if (onSubmit) {
-        onSubmit({
-          ...connector,
-          connector_definition: dataDefinition,
-        });
+        onSubmit(connector);
       }
 
       sendAmplitudeData("update_connector");

--- a/packages/toolkit/src/view/data/DataResourceForm.tsx
+++ b/packages/toolkit/src/view/data/DataResourceForm.tsx
@@ -228,7 +228,6 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
           variant: "alert-success",
           size: "small",
         });
-
       } catch (error) {
         toast({
           title: "Something went wrong when creating the data connector",
@@ -238,8 +237,7 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
             ? getInstillApiErrorMessage(error)
             : "Please try again later",
         });
-      }
-      finally {
+      } finally {
         setIsSaving(false);
       }
 
@@ -287,8 +285,7 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
           ? getInstillApiErrorMessage(error)
           : "Please try again later",
       });
-    }
-    finally {
+    } finally {
       setIsSaving(false);
     }
   }, [

--- a/packages/toolkit/src/view/data/DataResourceForm.tsx
+++ b/packages/toolkit/src/view/data/DataResourceForm.tsx
@@ -205,47 +205,44 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
         configuration: stripValues.configuration,
       };
 
-      createData.mutate(
-        { entityName: entityObject.entityName, payload, accessToken },
-        {
-          onSuccess: ({ connector }) => {
-            if (onSubmit) {
-              onSubmit(connector);
-            }
+      try {
+        const { connector } = await createData.mutateAsync({
+          entityName: entityObject.entityName,
+          payload,
+          accessToken,
+        });
 
-            sendAmplitudeData("create_connector", {
-              connector_definition_name: dataDefinition.name,
-            });
-
-            toast({
-              title: "Successfully create data connector",
-              variant: "alert-success",
-              size: "small",
-            });
-
-            setIsSaving(false);
-          },
-          onError: (error) => {
-            if (isAxiosError(error)) {
-              toast({
-                title: "Something went wrong when create the data connector",
-                variant: "alert-error",
-                size: "large",
-                description: getInstillApiErrorMessage(error),
-              });
-            } else {
-              toast({
-                title: "Something went wrong when create the data connector",
-                variant: "alert-error",
-                size: "large",
-                description: "Please try again later",
-              });
-            }
-
-            setIsSaving(false);
-          },
+        if (onSubmit) {
+          onSubmit({
+            ...connector,
+            connector_definition: dataDefinition,
+          });
         }
-      );
+
+        sendAmplitudeData("create_connector", {
+          connector_definition_name: dataDefinition.name,
+        });
+
+        toast({
+          title: "Successfully created data connector",
+          variant: "alert-success",
+          size: "small",
+        });
+
+      } catch (error) {
+        toast({
+          title: "Something went wrong when creating the data connector",
+          variant: "alert-error",
+          size: "large",
+          description: isAxiosError(error)
+            ? getInstillApiErrorMessage(error)
+            : "Please try again later",
+        });
+      }
+      finally {
+        setIsSaving(false);
+      }
+
       return;
     }
 
@@ -261,45 +258,39 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
       ),
     };
 
-    updateData.mutate(
-      { payload, accessToken },
-      {
-        onSuccess: ({ connector }) => {
-          if (onSubmit) {
-            onSubmit(connector);
-          }
+    try {
+      const { connector } = await updateData.mutateAsync({
+        payload,
+        accessToken,
+      });
 
-          sendAmplitudeData("update_connector");
-
-          toast({
-            title: "Successfully update ai connector",
-            variant: "alert-success",
-            size: "small",
-          });
-
-          setIsSaving(false);
-        },
-        onError: (error) => {
-          if (isAxiosError(error)) {
-            toast({
-              title: "Something went wrong when update the ai connector",
-              variant: "alert-error",
-              size: "large",
-              description: getInstillApiErrorMessage(error),
-            });
-          } else {
-            toast({
-              title: "Something went wrong when update the ai connector",
-              variant: "alert-error",
-              size: "large",
-              description: "Please try again later",
-            });
-          }
-
-          setIsSaving(false);
-        },
+      if (onSubmit) {
+        onSubmit({
+          ...connector,
+          connector_definition: dataDefinition,
+        });
       }
-    );
+
+      sendAmplitudeData("update_connector");
+
+      toast({
+        title: "Successfully update ai connector",
+        variant: "alert-success",
+        size: "small",
+      });
+    } catch (error) {
+      toast({
+        title: "Something went wrong when updating the ai connector",
+        variant: "alert-error",
+        size: "large",
+        description: isAxiosError(error)
+          ? getInstillApiErrorMessage(error)
+          : "Please try again later",
+      });
+    }
+    finally {
+      setIsSaving(false);
+    }
   }, [
     createData,
     formYup,

--- a/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
+++ b/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
@@ -66,9 +66,9 @@ export const ChangeModelStateToggle = ({
       const payload = {
         modelName: model.name,
         accessToken,
-      }
+      };
 
-      if(modelWatchState === "STATE_ONLINE") {
+      if (modelWatchState === "STATE_ONLINE") {
         await switchOff.mutateAsync(payload);
       } else {
         await switchOn.mutateAsync(payload);
@@ -77,10 +77,10 @@ export const ChangeModelStateToggle = ({
       setTimeout(() => {
         setIsChangingState(false);
       }, 3000);
-
     } catch (error) {
-      const axiosErrorMessage = axios.isAxiosError(error) && error.response?.data.message;
-      if(!axiosErrorMessage) {
+      const axiosErrorMessage =
+        axios.isAxiosError(error) && error.response?.data.message;
+      if (!axiosErrorMessage) {
         setError("There is an error. Please try again.");
         return;
       }

--- a/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
+++ b/packages/toolkit/src/view/model/ChangeModelStateToggle.tsx
@@ -55,60 +55,36 @@ export const ChangeModelStateToggle = ({
     }
   }, [modelWatchState]);
 
-  const changeModelInstanceStateHandler = React.useCallback(() => {
+  const changeModelInstanceStateHandler = React.useCallback(async () => {
     if (!model || !modelWatchState || modelWatchState === "STATE_UNSPECIFIED") {
       return;
     }
-    if (modelWatchState === "STATE_ONLINE") {
-      setIsChangingState(true);
-      switchOff.mutate(
-        {
-          modelName: model.name,
-          accessToken,
-        },
-        {
-          onError: (error) => {
-            if (axios.isAxiosError(error)) {
-              setError(
-                error.response?.data.message ??
-                  "There is an error. Please try again."
-              );
-            } else {
-              setError("There is an error. Please try again.");
-            }
-          },
-          onSuccess: () => {
-            setTimeout(() => {
-              setIsChangingState(false);
-            }, 3000);
-          },
-        }
-      );
-    } else {
-      setIsChangingState(true);
-      switchOn.mutate(
-        {
-          modelName: model.name,
-          accessToken,
-        },
-        {
-          onError: (error) => {
-            if (axios.isAxiosError(error)) {
-              setError(
-                error.response?.data.message ??
-                  "There is an error. Please try again."
-              );
-            } else {
-              setError("There is an error. Please try again.");
-            }
-          },
-          onSuccess: () => {
-            setTimeout(() => {
-              setIsChangingState(false);
-            }, 3000);
-          },
-        }
-      );
+
+    setIsChangingState(true);
+
+    try {
+      const payload = {
+        modelName: model.name,
+        accessToken,
+      }
+
+      if(modelWatchState === "STATE_ONLINE") {
+        await switchOff.mutateAsync(payload);
+      } else {
+        await switchOn.mutateAsync(payload);
+      }
+
+      setTimeout(() => {
+        setIsChangingState(false);
+      }, 3000);
+
+    } catch (error) {
+      const axiosErrorMessage = axios.isAxiosError(error) && error.response?.data.message;
+      if(!axiosErrorMessage) {
+        setError("There is an error. Please try again.");
+        return;
+      }
+      setError(axiosErrorMessage);
     }
   }, [switchOn, switchOff, model, accessToken, modelWatchState]);
 

--- a/packages/toolkit/src/view/model/ConfigureModelForm.tsx
+++ b/packages/toolkit/src/view/model/ConfigureModelForm.tsx
@@ -156,18 +156,15 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
       if (amplitudeIsInit) {
         sendAmplitudeData("update_model");
       }
-
     } catch (error) {
       const isAxiosError = axios.isAxiosError(error);
       setMessageBoxState(() => ({
         activate: true,
         status: "error",
-        description: isAxiosError
-        ? getInstillApiErrorMessage(error)
-        : null,
+        description: isAxiosError ? getInstillApiErrorMessage(error) : null,
         message: isAxiosError
-        ? error.message
-        : "Something went wrong when update the model",
+          ? error.message
+          : "Something went wrong when update the model",
       }));
     }
   }, [
@@ -229,9 +226,7 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
         activate: true,
         status: "error",
         message,
-        description: isAxiosError
-        ? getInstillApiErrorMessage(error)
-        : null,
+        description: isAxiosError ? getInstillApiErrorMessage(error) : null,
       });
     }
   }, [

--- a/packages/toolkit/src/view/model/ConfigureModelForm.tsx
+++ b/packages/toolkit/src/view/model/ConfigureModelForm.tsx
@@ -106,7 +106,7 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
 
   const updateUserModel = useUpdateUserModel();
 
-  const handleConfigureModel = React.useCallback(() => {
+  const handleConfigureModel = React.useCallback(async () => {
     if (!canEdit) {
       setCanEdit(true);
       return;
@@ -129,54 +129,47 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
       message: "Updating...",
     }));
 
-    updateUserModel.mutate(
-      {
+    try {
+      await updateUserModel.mutateAsync({
         payload: {
           name: model.name,
           description: description || "",
         },
         accessToken,
-      },
-      {
-        onSuccess: () => {
-          setCanEdit(false);
+      });
 
-          setMessageBoxState(() => ({
-            activate: true,
-            status: "success",
-            description: null,
-            message: "Succeed.",
-          }));
+      setCanEdit(false);
 
-          setFormIsDirty(false);
+      setMessageBoxState(() => ({
+        activate: true,
+        status: "success",
+        description: null,
+        message: "Succeed.",
+      }));
 
-          if (onConfigure) {
-            onConfigure(init);
-          }
+      setFormIsDirty(false);
 
-          if (amplitudeIsInit) {
-            sendAmplitudeData("update_model");
-          }
-        },
-        onError: (error) => {
-          if (axios.isAxiosError(error)) {
-            setMessageBoxState(() => ({
-              activate: true,
-              status: "error",
-              description: getInstillApiErrorMessage(error),
-              message: error.message,
-            }));
-          } else {
-            setMessageBoxState(() => ({
-              activate: true,
-              status: "error",
-              description: null,
-              message: "Something went wrong when update the model",
-            }));
-          }
-        },
+      if (onConfigure) {
+        onConfigure(init);
       }
-    );
+
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_model");
+      }
+
+    } catch (error) {
+      const isAxiosError = axios.isAxiosError(error);
+      setMessageBoxState(() => ({
+        activate: true,
+        status: "error",
+        description: isAxiosError
+        ? getInstillApiErrorMessage(error)
+        : null,
+        message: isAxiosError
+        ? error.message
+        : "Something went wrong when update the model",
+      }));
+    }
   }, [
     amplitudeIsInit,
     model,
@@ -194,7 +187,7 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
    * -----------------------------------------------------------------------*/
 
   const deleteModel = useDeleteModel();
-  const handleDeleteModel = React.useCallback(() => {
+  const handleDeleteModel = React.useCallback(async () => {
     if (!model) return;
 
     setMessageBoxState({
@@ -206,46 +199,41 @@ export const ConfigureModelForm = (props: ConfigureModelFormProps) => {
 
     closeModal();
 
-    deleteModel.mutate(
-      {
+    try {
+      await deleteModel.mutateAsync({
         modelName: model.name,
         accessToken,
-      },
-      {
-        onSuccess: () => {
-          setMessageBoxState({
-            activate: true,
-            message: "Succeed.",
-            description: null,
-            status: "success",
-          });
-          if (amplitudeIsInit) {
-            sendAmplitudeData("delete_model");
-          }
+      });
 
-          if (onDelete) {
-            onDelete(init);
-          }
-        },
-        onError: (error) => {
-          if (axios.isAxiosError(error)) {
-            setMessageBoxState({
-              activate: true,
-              message: `${error.response?.status} - ${error.response?.data.message}`,
-              description: getInstillApiErrorMessage(error),
-              status: "error",
-            });
-          } else {
-            setMessageBoxState({
-              activate: true,
-              message: "Something went wrong when delete the model",
-              description: null,
-              status: "error",
-            });
-          }
-        },
+      setMessageBoxState({
+        activate: true,
+        message: "Succeed.",
+        description: null,
+        status: "success",
+      });
+
+      if (amplitudeIsInit) {
+        sendAmplitudeData("delete_model");
       }
-    );
+
+      if (onDelete) {
+        onDelete(init);
+      }
+    } catch (error) {
+      const isAxiosError = axios.isAxiosError(error);
+      const message = isAxiosError
+        ? `${error.response?.status} - ${error.response?.data.message}`
+        : "Something went wrong when deleting the model";
+
+      setMessageBoxState({
+        activate: true,
+        status: "error",
+        message,
+        description: isAxiosError
+        ? getInstillApiErrorMessage(error)
+        : null,
+      });
+    }
   }, [
     init,
     model,

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -309,7 +309,6 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
       }
     };
 
-
     // We don't validate the rest of the field if the ID is incorrect
     if (!validateInstillID(modelId as string)) {
       setFieldError("model.new.id", InstillErrors.IDInvalidError);
@@ -339,7 +338,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         },
       };
 
-      await handleCreateModelMutation(payload)
+      await handleCreateModelMutation(payload);
     } else if (modelDefinition === "model-definitions/local") {
       if (!modelId || !modelLocalFile) {
         return;
@@ -355,7 +354,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         },
       };
 
-      await handleCreateModelMutation(payload)
+      await handleCreateModelMutation(payload);
     } else if (modelDefinition === "model-definitions/artivc") {
       if (!modelArtivcGcsBucketPath || !modelArtivcTag) return;
 
@@ -373,7 +372,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         },
       };
 
-      await handleCreateModelMutation(payload)
+      await handleCreateModelMutation(payload);
     } else {
       if (!modelHuggingFaceRepoUrl) return;
 
@@ -387,7 +386,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         },
       };
 
-      await handleCreateModelMutation(payload)
+      await handleCreateModelMutation(payload);
     }
   }, [
     createUserModel,

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -268,7 +268,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
           setCreateModelMessageBoxState(() => ({
             activate: true,
             status: "error",
-            description: "Something went wrong when create the model",
+            description: "Something went wrong when creating the model",
             message: "Create Model Failed",
           }));
           return;

--- a/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
@@ -29,7 +29,9 @@ export const CreateAPITokenDialog = (props: CreateAPITokenDialogProps) => {
   });
 
   const createAPIToken = useCreateApiToken();
-  const handleCreateAPIToken = async (data: z.infer<typeof CreateTokenSchema>) => {
+  const handleCreateAPIToken = async (
+    data: z.infer<typeof CreateTokenSchema>
+  ) => {
     if (!accessToken) return;
 
     const payload = {

--- a/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
@@ -29,7 +29,7 @@ export const CreateAPITokenDialog = (props: CreateAPITokenDialogProps) => {
   });
 
   const createAPIToken = useCreateApiToken();
-  const handleCreateAPIToken = (data: z.infer<typeof CreateTokenSchema>) => {
+  const handleCreateAPIToken = async (data: z.infer<typeof CreateTokenSchema>) => {
     if (!accessToken) return;
 
     const payload = {
@@ -39,38 +39,34 @@ export const CreateAPITokenDialog = (props: CreateAPITokenDialogProps) => {
 
     setIsLoading(true);
 
-    createAPIToken.mutate(
-      { payload, accessToken },
-      {
-        onSuccess: () => {
-          setIsLoading(false);
+    try {
+      await createAPIToken.mutateAsync({ payload, accessToken });
+      setIsLoading(false);
 
-          sendAmplitudeData("create_api_token");
+      sendAmplitudeData("create_api_token");
 
-          if (onCreate) {
-            onCreate();
-          }
-
-          setOpen(false);
-        },
-        onError: (err) => {
-          setIsLoading(false);
-          if (isAxiosError(err)) {
-            if (err.response?.status === 409) {
-              form.setError("id", {
-                type: "manual",
-                message: "Token name already exists",
-              });
-              return;
-            }
-            form.setError("id", {
-              type: "manual",
-              message: err.response?.data.message,
-            });
-          }
-        },
+      if (onCreate) {
+        onCreate();
       }
-    );
+
+      setOpen(false);
+    } catch (error) {
+      setIsLoading(false);
+      if (!isAxiosError(error)) return;
+
+      if (error.response?.status === 409) {
+        form.setError("id", {
+          type: "manual",
+          message: "Token name already exists",
+        });
+        return;
+      }
+
+      form.setError("id", {
+        type: "manual",
+        message: error.response?.data.message,
+      });
+    }
   };
 
   return (

--- a/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
@@ -62,7 +62,6 @@ export const DeleteAPITokenDialog = (props: DeleteAPITokenDialogProps) => {
       }
 
       setOpen(false);
-      
     } catch (error) {
       const description = isAxiosError(error)
         ? getInstillApiErrorMessage(error)

--- a/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
@@ -54,7 +54,7 @@ export const DeleteAPITokenDialog = (props: DeleteAPITokenDialogProps) => {
         accessToken: accessToken,
       });
       setIsLoading(false);
-      
+
       sendAmplitudeData("delete_api_token");
 
       if (onDelete) {

--- a/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
@@ -44,44 +44,37 @@ export const DeleteAPITokenDialog = (props: DeleteAPITokenDialogProps) => {
 
   const deleteAPIToken = useDeleteApiToken();
 
-  const handleDeleteApiToken = () => {
+  const handleDeleteApiToken = async () => {
     if (!accessToken) return;
     setIsLoading(true);
-    deleteAPIToken.mutate(
-      {
+
+    try {
+      await deleteAPIToken.mutateAsync({
         tokenName: deleteTokenName,
         accessToken: accessToken,
-      },
-      {
-        onSuccess: () => {
-          setIsLoading(false);
+      });
+      setIsLoading(false);
+      
+      sendAmplitudeData("delete_api_token");
 
-          sendAmplitudeData("delete_api_token");
-
-          if (onDelete) {
-            onDelete();
-          }
-
-          setOpen(false);
-        },
-        onError: (error) => {
-          if (isAxiosError(error)) {
-            toast({
-              title: "Something went wrong when delete the token",
-              description: getInstillApiErrorMessage(error),
-              variant: "alert-error",
-              size: "large",
-            });
-          } else {
-            toast({
-              title: "Something went wrong when delete the pipeline",
-              variant: "alert-error",
-              size: "large",
-            });
-          }
-        },
+      if (onDelete) {
+        onDelete();
       }
-    );
+
+      setOpen(false);
+      
+    } catch (error) {
+      const description = isAxiosError(error)
+        ? getInstillApiErrorMessage(error)
+        : null;
+
+      toast({
+        title: "Something went wrong when deleting the pipeline",
+        variant: "alert-error",
+        size: "large",
+        description,
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
Because

According to the open issue, the maintenance of the code is reduced when react query is using callbacks instead of async functions

This commit

- Fixes it by migrating all `.mutate` to `.mutateAsync` and does the necessary adaptations
- Also, whenever I had a chance to improve readability, I did. For example, a piece of code was being repeated 5 times, so I created a function for it
- I let just one `.mutate` as it doesnt have any callback


closes https://github.com/instill-ai/community/issues/455