### PR TITLE
feat(pipeline-builder): support hinting other type that can be stringified

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -29,6 +29,7 @@ export const TextArea = ({
   componentID,
   size,
   isHidden,
+  instillFormat,
 }: {
   fieldKey: Nullable<string>;
   instillAcceptFormats: string[];
@@ -37,6 +38,7 @@ export const TextArea = ({
   isRequired?: boolean;
   instillUpstreamTypes: string[];
   componentID?: string;
+  instillFormat?: string;
 } & AutoFormFieldBaseProps) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -29,6 +29,7 @@ export const TextField = ({
   componentID,
   size,
   isHidden,
+  instillFormat,
 }: {
   fieldKey: Nullable<string>;
   instillAcceptFormats: string[];
@@ -37,6 +38,7 @@ export const TextField = ({
   isRequired?: boolean;
   instillUpstreamTypes: string[];
   componentID?: string;
+  instillFormat?: string;
 } & AutoFormFieldBaseProps) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -231,6 +231,7 @@ export function pickRegularFieldsFromInstillFormTree(
           componentID={componentID}
           size={size}
           isHidden={tree.isHidden}
+          instillFormat={tree.instillFormat}
         />
       );
     }
@@ -283,6 +284,7 @@ export function pickRegularFieldsFromInstillFormTree(
         componentID={componentID}
         size={size}
         isHidden={tree.isHidden}
+        instillFormat={tree.instillFormat}
       />
     );
   }

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
@@ -17,7 +17,7 @@ test("should pick hints from non-array hints", () => {
     },
   ];
 
-  const instillAcceptFormats = ["text/plain", "image/png"];
+  const instillAcceptFormats = ["text/plain"];
 
   const pickHints = pickSmartHintsFromAcceptFormats(
     hints,

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
@@ -15,6 +15,61 @@ export function pickSmartHintsFromAcceptFormats(
     return hints;
   }
 
+  // If the the field's instillAcceptFormats is string, we will automatically
+  // convert the hint's field value to string. So we also need to pick
+  // various other types
+
+  // These are the value that can be stringified
+  // bool
+  // number
+  // integer
+  // string
+  // object
+  // semi-structured/*
+  // structured/*
+
+  // These are the value that can't be stringified
+  // image/*
+  // audio/*
+  // video/*
+
+  if (
+    instillAcceptFormats.length === 1 &&
+    instillAcceptFormats[0] === "string"
+  ) {
+    const allowStringifyTypes = [
+      "boolean",
+      "array:boolean",
+      "number",
+      "array:number",
+      "integer",
+      "array:integer",
+      "string",
+      "array:string",
+      "object",
+      "array:object",
+    ];
+
+    for (const hint of hints) {
+      if (allowStringifyTypes.includes(hint.instillFormat)) {
+        pickHints.push(hint);
+      }
+
+      if (hint.instillFormat.includes("/")) {
+        // We will include both array and non-array semi-structured and structured
+        const [type] = hint.instillFormat.replaceAll("array:", "").split("/");
+
+        if (type === "semi-structured") {
+          pickHints.push(hint);
+        }
+
+        if (type === "structured") {
+          pickHints.push(hint);
+        }
+      }
+    }
+  }
+
   for (const hint of hints) {
     // Deal with array
     if (hint.type === "array") {


### PR DESCRIPTION
Because

- support hinting other types that can be stringified

```
// These are the value that can be stringified
// bool
// number
// integer
// string
// object
// semi-structured/*
// structured/*

// These are the value that can't be stringified
// image/*
// audio/*
// video/*
```

This commit

- support hinting other types that can be stringified
