### PR TITLE
fix(pipeline-builder): support the potential breaking changes of connector task

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/lib/getConnectorInputOutputSchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getConnectorInputOutputSchema.ts
@@ -25,7 +25,12 @@ export function getConnectorInputOutputSchema(
 
   const targetTask = task ?? component.configuration.task;
 
-  if (targetTask) {
+  // We need to support the breaking changes that maybe the previous selected task's
+  // definition is not support anymore. Console need to check this.
+  if (
+    targetTask &&
+    component?.connector_definition?.spec.openapi_specifications[targetTask]
+  ) {
     inputSchema = (
       (
         (

--- a/packages/toolkit/src/view/pipeline-builder/lib/getOperatorInputOutputSchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getOperatorInputOutputSchema.ts
@@ -25,7 +25,12 @@ export function getOperatorInputOutputSchema(
 
   const targetTask = task ?? component.configuration.task;
 
-  if (targetTask) {
+  // We need to support the breaking changes that maybe the previous selected task's
+  // definition is not support anymore. Console need to check this.
+  if (
+    targetTask &&
+    component?.operator_definition?.spec.openapi_specifications[targetTask]
+  ) {
     inputSchema = (
       (
         (


### PR DESCRIPTION
Because

- Backend may change the task of connector. But the migration may not catch up so it will have deviation. For example, if the task is `TASK_NOT_FOUND`,  but the backend provided definition already remove this definition. Console will break. We need to support this kind of breaking change

This commit

- support the potential breaking changes of connector task
