### PR TITLE
fix: fix user can not wheel scroll up and down on TextArea

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/MDTextViewer.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/MDTextViewer.tsx
@@ -16,7 +16,7 @@ export const MDTextViewer = ({ text }: { text: Nullable<string> }) => {
           word-break: break-all !important;
         }
       `}</style>
-      <div className="nodrag flex flex-col rounded-sm border border-semantic-bg-line">
+      <div className="nodrag nowheel flex flex-col rounded-sm border border-semantic-bg-line">
         <div className="flex flex-row rounded-t-sm border-b border-semantic-bg-line bg-semantic-bg-secondary px-2 py-1">
           <div className="flex flex-row gap-x-1">
             <p className="my-auto text-semantic-fg-primary product-body-text-4-medium">

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
@@ -40,7 +40,7 @@ export const CredentialTextField = ({
                 <Input.Core
                   {...field}
                   className={cn(
-                    "nodrag",
+                    "nodrag nowheel",
                     size === "sm" ? "!product-body-text-4-regular" : ""
                   )}
                   type="text"

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
@@ -35,7 +35,7 @@ export const TextAreaField = ({
               <Textarea
                 {...field}
                 className={cn(
-                  "nodrag",
+                  "nodrag nowheel",
                   size === "sm" ? "!product-body-text-4-regular" : ""
                 )}
                 // At some moment the value maybe a object

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
@@ -38,7 +38,7 @@ export const TextField = ({
                   {...field}
                   aria-label={title ?? undefined}
                   className={cn(
-                    "nodrag",
+                    "nodrag nowheel",
                     size === "sm" ? "!product-body-text-4-regular" : ""
                   )}
                   type="text"

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -123,7 +123,7 @@ export const TextArea = ({
                   <Textarea
                     {...field}
                     className={cn(
-                      "nodrag placeholder:text-semantic-fg-disabled",
+                      "nodrag nowheel placeholder:text-semantic-fg-disabled",
                       size === "sm" ? "!product-body-text-4-regular" : ""
                     )}
                     ref={inputRef}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -134,7 +134,7 @@ export const TextField = ({
                         typeof field.value === "object" ? "" : field.value ?? ""
                       }
                       className={cn(
-                        "nodrag placeholder:text-semantic-fg-disabled",
+                        "nodrag nowheel placeholder:text-semantic-fg-disabled",
                         size === "sm" ? "!product-body-text-4-regular" : ""
                       )}
                       placeholder={placeholder}

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/LongTextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/LongTextField.tsx
@@ -32,7 +32,7 @@ export const LongTextField = ({
     editorProps: {
       attributes: {
         class:
-          "nodrag prose max-h-[450px] rounded-sm min-h-[60px] border border-semantic-bg-line bg-semantic-bg-primary p-2 focus-within:border-semantic-accent-default focus-within:outline focus-within:outline-1 focus-within:outline-semantic-accent-default focus-within:ring-0 disabled-within:cursor-not-allowed disabled-within:bg-semantic-bg-secondary",
+          "nodrag nowheel prose max-h-[450px] rounded-sm min-h-[60px] border border-semantic-bg-line bg-semantic-bg-primary p-2 focus-within:border-semantic-accent-default focus-within:outline focus-within:outline-1 focus-within:outline-semantic-accent-default focus-within:ring-0 disabled-within:cursor-not-allowed disabled-within:bg-semantic-bg-secondary",
       },
     },
     onUpdate: ({ editor }) => {

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/NumberField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/NumberField.tsx
@@ -46,7 +46,7 @@ export const NumberField = ({
                   // AlphaValueIssue: We still have alpha value issue in
                   // out design-token, so we need to use the hex value
                   // here
-                  className="nodrag appearance-none !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular"
+                  className="nodrag nowheel appearance-none !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/NumbersField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/NumbersField.tsx
@@ -77,7 +77,7 @@ export const NumbersField = ({
                         type="number"
                         value={numberFieldsValue[idx] ?? undefined}
                         autoComplete="off"
-                        className="nodrag appearance-none text-semantic-fg-primary product-body-text-4-regular"
+                        className="nodrag nowheel appearance-none text-semantic-fg-primary product-body-text-4-regular"
                         onChange={(e) => {
                           const newNumberFieldsValue = [...numberFieldsValue];
                           newNumberFieldsValue[idx] = e.target.value;

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ObjectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/ObjectField.tsx
@@ -41,7 +41,7 @@ export const ObjectField = ({
                 {...field}
                 value={field.value ?? ""}
                 autoComplete="off"
-                className="nodrag !resize-y !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular focus-visible:!ring-1"
+                className="nodrag nowheel !resize-y !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular focus-visible:!ring-1"
                 disabled={disabled}
               />
             </Form.Control>

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextField.tsx
@@ -43,7 +43,7 @@ export const TextField = ({
                   type="text"
                   value={field.value ?? ""}
                   autoComplete="off"
-                  className="nodrag !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular"
+                  className="nodrag nowheel !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {
                       e.preventDefault();

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextareaField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextareaField.tsx
@@ -41,7 +41,7 @@ export const TextareaField = ({
                 {...field}
                 value={field.value ?? ""}
                 autoComplete="off"
-                className="nodrag !resize-y !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular focus-visible:!ring-1"
+                className="nodrag nowheel !resize-y !text-[#1D2433] !text-opacity-80 !product-body-text-3-regular focus-visible:!ring-1"
                 disabled={disabled}
               />
             </Form.Control>

--- a/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextsField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/start-operator-free-form-fields/TextsField.tsx
@@ -70,7 +70,7 @@ export const TextsField = ({
                     type="text"
                     value={textFieldsValue[0] ?? undefined}
                     autoComplete="off"
-                    className="nodrag text-semantic-fg-primary product-body-text-4-regular"
+                    className="nodrag nowheel text-semantic-fg-primary product-body-text-4-regular"
                     onChange={(e) => {
                       const newTextFieldsValue = [...textFieldsValue];
                       newTextFieldsValue[0] = e.target.value;
@@ -98,7 +98,7 @@ export const TextsField = ({
                         type="text"
                         value={textFieldsValue[idx + 1] ?? undefined}
                         autoComplete="off"
-                        className="nodrag text-semantic-fg-primary product-body-text-4-regular"
+                        className="nodrag nowheel text-semantic-fg-primary product-body-text-4-regular"
                         onChange={(e) => {
                           const newTextFieldsValue = [...textFieldsValue];
                           newTextFieldsValue[idx + 1] = e.target.value;

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeSortableFieldWrapper.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeSortableFieldWrapper.tsx
@@ -47,7 +47,7 @@ export const NodeSortableFieldWrapper = ({
       style={style}
       key={path}
       className={cn(
-        "nodrag group relative flex cursor-default flex-row gap-x-2 bg-semantic-bg-base-bg",
+        "nodrag nowheel group relative flex cursor-default flex-row gap-x-2 bg-semantic-bg-base-bg",
         isDragging ? "z-10" : ""
       )}
     >

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/UserDefinedFieldItem.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/UserDefinedFieldItem.tsx
@@ -92,7 +92,7 @@ export const UserDefinedFieldItem = ({
           </div>
         ) : null}
       </div>
-      <p className="nodrag rounded-sm border border-semantic-bg-line bg-semantic-bg-primary px-1.5 py-[9px] product-body-text-4-regular">
+      <p className="nodrag nowheel rounded-sm border border-semantic-bg-line bg-semantic-bg-primary px-1.5 py-[9px] product-body-text-4-regular">
         {fieldValue}
       </p>
     </div>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -517,7 +517,7 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
         />
       </NodeHead>
       {nodeIsCollapsed ? null : (
-        <div className="nodrag flex flex-col">
+        <div className="nodrag nowheel flex flex-col">
           {enableEdit ? (
             <StartOperatorNodeFreeForm
               form={form}


### PR DESCRIPTION
Because

- User can not wheel scroll up and down on the TextArea input in the pipeline-builder right now

This commit

- fix user can not wheel scroll up and down on TextArea
