### PR TITLE
fix: fix smart hint didn't correctly filter hints

### DIFF
--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
@@ -1,23 +1,127 @@
 import { test, expect } from "vitest";
 import { pickSmartHintsFromAcceptFormats } from "./pickSmartHintsFromAcceptFormats";
 
-test("should pick hints from non-array hints", () => {
+test("should pick hints when accept format is *", () => {
   const hints = [
     {
       path: "root.texts",
       key: "texts",
-      instillFormat: "text/plain",
-      type: "array",
+      instillFormat: "string",
+      type: "null",
     },
     {
       path: "root.images",
       key: "texts",
       instillFormat: "image/jpeg",
-      type: "array",
+      type: "null",
     },
   ];
 
-  const instillAcceptFormats = ["text/plain"];
+  const pickHints = pickSmartHintsFromAcceptFormats(hints, ["*"]);
+  expect(pickHints).toStrictEqual(hints);
+
+  const arrayHints = [
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.segments.mask",
+          key: "mask",
+          instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ];
+
+  const pickArrayHints = pickSmartHintsFromAcceptFormats(arrayHints, ["*"]);
+  expect(pickArrayHints).toStrictEqual(arrayHints);
+});
+
+test("should pick hints when accept format is */*", () => {
+  const hints = [
+    {
+      path: "root.texts",
+      key: "texts",
+      instillFormat: "string",
+      type: "null",
+    },
+    {
+      path: "root.images",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "null",
+    },
+  ];
+
+  const pickHints = pickSmartHintsFromAcceptFormats(hints, ["*/*"]);
+  expect(pickHints).toStrictEqual(hints);
+
+  const arrayHints = [
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.segments.mask",
+          key: "mask",
+          instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ];
+
+  const pickArrayHints = pickSmartHintsFromAcceptFormats(arrayHints, ["*/*"]);
+  expect(pickArrayHints).toStrictEqual(arrayHints);
+});
+
+test("should pick hints from non objectArray hints", () => {
+  const hints = [
+    {
+      path: "root.texts",
+      key: "texts",
+      instillFormat: "string",
+      type: "null",
+    },
+    {
+      path: "root.images",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "null",
+    },
+  ];
+
+  const instillAcceptFormats = ["string"];
 
   const pickHints = pickSmartHintsFromAcceptFormats(
     hints,
@@ -28,13 +132,110 @@ test("should pick hints from non-array hints", () => {
     {
       path: "root.texts",
       key: "texts",
-      instillFormat: "text/plain",
-      type: "array",
+      instillFormat: "string",
+      type: "null",
     },
   ]);
 });
 
-test("should pick hints from array hints", () => {
+test("should pick hints from non objectArray hints with complicated array format", () => {
+  const hints = [
+    {
+      path: "root.texts",
+      key: "texts",
+      instillFormat: "string",
+      type: "null",
+    },
+    {
+      path: "root.arrayNum",
+      key: "texts",
+      instillFormat: "array:number",
+      type: "null",
+    },
+    {
+      path: "root.semiStructured",
+      key: "texts",
+      instillFormat: "semi-structured/*",
+      type: "null",
+    },
+    {
+      path: "root.image",
+      key: "texts",
+      instillFormat: "image/*",
+      type: "array",
+    },
+    {
+      path: "root.jpeg",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "array",
+    },
+    {
+      path: "root.jpegs",
+      key: "texts",
+      instillFormat: "array:image/jpeg",
+      type: "array",
+    },
+    {
+      path: "root.images",
+      key: "texts",
+      instillFormat: "array:image/*",
+      type: "array",
+    },
+  ];
+
+  const pickImage = pickSmartHintsFromAcceptFormats(hints, ["image/*"]);
+
+  expect(pickImage).toStrictEqual([
+    {
+      path: "root.image",
+      key: "texts",
+      instillFormat: "image/*",
+      type: "array",
+    },
+    {
+      path: "root.jpeg",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "array",
+    },
+  ]);
+
+  // This is a special rule of instill-ai protocol. Although the field only accept image/jpeg
+  // We will still hint user a universal image/* field to make sure the experience is good
+  // When the pipeline fails to the non-correct format, backedn will throw runtime error
+  const pickJpeg = pickSmartHintsFromAcceptFormats(hints, ["image/jpeg"]);
+
+  expect(pickJpeg).toStrictEqual([
+    {
+      path: "root.image",
+      key: "texts",
+      instillFormat: "image/*",
+      type: "array",
+    },
+    {
+      path: "root.jpeg",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "array",
+    },
+  ]);
+
+  const pickSemiStructured = pickSmartHintsFromAcceptFormats(hints, [
+    "semi-structured/*",
+  ]);
+
+  expect(pickSemiStructured).toStrictEqual([
+    {
+      path: "root.semiStructured",
+      key: "texts",
+      instillFormat: "semi-structured/*",
+      type: "null",
+    },
+  ]);
+});
+
+test("should pick hints from objectArray hints", () => {
   const hints = [
     {
       path: "root.segments",
@@ -84,6 +285,188 @@ test("should pick hints from array hints", () => {
           path: "root.segments.mask",
           key: "mask",
           instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ]);
+});
+
+test("should pick hints when accept format is array:*", () => {
+  const hints = [
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.segments.mask",
+          key: "mask",
+          instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ];
+
+  const pickHints = pickSmartHintsFromAcceptFormats(hints, ["array:*"]);
+
+  expect(pickHints).toStrictEqual([
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.segments.mask",
+          key: "mask",
+          instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ]);
+});
+
+test("should pick hints when accept format is string from non objectArray hints", () => {
+  const hints = [
+    {
+      path: "root.texts",
+      key: "texts",
+      instillFormat: "string",
+      type: "null",
+    },
+    {
+      path: "root.arrayNum",
+      key: "texts",
+      instillFormat: "array:number",
+      type: "null",
+    },
+    {
+      path: "root.semiStructured",
+      key: "texts",
+      instillFormat: "semi-structured/*",
+      type: "null",
+    },
+    {
+      path: "root.images",
+      key: "texts",
+      instillFormat: "image/jpeg",
+      type: "array",
+    },
+  ];
+
+  const pickHints = pickSmartHintsFromAcceptFormats(hints, ["string"]);
+
+  expect(pickHints).toStrictEqual([
+    {
+      path: "root.texts",
+      key: "texts",
+      instillFormat: "string",
+      type: "null",
+    },
+    {
+      path: "root.arrayNum",
+      key: "texts",
+      instillFormat: "array:number",
+      type: "null",
+    },
+    {
+      path: "root.semiStructured",
+      key: "texts",
+      instillFormat: "semi-structured/*",
+      type: "null",
+    },
+  ]);
+});
+
+test("should pick hints when accept format is string from objectArray hints", () => {
+  const hints = [
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.arrayNum",
+          key: "texts",
+          instillFormat: "array:number",
+          type: "null",
+        },
+        {
+          path: "root.segments.mask",
+          key: "mask",
+          instillFormat: "image/jpeg",
+          type: "null",
+        },
+        {
+          path: "root.segments.score",
+          key: "score",
+          instillFormat: "number",
+          type: "null",
+        },
+      ],
+    },
+  ];
+
+  const pickHints = pickSmartHintsFromAcceptFormats(hints, ["string"]);
+
+  expect(pickHints).toStrictEqual([
+    {
+      path: "root.segments",
+      key: "segments",
+      instillFormat: "null",
+      type: "array",
+      properties: [
+        {
+          path: "root.segments.label",
+          key: "label",
+          instillFormat: "string",
+          type: "null",
+        },
+        {
+          path: "root.arrayNum",
+          key: "texts",
+          instillFormat: "array:number",
           type: "null",
         },
         {

--- a/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
@@ -21,76 +21,83 @@ export const useSmartHint = () => {
     let smartHints: SmartHint[] = [];
 
     for (const node of nodes) {
-      if (node.data.nodeType === "connector") {
-        const { outputSchema } = getConnectorInputOutputSchema(
-          node.data.component
-        );
-
-        if (outputSchema) {
-          const outputFormTree =
-            transformInstillJSONSchemaToFormTree(outputSchema);
-
-          const hints = transformConnectorComponentFormTreeToSmartHints(
-            outputFormTree,
-            node.id
+      switch (node.data.nodeType) {
+        case "connector": {
+          const { outputSchema } = getConnectorInputOutputSchema(
+            node.data.component
           );
 
-          smartHints = [...smartHints, ...hints];
-        }
+          if (outputSchema) {
+            const outputFormTree =
+              transformInstillJSONSchemaToFormTree(outputSchema);
 
-        smartHints = [
-          ...smartHints,
-          {
-            path: `${node.id}.output`,
-            key: "output",
-            instillFormat: "null",
-            type: "object",
-            properties: [],
-          },
-        ];
-      }
+            const hints = transformConnectorComponentFormTreeToSmartHints(
+              outputFormTree,
+              node.id
+            );
 
-      if (node.data.nodeType === "start") {
-        if (!node.data.component.configuration.metadata) {
+            smartHints = [...smartHints, ...hints];
+          }
+
+          smartHints = [
+            ...smartHints,
+            {
+              path: `${node.id}.output`,
+              key: "output",
+              instillFormat: "null",
+              type: "object",
+              properties: [],
+            },
+          ];
           continue;
         }
+        case "start": {
+          if (!node.data.component.configuration.metadata) {
+            continue;
+          }
 
-        const hints = transformStartOperatorMetadataToSmartHints(
-          node.data.component.configuration.metadata
-        );
-
-        smartHints = [...smartHints, ...hints];
-      }
-
-      if (node.data.nodeType === "operator") {
-        const { outputSchema } = getOperatorInputOutputSchema(
-          node.data.component
-        );
-
-        if (outputSchema) {
-          const outputFormTree =
-            transformInstillJSONSchemaToFormTree(outputSchema);
-
-          const hints = transformConnectorComponentFormTreeToSmartHints(
-            outputFormTree,
-            node.id
+          const hints = transformStartOperatorMetadataToSmartHints(
+            node.data.component.configuration.metadata
           );
 
           smartHints = [...smartHints, ...hints];
-        }
 
-        smartHints = [
-          ...smartHints,
-          {
-            path: `${node.id}.output`,
-            key: "output",
-            instillFormat: "null",
-            type: "object",
-            properties: [],
-          },
-        ];
+          continue;
+        }
+        case "operator": {
+          const { outputSchema } = getOperatorInputOutputSchema(
+            node.data.component
+          );
+
+          if (outputSchema) {
+            const outputFormTree =
+              transformInstillJSONSchemaToFormTree(outputSchema);
+
+            const hints = transformConnectorComponentFormTreeToSmartHints(
+              outputFormTree,
+              node.id
+            );
+
+            smartHints = [...smartHints, ...hints];
+          }
+
+          smartHints = [
+            ...smartHints,
+            {
+              path: `${node.id}.output`,
+              key: "output",
+              instillFormat: "null",
+              type: "object",
+              properties: [],
+            },
+          ];
+
+          continue;
+        }
       }
     }
+
+    console.log("smartHints", smartHints);
 
     updateSmartHints(() => smartHints);
   }, [nodes, updateSmartHints]);


### PR DESCRIPTION
Because

- There are multiple scenario smart hint doesn't correctly filter hints
  - The hints will duplicated 
  - It can not correctly filter array types
  - The logic is messy
- The unit tests are not complete

This commit

- Fix above filter issue
- Add more unit tests to guard this feature
