### PR TITLE
feat(pipeline-builder): copy & paste full reference with ${} instead of path only

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.80.4-rc.13",
+  "version": "0.80.4-rc.14",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/components/ReferenceHintTag.tsx
+++ b/packages/toolkit/src/components/ReferenceHintTag.tsx
@@ -80,7 +80,7 @@ export const ReferenceHintTagLabel = ({
 
               e.stopPropagation();
               e.preventDefault();
-              await navigator.clipboard.writeText(label);
+              await navigator.clipboard.writeText("${" + label + "}");
               setCopied(true);
               setOpen(true);
               setTimeout(() => {


### PR DESCRIPTION
Because

- copy & paste full reference with ${} instead of path only

This commit

- copy & paste full reference with ${} instead of path only
