### PR TITLE
fix(dashboard): update pipeline chart status type

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/types.ts
@@ -20,8 +20,8 @@ export type TriggeredPipeline = {
 export type PipelinesChart = {
   pipeline_id: string;
   pipeline_uid: string;
-  trigger_mode: "MODE_SYNC" | "MODE_ASYNC";
-  status: PipelineReleaseState;
+  trigger_mode: PipelineMode;
+  status: PipelineTriggerStatus;
   time_buckets: string[];
   trigger_counts: number[] | string[];
   compute_time_duration: number[] | string[];


### PR DESCRIPTION
Because

- Dashboard numbers don't add up

This commit

- updated pipeline chart `status` types
