### PR TITLE
fix(dashboard): chart yAxis calculation

### DIFF
--- a/packages/toolkit/src/lib/dashboard/generateChartData.ts
+++ b/packages/toolkit/src/lib/dashboard/generateChartData.ts
@@ -42,8 +42,13 @@ export function generateChartData(
     ].entries()) {
       const xAxisIndex = xAxis.findIndex((date) => date === formattedBucket);
       if (xAxisIndex !== -1) {
-        yAxis[pipelineIndex]["data"][xAxisIndex] =
-          pipeline.trigger_counts[bucketIndex];
+        if (yAxis[pipelineIndex]["data"][xAxisIndex]) {
+          yAxis[pipelineIndex]["data"][xAxisIndex] +=
+            pipeline.trigger_counts[bucketIndex];
+        } else {
+          yAxis[pipelineIndex]["data"][xAxisIndex] +=
+            pipeline.trigger_counts[bucketIndex];
+        }
       }
     }
   });

--- a/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/types.ts
@@ -20,8 +20,8 @@ export type TriggeredPipeline = {
 export type PipelinesChart = {
   pipeline_id: string;
   pipeline_uid: string;
-  trigger_mode: "MODE_SYNC" | "MODE_ASYNC";
-  status: PipelineReleaseState;
+  trigger_mode: PipelineMode;
+  status: PipelineTriggerStatus;
   time_buckets: string[];
   trigger_counts: number[] | string[];
   compute_time_duration: number[] | string[];


### PR DESCRIPTION
Because

currently the triggered count was getting overwritten by next value.
```
 yAxis[pipelineIndex]["data"][xAxisIndex] = pipeline.trigger_counts[bucketIndex];
```

This commit

it should be, if their is already a value, to the index, it should add up to the previous value
```
if (yAxis[pipelineIndex]["data"][xAxisIndex]) {
        yAxis[pipelineIndex]["data"][xAxisIndex] += pipeline.trigger_counts[bucketIndex];
   } else {
       yAxis[pipelineIndex]["data"][xAxisIndex] += pipeline.trigger_counts[bucketIndex];
}
```