### PR TITLE
fix: fix can not keydown enter on the TextArea field in pipeline builder

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
@@ -74,8 +74,8 @@ export function onInputKeydown({
       break;
     }
     case "Enter": {
-      event.preventDefault();
       if (enableSmartHints) {
+        event.preventDefault();
         if (filteredHints.length > 0) {
           if (inputRef.current) {
             const cursorPosition = inputRef.current.selectionStart;


### PR DESCRIPTION
Because

- User can not press enter and add an new line on TextArea field in pipeline-builder

This commit

- fix can not keydown enter on the TextArea field in pipeline builder
