### PR TITLE
feat(tracking): add isAmplitudeInit guard before send the amplitude event

### DIFF
--- a/packages/toolkit/src/components/ClonePipelineDialog.tsx
+++ b/packages/toolkit/src/components/ClonePipelineDialog.tsx
@@ -26,6 +26,7 @@ import {
   env,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useCreateUserPipeline,
   useInstillStore,
   useShallow,
@@ -71,6 +72,7 @@ export const ClonePipelineDialog = ({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [dialogIsOpen, setDialogIsOpen] = React.useState(open ?? false);
   const [cloning, setCloning] = React.useState(false);
   const [permission, setPermission] =
@@ -161,10 +163,12 @@ export const ClonePipelineDialog = ({
           entityName: namespace,
         });
 
-        if (pipeline.owner_name === me.data.name) {
-          sendAmplitudeData("duplicate_pipeline");
-        } else {
-          sendAmplitudeData("clone_pipeline");
+        if (amplitudeIsInit) {
+          if (pipeline.owner_name === me.data.name) {
+            sendAmplitudeData("duplicate_pipeline");
+          } else {
+            sendAmplitudeData("clone_pipeline");
+          }
         }
 
         await router.push(`/${data.namespaceId}/pipelines/${payload.id}`);

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/FieldHead.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import cn from "clsx";
 import { useShallow } from "zustand/react/shallow";
 import {
   FieldMode,

--- a/packages/toolkit/src/view/ai/AIResourceAutoForm.tsx
+++ b/packages/toolkit/src/view/ai/AIResourceAutoForm.tsx
@@ -6,6 +6,7 @@ import {
   Nullable,
   UpdateUserConnectorPayload,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useCreateUserConnector,
   useEntity,
   useUpdateUserConnector,
@@ -24,6 +25,7 @@ export type AIResourceAutoFormProps = {
 };
 
 export const AIResourceAutoForm = (props: AIResourceAutoFormProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { definition, resource, accessToken, onSubmit } = props;
   const { toast } = useToast();
 
@@ -53,9 +55,11 @@ export const AIResourceAutoForm = (props: AIResourceAutoFormProps) => {
           accessToken,
         });
 
-        sendAmplitudeData("create_connector", {
-          connector_definition_name: definition.name,
-        });
+        if (amplitudeIsInit) {
+          sendAmplitudeData("create_connector", {
+            connector_definition_name: definition.name,
+          });
+        }
 
         if (onSubmit) {
           onSubmit(connector);
@@ -91,7 +95,9 @@ export const AIResourceAutoForm = (props: AIResourceAutoFormProps) => {
         accessToken,
       });
 
-      sendAmplitudeData("update_connector");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_connector");
+      }
 
       if (onSubmit) {
         onSubmit(connector);

--- a/packages/toolkit/src/view/blockchain/BlockchainResourceAutoForm.tsx
+++ b/packages/toolkit/src/view/blockchain/BlockchainResourceAutoForm.tsx
@@ -5,6 +5,7 @@ import {
   Nullable,
   UpdateUserConnectorPayload,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useCreateUserConnector,
   useEntity,
   useUpdateUserConnector,
@@ -25,6 +26,7 @@ export type BlockchainResourceAutoFormProps = {
 export const BlockchainResourceAutoForm = (
   props: BlockchainResourceAutoFormProps
 ) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { definition, resource, accessToken, onSubmit } = props;
   const { toast } = useToast();
 
@@ -53,9 +55,11 @@ export const BlockchainResourceAutoForm = (
           accessToken,
         });
 
-        sendAmplitudeData("create_connector", {
-          connector_definition_name: definition.name,
-        });
+        if (amplitudeIsInit) {
+          sendAmplitudeData("create_connector", {
+            connector_definition_name: definition.name,
+          });
+        }
 
         if (onSubmit) {
           onSubmit(connector);
@@ -91,7 +95,9 @@ export const BlockchainResourceAutoForm = (
         accessToken,
       });
 
-      sendAmplitudeData("update_connector");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_connector");
+      }
 
       if (onSubmit) {
         onSubmit(connector);

--- a/packages/toolkit/src/view/data/DataResourceForm.tsx
+++ b/packages/toolkit/src/view/data/DataResourceForm.tsx
@@ -23,6 +23,7 @@ import {
   useAirbyteFieldValues,
   useAirbyteFormTree,
   useAirbyteSelectedConditionMap,
+  useAmplitudeCtx,
   useBuildAirbyteYup,
   useCreateUserConnector,
   useEntity,
@@ -53,6 +54,7 @@ type BackButtonProps =
     };
 
 export const DataResourceForm = (props: DataResourceFormProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const {
     disabledAll,
     dataResource,
@@ -216,9 +218,11 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
           onSubmit(connector);
         }
 
-        sendAmplitudeData("create_connector", {
-          connector_definition_name: dataDefinition.name,
-        });
+        if (amplitudeIsInit) {
+          sendAmplitudeData("create_connector", {
+            connector_definition_name: dataDefinition.name,
+          });
+        }
 
         toast({
           title: "Successfully created data connector",
@@ -263,7 +267,9 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
         onSubmit(connector);
       }
 
-      sendAmplitudeData("update_connector");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_connector");
+      }
 
       toast({
         title: "Successfully update ai connector",
@@ -295,6 +301,7 @@ export const DataResourceForm = (props: DataResourceFormProps) => {
     isSaving,
     entityObject.isSuccess,
     entityObject.entityName,
+    amplitudeIsInit,
   ]);
 
   return (

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -31,6 +31,7 @@ import {
   watchUserModel,
   validateInstillID,
   useUserMe,
+  useAmplitudeCtx,
 } from "../../lib";
 import { checkUntilOperationIsDoen } from "../../lib/vdp-sdk/operation";
 import { InstillErrors } from "../../constant/errors";
@@ -71,6 +72,7 @@ const selector = (state: CreateResourceFormStore) => ({
 });
 
 export const CreateModelForm = (props: CreateModelFormProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const {
     accessToken,
     enabledQuery,
@@ -227,11 +229,13 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
         message: "Succeed.",
       });
 
-      sendAmplitudeData("create_model", {
-        model_definition_name: modelDefinitionName,
-      });
+      if (amplitudeIsInit) {
+        sendAmplitudeData("create_model", {
+          model_definition_name: modelDefinitionName,
+        });
+      }
     },
-    [accessToken, queryClient, setFieldValue]
+    [accessToken, queryClient, setFieldValue, amplitudeIsInit]
   );
 
   const deployUserModel = useDeployUserModel();

--- a/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/FlowControl.tsx
@@ -34,6 +34,7 @@ import {
   env,
   getInstillApiErrorMessage,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useCreateUserPipeline,
   useEntity,
   useInstillStore,
@@ -75,6 +76,7 @@ export type FlowControlProps = {
 };
 
 export const FlowControl = (props: FlowControlProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { reactFlowInstance, appEnv } = props;
   const {
     nodes,
@@ -144,7 +146,9 @@ export const FlowControl = (props: FlowControlProps) => {
           accessToken,
         });
 
-        sendAmplitudeData("update_pipeline_recipe");
+        if (amplitudeIsInit) {
+          sendAmplitudeData("update_pipeline_recipe");
+        }
 
         toast({
           title: "Pipeline is saved",
@@ -193,7 +197,10 @@ export const FlowControl = (props: FlowControlProps) => {
       setPipelineUid(res.pipeline.uid);
       updatePipelineRecipeIsDirty(() => false);
       updatePipelineIsNew(() => false);
-      sendAmplitudeData("create_pipeline");
+
+      if (amplitudeIsInit) {
+        sendAmplitudeData("create_pipeline");
+      }
 
       toast({
         title: "Successfully saved the pipeline",

--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineNameForm.tsx
@@ -16,6 +16,7 @@ import {
   UpdateUserPipelinePayload,
   getInstillApiErrorMessage,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useCreateUserPipeline,
   useEntity,
   useInstillStore,
@@ -51,6 +52,7 @@ export const UpdatePipelineIdSchema = z.object({
 });
 
 export const PipelineNameForm = (props: PipelineNameFormProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken } = props;
   const router = useRouter();
   const { entity, id } = router.query;
@@ -126,7 +128,10 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
         setPipelineName(res.pipeline.name);
         updatePipelineIsNew(() => false);
         updatePipelineRecipeIsDirty(() => false);
-        sendAmplitudeData("create_pipeline");
+
+        if (amplitudeIsInit) {
+          sendAmplitudeData("create_pipeline");
+        }
 
         await router.push(`/${entity}/pipelines/${newId}/builder`, undefined, {
           shallow: true,
@@ -176,7 +181,9 @@ export const PipelineNameForm = (props: PipelineNameFormProps) => {
           accessToken,
         });
 
-        sendAmplitudeData("update_pipeline_name");
+        if (amplitudeIsInit) {
+          sendAmplitudeData("update_pipeline_name");
+        }
 
         updatePipelineRecipeIsDirty(() => false);
       } catch (error) {

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/PublishPipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/PublishPipelineDialog.tsx
@@ -11,6 +11,7 @@ import {
   UpdateUserPipelinePayload,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useInstillStore,
   useUpdateUserPipeline,
   useUserPipeline,
@@ -36,6 +37,7 @@ export const PublishPipelineFormSchema = z.object({
 });
 
 export const PublishPipelineDialog = () => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [isPublishing, setIsPublishing] = React.useState(false);
 
   const { toast } = useToast();
@@ -97,7 +99,10 @@ export const PublishPipelineDialog = () => {
       });
 
       setIsPublishing(false);
-      sendAmplitudeData("publish_pipeline");
+
+      if (amplitudeIsInit) {
+        sendAmplitudeData("publish_pipeline");
+      }
 
       toast({
         size: "large",

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
@@ -7,6 +7,7 @@ import {
   env,
   getInstillApiErrorMessage,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useEntity,
   useInstillStore,
   useShallow,
@@ -24,6 +25,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const TabShare = () => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken, enableQuery, pipelineIsNew } = useInstillStore(
     useShallow(selector)
   );
@@ -105,7 +107,9 @@ export const TabShare = () => {
           accessToken,
         });
 
-        sendAmplitudeData("enable_pipeline_share_by_link");
+        if (amplitudeIsInit) {
+          sendAmplitudeData("enable_pipeline_share_by_link");
+        }
 
         link = `${env(
           "NEXT_PUBLIC_CONSOLE_BASE_URL"
@@ -156,6 +160,7 @@ export const TabShare = () => {
     toast,
     entityObject.isSuccess,
     entityObject.pipelineName,
+    amplitudeIsInit,
   ]);
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/UnpublishPipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/UnpublishPipelineDialog.tsx
@@ -5,6 +5,7 @@ import {
   UpdateUserPipelinePayload,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useEntity,
   useInstillStore,
   useShallow,
@@ -19,6 +20,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const UnpublishPipelineDialog = () => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [isOpen, setIsOpen] = React.useState(false);
   const { accessToken, enabledQuery, updateDialogSharePipelineIsOpen } =
     useInstillStore(useShallow(selector));
@@ -52,7 +54,9 @@ export const UnpublishPipelineDialog = () => {
 
       await updateUserPipeline.mutateAsync({ payload, accessToken });
 
-      sendAmplitudeData("unpublish_pipeline");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("unpublish_pipeline");
+      }
 
       toast({
         title: "Pipeline successfully unpublished",

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarOutput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarOutput.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import cn from "clsx";
 import JsonView from "@uiw/react-json-view";
 import { customTheme } from "../../../../../../lib/react-json-view";
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
@@ -14,7 +14,6 @@ import {
 import {
   GeneralRecord,
   InstillStore,
-  Nullable,
   useConnectorDefinitions,
   useInstillForm,
   useInstillStore,
@@ -55,8 +54,6 @@ const selector = (store: InstillStore) => ({
   accessToken: store.accessToken,
   enabledQuery: store.enabledQuery,
 });
-
-type BottomBarOption = "output" | "schema";
 
 export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
   const {

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
@@ -37,7 +37,6 @@ const selector = (store: InstillStore) => ({
   isOwner: store.isOwner,
   currentVersion: store.currentVersion,
   isTriggeringPipeline: store.isTriggeringPipeline,
-  testModeTriggerResponse: store.testModeTriggerResponse,
   pipelineIsReadOnly: store.pipelineIsReadOnly,
 });
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -22,6 +22,7 @@ import {
   toastInstillError,
   GeneralRecord,
   sendAmplitudeData,
+  useAmplitudeCtx,
 } from "../../../../../lib";
 import {
   StartOperatorNodeFreeForm,
@@ -57,6 +58,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [noteIsOpen, setNoteIsOpen] = React.useState<boolean>(false);
   const [nodeIsCollapsed, setNodeIsCollapsed] = React.useState(false);
 
@@ -394,7 +396,9 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
           returnTraces: true,
         });
 
-        sendAmplitudeData("trigger_pipeline");
+        if (amplitudeIsInit) {
+          sendAmplitudeData("trigger_pipeline");
+        }
 
         updateIsTriggeringPipeline(() => false);
         updateTestModeTriggerResponse(() => data);

--- a/packages/toolkit/src/view/pipeline/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelineBuilderMainView.tsx
@@ -21,6 +21,7 @@ import {
   useUpdateUserPipeline,
   useUserPipeline,
   sendAmplitudeData,
+  useAmplitudeCtx,
 } from "../../lib";
 import {
   BottomBar,
@@ -47,6 +48,7 @@ export type PipelineBuilderMainViewProps = GeneralPageProp;
 export const PipelineBuilderMainView = (
   props: PipelineBuilderMainViewProps
 ) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken, enableQuery, router } = props;
   const [reactFlowInstance, setReactFlowInstance] =
     React.useState<Nullable<ReactFlowInstance>>(null);
@@ -189,7 +191,9 @@ export const PipelineBuilderMainView = (
                 accessToken,
               });
 
-              sendAmplitudeData("create_pipeline");
+              if (amplitudeIsInit) {
+                sendAmplitudeData("create_pipeline");
+              }
 
               toast({
                 title: "Pipeline is saved",
@@ -233,7 +237,9 @@ export const PipelineBuilderMainView = (
               accessToken,
             });
 
-            sendAmplitudeData("update_pipeline_recipe");
+            if (amplitudeIsInit) {
+              sendAmplitudeData("update_pipeline_recipe");
+            }
 
             toast({
               title: "Successfully saved the pipeline",

--- a/packages/toolkit/src/view/pipeline/view-pipeline/EditMetadataDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/EditMetadataDialog.tsx
@@ -17,6 +17,7 @@ import {
   UpdateUserPipelinePayload,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useEntity,
   useInstillStore,
   useUpdateUserPipeline,
@@ -31,6 +32,7 @@ export const EditMetadataDialog = ({
 }: {
   description: Nullable<string>;
 }) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [open, setOpen] = React.useState(false);
   const form = useForm<z.infer<typeof PipelineEditMetadataSchema>>({
     resolver: zodResolver(PipelineEditMetadataSchema),
@@ -58,7 +60,11 @@ export const EditMetadataDialog = ({
 
     try {
       await updateUserPipeline.mutateAsync({ payload, accessToken });
-      sendAmplitudeData("update_pipeline_description");
+
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_pipeline_description");
+      }
+
       setOpen(false);
       toast({
         size: "small",

--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -9,6 +9,7 @@ import {
   TriggerUserPipelineResponse,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useEntity,
   useInstillStore,
   useShallow,
@@ -34,6 +35,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const InOutPut = () => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
   const router = useRouter();
   const [response, setResponse] =
@@ -123,7 +125,9 @@ export const InOutPut = () => {
         returnTraces: true,
       });
 
-      sendAmplitudeData("trigger_pipeline");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("trigger_pipeline");
+      }
 
       setResponse(data);
     } catch (error) {

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
@@ -13,6 +13,7 @@ import {
   UpdateUserPipelinePayload,
   useEntity,
   sendAmplitudeData,
+  useAmplitudeCtx,
 } from "../../../lib";
 import { useToast } from "@instill-ai/design-system";
 import { LoadingSpin } from "../../../components";
@@ -29,6 +30,7 @@ export const Readme = ({
   isOwner: boolean;
   readme: Nullable<string>;
 }) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken } = useInstillStore(useShallow(selector));
   const { toast } = useToast();
 
@@ -64,7 +66,9 @@ export const Readme = ({
 
           await updateUserPipeline.mutateAsync({ payload, accessToken });
 
-          sendAmplitudeData("update_pipeline_readme");
+          if (amplitudeIsInit) {
+            sendAmplitudeData("update_pipeline_readme");
+          }
 
           toast({
             size: "small",
@@ -91,6 +95,7 @@ export const Readme = ({
       accessToken,
       toast,
       updateUserPipeline,
+      amplitudeIsInit,
     ]
   );
 

--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -26,6 +26,7 @@ import {
   env,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useCreateUserPipeline,
   useEntity,
   useInstillStore,
@@ -63,6 +64,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const CreatePipelineDialog = ({ className }: { className?: string }) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [open, setOpen] = React.useState(false);
   const [creating, setCreating] = React.useState(false);
   const [permission, setPermission] =
@@ -178,7 +180,9 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
           payload,
         });
 
-        sendAmplitudeData("create_pipeline");
+        if (amplitudeIsInit) {
+          sendAmplitudeData("create_pipeline");
+        }
 
         await router.push(`/${data.namespaceId}/pipelines/${data.id}/builder`);
       } catch (error) {

--- a/packages/toolkit/src/view/resource/ResourcesTable.tsx
+++ b/packages/toolkit/src/view/resource/ResourcesTable.tsx
@@ -7,6 +7,7 @@ import {
   formatDate,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useDeleteUserConnector,
   useInstillStore,
 } from "../../lib";
@@ -25,6 +26,7 @@ export type ResourcesTableProps = {
 };
 
 export const ResourcesTable = (props: ResourcesTableProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { connectors, isError, isLoading } = props;
   const { toast } = useToast();
   const accessToken = useInstillStore((store) => store.accessToken);
@@ -38,7 +40,9 @@ export const ResourcesTable = (props: ResourcesTableProps) => {
         accessToken,
       });
 
-      sendAmplitudeData("delete_connector");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("delete_connector");
+      }
 
       toast({
         title: "Successfully delete connector",

--- a/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
@@ -1,7 +1,12 @@
 import * as z from "zod";
 import * as React from "react";
 import { Button, Dialog, Form, Input } from "@instill-ai/design-system";
-import { Nullable, sendAmplitudeData, useCreateApiToken } from "../../../lib";
+import {
+  Nullable,
+  sendAmplitudeData,
+  useAmplitudeCtx,
+  useCreateApiToken,
+} from "../../../lib";
 import { isAxiosError } from "axios";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,6 +22,7 @@ const CreateTokenSchema = z.object({
 });
 
 export const CreateAPITokenDialog = (props: CreateAPITokenDialogProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const [open, setOpen] = React.useState(false);
   const { accessToken, onCreate } = props;
   const [isLoading, setIsLoading] = React.useState(false);
@@ -45,7 +51,9 @@ export const CreateAPITokenDialog = (props: CreateAPITokenDialogProps) => {
       await createAPIToken.mutateAsync({ payload, accessToken });
       setIsLoading(false);
 
-      sendAmplitudeData("create_api_token");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("create_api_token");
+      }
 
       if (onCreate) {
         onCreate();

--- a/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
@@ -11,6 +11,7 @@ import {
   Nullable,
   getInstillApiErrorMessage,
   sendAmplitudeData,
+  useAmplitudeCtx,
   useDeleteApiToken,
 } from "../../../lib";
 import { isAxiosError } from "axios";
@@ -29,6 +30,7 @@ const DeleteTokenSchema = z.object({
 });
 
 export const DeleteAPITokenDialog = (props: DeleteAPITokenDialogProps) => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { deleteTokenName, accessToken, onDelete } = props;
   const [open, setOpen] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
@@ -55,7 +57,9 @@ export const DeleteAPITokenDialog = (props: DeleteAPITokenDialogProps) => {
       });
       setIsLoading(false);
 
-      sendAmplitudeData("delete_api_token");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("delete_api_token");
+      }
 
       if (onDelete) {
         onDelete();

--- a/packages/toolkit/src/view/settings/user/UserProfileTab.tsx
+++ b/packages/toolkit/src/view/settings/user/UserProfileTab.tsx
@@ -19,6 +19,7 @@ import {
   User,
   sendAmplitudeData,
   toastInstillError,
+  useAmplitudeCtx,
   useInstillStore,
   useShallow,
   useUpdateUser,
@@ -50,6 +51,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const UserProfileTab = () => {
+  const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
   const { toast } = useToast();
   const [profileAvatar, setProfileAvatar] = React.useState<
@@ -102,7 +104,9 @@ export const UserProfileTab = () => {
     try {
       await updateUser.mutateAsync({ payload, accessToken });
 
-      sendAmplitudeData("update_user_profile_settings");
+      if (amplitudeIsInit) {
+        sendAmplitudeData("update_user_profile_settings");
+      }
 
       form.reset(payload);
       toast({


### PR DESCRIPTION
Because

- If we send the event before initialize the amplitude, it will cause error

This commit

- add isAmplitudeInit guard before send the amplitude event