### PR TITLE
fix: fix console wrongly warn field not supporting multiple references

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
@@ -321,13 +321,6 @@ export function transformInstillJSONSchemaToZod({
           });
         }
 
-        if (references.length > 1 && !acceptTemplate) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: "This field only accepts single reference",
-          });
-        }
-
         if (
           references.length === 0 &&
           instillUpstreamValue &&


### PR DESCRIPTION
Because

- console wrongly warn field not supporting multiple references (We don't support this before, but since we change our reference syntax and support auto converting the reference to target type right now, so we support multiple references out of the box)

This commit

- fix console wrongly warn field not supporting multiple references
