### PR TITLE
fix(pipeline-builder): prevent user create duplicated field on start and end operator

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.80.4-rc.7",
+  "version": "0.80.4-rc.8",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
@@ -76,6 +76,17 @@ export const EndOperatorNode = ({ data, id }: NodeProps<EndNodeData>) => {
   const onCreateFreeFormField = (
     formData: z.infer<typeof EndOperatorFreeFormSchema>
   ) => {
+    if (
+      data.component.configuration.metadata &&
+      Object.keys(data.component.configuration.metadata).includes(formData.key)
+    ) {
+      form.setError("key", {
+        type: "manual",
+        message: "Key already exists",
+      });
+      return;
+    }
+
     const newNodes = nodes.map((node) => {
       if (node.data.nodeType === "end") {
         if (prevFieldKey) {

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -129,10 +129,21 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
     updatePipelineRecipeIsDirty(() => true);
   };
 
-  const onCreateFreeFormField = (
+  function onCreateFreeFormField(
     formData: z.infer<typeof StartOperatorFreeFormSchema>
-  ) => {
+  ) {
     let configuraton: Nullable<StartOperatorInput> = null;
+
+    if (
+      data.component.configuration.metadata &&
+      Object.keys(data.component.configuration.metadata).includes(formData.key)
+    ) {
+      form.setError("key", {
+        type: "manual",
+        message: "Key already exists",
+      });
+      return;
+    }
 
     switch (selectedType) {
       case "string": {
@@ -313,7 +324,7 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
       title: "",
       description: "",
     });
-  };
+  }
 
   function onCancelFreeForm() {
     setEnableEdit((prev) => !prev);


### PR DESCRIPTION
Because

- relates issue https://github.com/instill-ai/community/issues/559

This commit

- prevent user create duplicated field on start and end operator
