### PR TITLE
fix(pipeline-builder): fix smart-hint list not align to left when the key is too long

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
@@ -76,7 +76,7 @@ export const SmartHintList = ({
                   key={hint.path}
                   id={`${path.split(".").join("")}-${index}`}
                   className={cn(
-                    "flex rounded p-2 product-body-text-4-semibold",
+                    "flex rounded p-2 text-left product-body-text-4-semibold",
                     {
                       "bg-semantic-accent-bg text-semantic-accent-hover":
                         highlightedHintIndex === index,


### PR DESCRIPTION
Because

- fix smart-hint list not align to left when the key is too long

This commit

- fix smart-hint list not align to left when the key is too long
