### PR TITLE
fix: fix user profile card bio not left-align

### DIFF
--- a/packages/toolkit/src/components/UserProfileCard.tsx
+++ b/packages/toolkit/src/components/UserProfileCard.tsx
@@ -73,7 +73,7 @@ export const UserProfileCard = ({
               </div>
             )}
             {me.data.profile?.bio ? (
-              <p className="py-2 text-center text-semantic-fg-primary product-body-text-3-regular">
+              <p className="py-2 text-left text-semantic-fg-primary product-body-text-3-regular">
                 {me.data.profile.bio}
               </p>
             ) : null}


### PR DESCRIPTION
Because

- fix user profile card bio not left-align

![CleanShot 2023-12-16 at 09 16 16](https://github.com/instill-ai/console/assets/57251712/18e07306-5adc-4003-b82b-4779ab64c37d)

This commit

- fix user profile card bio not left-align
