### PR TITLE
feat(pipeline-builder): replace semi-structured/object with semi-structured/json on start operator

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/pick/pickStartOperatorFreeFormFields.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickStartOperatorFreeFormFields.tsx
@@ -361,7 +361,7 @@ export function pickStartOperatorFreeFormFields({
           ),
         });
         break;
-      case "semi-structured/object":
+      case "semi-structured/json":
         fields.push({
           key,
           instillUIOrder: value.instillUiOrder,

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformStartOperatorMetadataToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformStartOperatorMetadataToZod.ts
@@ -73,7 +73,7 @@ export function transformStartOperatorMetadataToZod(
           z.array(z.string()).nullable().optional()
         );
         break;
-      case "semi-structured/object":
+      case "semi-structured/json":
         zodSchema = zodSchema.setKey(key, z.string().nullable().optional());
         break;
       default:

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
@@ -167,7 +167,7 @@ export function pickSmartHintsFromAcceptFormats(
         pickHints.push(hint);
       }
 
-      // Deal with semi-structured. Now we have semi-structured/object
+      // Deal with semi-structured. Now we have semi-structured/json
       // and semi-structured/*, in the view of smart-hint they support the same
       // structure
       if (

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -202,7 +202,7 @@ export type StartOperatorInputType =
   | "array:string"
   | "*/*"
   | "array:*/*"
-  | "semi-structured/object"
+  | "semi-structured/json"
   | "video/*"
   | "array:video/*"
   | JSONSchema7TypeName;

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartNodeInputType.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartNodeInputType.tsx
@@ -115,7 +115,7 @@ export const StartNodeInputType = ({
       label = "Multiple Files";
       break;
     }
-    case "semi-structured/object": {
+    case "semi-structured/json": {
       icon = (
         <Icons.BracketSlash className="m-auto h-4 w-4 stroke-semantic-fg-primary" />
       );

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -268,10 +268,10 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
         };
         break;
       }
-      case "semi-structured/object": {
+      case "semi-structured/json": {
         configuraton = {
           type: "object",
-          instillFormat: "semi-structured/object",
+          instillFormat: "semi-structured/json",
           title: formData.title,
           description: formData.description,
         };
@@ -374,7 +374,7 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
     if (data.component.configuration.metadata) {
       Object.entries(data.component.configuration.metadata).forEach(
         ([key, value]) => {
-          if (value.instillFormat === "semi-structured/object") {
+          if (value.instillFormat === "semi-structured/json") {
             semiStructuredObjectKeys.push(key);
           }
         }

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNodeFreeForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNodeFreeForm.tsx
@@ -153,9 +153,9 @@ export const StartOperatorNodeFreeForm = ({
             onSelect={() => setSelectedType("boolean")}
           />
           <StartNodeInputType
-            type="semi-structured/object"
+            type="semi-structured/json"
             selectedType={selectedType}
-            onSelect={() => setSelectedType("semi-structured/object")}
+            onSelect={() => setSelectedType("semi-structured/json")}
           />
         </div>
         <div className="flex flex-col space-y-3">

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/pickSelectedTypeFromInstillFormat.ts
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/pickSelectedTypeFromInstillFormat.ts
@@ -40,8 +40,8 @@ export function pickSelectedTypeFromInstillFormat(
     case "array:*/*": {
       return "array:*/*";
     }
-    case "semi-structured/object": {
-      return "semi-structured/object";
+    case "semi-structured/json": {
+      return "semi-structured/json";
     }
     default:
       return null;

--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -89,7 +89,7 @@ export const InOutPut = () => {
 
     if (startOperatorMetadata) {
       Object.entries(startOperatorMetadata).forEach(([key, value]) => {
-        if (value.instillFormat === "semi-structured/object") {
+        if (value.instillFormat === "semi-structured/json") {
           semiStructuredObjectKeys.push(key);
         }
       });


### PR DESCRIPTION
Because

- We need to replace semi-structured/object with semi-structured/json on start operator to better support backend

This commit

- replace semi-structured/object with semi-structured/json on start operator
