### PR TITLE
fix: fix create pipeline dialog use the wrong entity as query param

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.test.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.test.ts
@@ -354,7 +354,7 @@ test("should transform nested fields with anyOf", () => {
     },
   };
 
-  expect(speechZodSchema.safeParse(templateAudio).success).toBe(false);
+  expect(speechZodSchema.safeParse(templateAudio).success).toBe(true);
 
   const stringAudio = {
     task: "TASK_SPEECH_RECOGNITION",

--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -27,6 +27,7 @@ import {
   sendAmplitudeData,
   toastInstillError,
   useAmplitudeCtx,
+  useAuthenticatedUser,
   useCreateUserPipeline,
   useEntity,
   useInstillStore,
@@ -61,6 +62,7 @@ export type CreatePipelineDialogProps = {
 
 const selector = (store: InstillStore) => ({
   accessToken: store.accessToken,
+  enabledQuery: store.enabledQuery,
 });
 
 export const CreatePipelineDialog = ({ className }: { className?: string }) => {
@@ -78,13 +80,18 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
     mode: "onChange",
   });
 
-  const { accessToken } = useInstillStore(useShallow(selector));
+  const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
 
   const entityObject = useEntity();
 
+  const me = useAuthenticatedUser({
+    enabled: enabledQuery,
+    accessToken,
+  });
+
   const organizations = useUserMemberships({
     enabled: entityObject.isSuccess,
-    userID: entityObject.isSuccess ? entityObject.entity : null,
+    userID: me.isSuccess ? me.data.id : null,
     accessToken,
   });
 


### PR DESCRIPTION

Because

- fix create pipeline dialog use the wrong entity as query param

This commit

- fix create pipeline dialog use the wrong entity as query param
