### PR TITLE
feat: add trial_end field into StripeSubscriptionDetail

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.80.4-rc.9",
+  "version": "0.80.4-rc.10",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/vdp-sdk/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/types.ts
@@ -36,12 +36,12 @@ export type Permission = {
 };
 
 export type StripeSubscriptionDetail = {
-  customer_id: string;
   product_name: string;
   id: string;
   item_id: string;
   price: number;
   canceled_at?: number;
+  trial_end?: number;
   status: StripeSubscriptionStatus;
 };
 


### PR DESCRIPTION
Because

- Backend provide stripe.trial_end field

This commit

- add trial_end field into StripeSubscriptionDetail
