### PR TITLE
feat(pipeline-builder): add collapseAllNodes pipeline-builder flag

### DIFF
--- a/packages/toolkit/src/lib/use-instill-store/pipelineBuilderSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/pipelineBuilderSlice.ts
@@ -37,7 +37,7 @@ export const pipelineBuilderInitialState: PipelineBuilderState = {
   connectorFormIsDirty: false,
   selectResourceDialogIsOpen: false,
   currentAdvancedConfigurationNodeID: null,
-  expandAllNodes: false,
+  collapseAllNodes: false,
   testModeEnabled: false,
   testModeTriggerResponse: null,
   pipelineOpenAPIOutputSchema: null,
@@ -172,11 +172,11 @@ export const createPipelineBuilderSlice: StateCreator<
         selectResourceDialogIsOpen: fn(state.selectResourceDialogIsOpen),
       };
     }),
-  updateExpandAllNodes: (fn: (prev: boolean) => boolean) =>
+  updateCollapseAllNodes: (fn: (prev: boolean) => boolean) =>
     set((state) => {
       return {
         ...state,
-        expandAllNodes: fn(state.expandAllNodes),
+        collapseAllNodes: fn(state.collapseAllNodes),
       };
     }),
   updateTestModeEnabled: (fn: (prev: boolean) => boolean) =>

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -35,7 +35,7 @@ export type PipelineBuilderState = {
   currentAdvancedConfigurationNodeID: Nullable<string>;
   connectorFormIsDirty: boolean;
   selectResourceDialogIsOpen: boolean;
-  expandAllNodes: boolean;
+  collapseAllNodes: boolean;
   testModeEnabled: boolean;
   testModeTriggerResponse: Nullable<TriggerUserPipelineResponse>;
   pipelineOpenAPIOutputSchema: Nullable<InstillJSONSchema>;
@@ -72,7 +72,7 @@ export type PipelineBuilderAction = {
   ) => void;
   updateConnectorFormIsDirty: (fn: (prev: boolean) => boolean) => void;
   updateSelectResourceDialogIsOpen: (fn: (prev: boolean) => boolean) => void;
-  updateExpandAllNodes: (fn: (prev: boolean) => boolean) => void;
+  updateCollapseAllNodes: (fn: (prev: boolean) => boolean) => void;
   updateTestModeEnabled: (fn: (prev: boolean) => boolean) => void;
   updateTestModeTriggerResponse: (
     fn: (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
@@ -53,6 +53,7 @@ const selector = (store: InstillStore) => ({
   currentVersion: store.currentVersion,
   accessToken: store.accessToken,
   enabledQuery: store.enabledQuery,
+  collapseAllNodes: store.collapseAllNodes,
 });
 
 export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
@@ -70,6 +71,7 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     pipelineIsReadOnly,
     accessToken,
     enabledQuery,
+    collapseAllNodes,
   } = useInstillStore(useShallow(selector));
 
   const { toast } = useToast();
@@ -85,6 +87,10 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     enabled: enabledQuery,
     accessToken,
   });
+
+  React.useEffect(() => {
+    setNodeIsCollapsed(collapseAllNodes);
+  }, [collapseAllNodes]);
 
   const { reset } = nodeIDEditorForm;
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
@@ -38,6 +38,7 @@ const selector = (store: InstillStore) => ({
   currentVersion: store.currentVersion,
   isTriggeringPipeline: store.isTriggeringPipeline,
   pipelineIsReadOnly: store.pipelineIsReadOnly,
+  collapseAllNodes: store.collapseAllNodes,
 });
 
 export type EndOperatorNodeFieldItem = {
@@ -65,7 +66,12 @@ export const EndOperatorNode = ({ data, id }: NodeProps<EndNodeData>) => {
     currentVersion,
     isTriggeringPipeline,
     pipelineIsReadOnly,
+    collapseAllNodes,
   } = useInstillStore(useShallow(selector));
+
+  React.useEffect(() => {
+    setNodeIsCollapsed(collapseAllNodes);
+  }, [collapseAllNodes]);
 
   const form = useForm<z.infer<typeof EndOperatorFreeFormSchema>>({
     resolver: zodResolver(EndOperatorFreeFormSchema),

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
@@ -46,6 +46,7 @@ const selector = (store: InstillStore) => ({
   updateCurrentAdvancedConfigurationNodeID:
     store.updateCurrentAdvancedConfigurationNodeID,
   pipelineIsReadOnly: store.pipelineIsReadOnly,
+  collapseAllNodes: store.collapseAllNodes,
 });
 
 export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
@@ -59,14 +60,18 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
     updatePipelineRecipeIsDirty,
     updateCurrentAdvancedConfigurationNodeID,
     pipelineIsReadOnly,
+    collapseAllNodes,
   } = useInstillStore(useShallow(selector));
 
   const { toast } = useToast();
 
   const [nodeIsCollapsed, setNodeIsCollapsed] = React.useState(false);
   const [noteIsOpen, setNoteIsOpen] = React.useState(false);
-
   const nodeIDEditorForm = useNodeIDEditorForm(id);
+
+  React.useEffect(() => {
+    setNodeIsCollapsed(collapseAllNodes);
+  }, [collapseAllNodes]);
 
   const { reset } = nodeIDEditorForm;
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -55,6 +55,7 @@ const selector = (store: InstillStore) => ({
   updatePipelineRecipeIsDirty: store.updatePipelineRecipeIsDirty,
   updateIsTriggeringPipeline: store.updateIsTriggeringPipeline,
   pipelineIsReadOnly: store.pipelineIsReadOnly,
+  collapseAllNodes: store.collapseAllNodes,
 });
 
 export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
@@ -76,6 +77,7 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
     updatePipelineRecipeIsDirty,
     updateIsTriggeringPipeline,
     pipelineIsReadOnly,
+    collapseAllNodes,
   } = useInstillStore(useShallow(selector));
 
   const { toast } = useToast();
@@ -91,6 +93,10 @@ export const StartOperatorNode = ({ data, id }: NodeProps<StartNodeData>) => {
     mode: "onChange",
     reValidateMode: "onChange",
   });
+
+  React.useEffect(() => {
+    setNodeIsCollapsed(collapseAllNodes);
+  }, [collapseAllNodes]);
 
   // When edit field, the input key is already the auto generated key
   const onEditFreeFormField = (key: string) => {


### PR DESCRIPTION
Because

- We need a global flag to toggle the node in the pipeline-builder

This commit

- add collapseAllNodes pipeline-builder flag
