### PR TITLE
fix(pipeline-builder): fix semi-structured/json at start operator not obey the protocol

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -183,7 +183,7 @@ export type StartOperatorMetadata = Record<string, StartOperatorInput>;
 
 export type StartOperatorInput = {
   title: string;
-  type: StartOperatorInputType;
+  type?: StartOperatorInputType;
   instillFormat: string;
   items?: {
     type: string;

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartNodeInputType.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartNodeInputType.tsx
@@ -119,7 +119,7 @@ export const StartNodeInputType = ({
       icon = (
         <Icons.BracketSlash className="m-auto h-4 w-4 stroke-semantic-fg-primary" />
       );
-      label = "JSON object";
+      label = "JSON";
       break;
     }
     default:

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -268,9 +268,11 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
         };
         break;
       }
+
+      // This is the special case. We use this input to store arbitrary JSON
+      // By protocol, it don't have a type
       case "semi-structured/json": {
         configuraton = {
-          type: "object",
           instillFormat: "semi-structured/json",
           title: formData.title,
           description: formData.description,


### PR DESCRIPTION
Because

When using semi-structured/json, the type in the metadata of start operator need to be removed.
```
{
    "type": "object",
    "instillFormat": "semi-structured/json",
    "title": "www"
}
```

to

```
{
    "instillFormat": "semi-structured/json",
    "title": "www"
} 
```

This commit

- fix semi-structured/json at start operator not obey the protocol
