### PR TITLE
feat(pipeline-builder): close advanced configuration right panel after delete current node

### DIFF
--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
@@ -131,8 +131,6 @@ export function pickSmartHintsFromAcceptFormats(
         continue;
       }
 
-      console.log(instillAcceptFormats, hint.instillFormat, "here");
-
       // Deal with direct match
       if (instillAcceptFormats.includes(hint.instillFormat)) {
         pickHints.push(hint);

--- a/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
@@ -97,8 +97,6 @@ export const useSmartHint = () => {
       }
     }
 
-    console.log("smartHints", smartHints);
-
     updateSmartHints(() => smartHints);
   }, [nodes, updateSmartHints]);
 };

--- a/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputReferenceHints.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputReferenceHints.tsx
@@ -15,7 +15,7 @@ export const ComponentOutputReferenceHints = ({
   componentID: string;
   outputSchema: Nullable<InstillJSONSchema>;
 }) => {
-  const [mode, setMode] =
+  const [mode] =
     React.useState<Required<PickComponentsFromReferenceHintsOptions["mode"]>>(
       "groupByFormat"
     );

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
@@ -178,49 +178,6 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     return edges.some((edge) => edge.source === id);
   }, [edges, id]);
 
-  function handleCopyNode() {
-    if (!data.component.connector_definition) {
-      return;
-    }
-
-    const nodePrefix = transformConnectorDefinitionIDToComponentIDPrefix(
-      data.component.connector_definition.id
-    );
-
-    // Generate a new component index
-    const nodeIndex = generateNewComponentIndex(
-      nodes.map((e) => e.id),
-      nodePrefix
-    );
-
-    const nodeID = `${nodePrefix}_${nodeIndex}`;
-
-    const newNodes: Node<NodeData>[] = [
-      ...nodes,
-      {
-        id: nodeID,
-        type: "connectorNode",
-        sourcePosition: Position.Left,
-        targetPosition: Position.Right,
-        position: { x: 0, y: 0 },
-        data,
-      },
-    ];
-    const newEdges = composeEdgesFromNodes(newNodes);
-    updateNodes(() => newNodes);
-    updateEdges(() => newEdges);
-    updatePipelineRecipeIsDirty(() => true);
-  }
-
-  function handleDeleteNode() {
-    const newNodes = nodes.filter((node) => node.id !== id);
-    const newEdges = composeEdgesFromNodes(newNodes);
-    updateEdges(() => newEdges);
-    updatePipelineRecipeIsDirty(() => true);
-    updateNodes(() => newNodes);
-    updateEdges(() => newEdges);
-  }
-
   const checkIsHidden = useCheckIsHidden("onNode");
 
   const { fields, form, ValidatorSchema, selectedConditionMap } =
@@ -309,9 +266,9 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
           />
         </div>
         <ConnectorOperatorControlPanel
+          nodeID={id}
+          nodeData={data}
           componentType={data.component.type}
-          handleCopyNode={handleCopyNode}
-          handleDeleteNode={handleDeleteNode}
           nodeIsCollapsed={nodeIsCollapsed}
           setNodeIsCollapsed={setNodeIsCollapsed}
           handleToggleNote={() => setNoteIsOpen((prev) => !prev)}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/operator-node/OperatorNode.tsx
@@ -1,14 +1,10 @@
 import * as React from "react";
-import { Node, NodeProps, Position } from "reactflow";
+import { NodeProps, Position } from "reactflow";
 import { Form, Icons, useToast } from "@instill-ai/design-system";
 
-import { NodeData, OperatorNodeData } from "../../../type";
+import { OperatorNodeData } from "../../../type";
 import { CustomHandle } from "../../CustomHandle";
-import {
-  generateNewComponentIndex,
-  transformConnectorDefinitionIDToComponentIDPrefix,
-  composeEdgesFromNodes,
-} from "../../../lib";
+import { composeEdgesFromNodes } from "../../../lib";
 import {
   GeneralRecord,
   InstillStore,
@@ -180,48 +176,6 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
     updatePipelineRecipeIsDirty(() => true);
   }
 
-  function handleCopyNode() {
-    if (!data.component.operator_definition) {
-      return;
-    }
-
-    const nodePrefix = transformConnectorDefinitionIDToComponentIDPrefix(
-      data.component.operator_definition.id
-    );
-
-    // Generate a new component index
-    const nodeIndex = generateNewComponentIndex(
-      nodes.map((e) => e.id),
-      nodePrefix
-    );
-
-    const nodeID = `${nodePrefix}_${nodeIndex}`;
-
-    const newNodes: Node<NodeData>[] = [
-      ...nodes,
-      {
-        id: nodeID,
-        type: "operatorNode",
-        sourcePosition: Position.Left,
-        targetPosition: Position.Right,
-        position: { x: 0, y: 0 },
-        data,
-      },
-    ];
-    const newEdges = composeEdgesFromNodes(newNodes);
-    updateNodes(() => newNodes);
-    updateEdges(() => newEdges);
-    updatePipelineRecipeIsDirty(() => true);
-  }
-
-  function handleDeleteNode() {
-    const newNodes = nodes.filter((node) => node.id !== id);
-    const newEdges = composeEdgesFromNodes(newNodes);
-    updateNodes(() => newNodes);
-    updateEdges(() => newEdges);
-    updatePipelineRecipeIsDirty(() => true);
-  }
-
   const { getValues, trigger } = form;
 
   useUpdaterOnNode({
@@ -269,9 +223,9 @@ export const OperatorNode = ({ data, id }: NodeProps<OperatorNodeData>) => {
           />
         </div>
         <ConnectorOperatorControlPanel
+          nodeID={id}
+          nodeData={data}
           componentType={data.component.type}
-          handleCopyNode={handleCopyNode}
-          handleDeleteNode={handleDeleteNode}
           nodeIsCollapsed={nodeIsCollapsed}
           setNodeIsCollapsed={setNodeIsCollapsed}
           handleToggleNote={() => setNoteIsOpen((prev) => !prev)}

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Menu.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Menu.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../pipeline-builder";
 
 const selector = (store: InstillStore) => ({
-  dialogSharePipelineIsOpen: store.dialogSharePipelineIsOpen,
   updateDialogSharePipelineIsOpen: store.updateDialogSharePipelineIsOpen,
 });
 
@@ -29,8 +28,9 @@ export const Menu = ({ pipeline, handleDeletePipeline }: MenuProps) => {
   const [deleteDialogIsOpen, setDeleteDialogIsOpen] = React.useState(false);
   const [cloneDialogIsOpen, setCloneDialogIsOpen] = React.useState(false);
 
-  const { dialogSharePipelineIsOpen, updateDialogSharePipelineIsOpen } =
-    useInstillStore(useShallow(selector));
+  const { updateDialogSharePipelineIsOpen } = useInstillStore(
+    useShallow(selector)
+  );
 
   return (
     <React.Fragment>

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -56,12 +56,16 @@ export const ViewPipeline = () => {
   }, [pipeline.isError, router]);
 
   const pipelineRelease = React.useMemo(() => {
-    if (pipeline.data?.releases && currentVersion) {
-      return pipeline.data.releases.find(
-        (release) => release.id === currentVersion
-      );
+    if (
+      !pipeline.isSuccess ||
+      !currentVersion ||
+      pipeline.data.releases.length === 0
+    ) {
+      return null;
     }
-    return pipeline.data;
+    return pipeline.data.releases.find(
+      (release) => release.id === currentVersion
+    );
   }, [pipeline.isSuccess, pipeline.data, currentVersion]);
 
   return (
@@ -76,15 +80,9 @@ export const ViewPipeline = () => {
         <div className="flex h-full w-[718px] flex-col gap-y-6 py-10 pr-10">
           <ReadOnlyPipelineBuilder
             pipelineName={pipeline.isSuccess ? pipeline.data.name : null}
-            recipe={
-              pipeline.isSuccess && pipelineRelease
-                ? pipelineRelease.recipe
-                : null
-            }
+            recipe={pipelineRelease?.recipe || pipeline.data?.recipe || null}
             metadata={
-              pipeline.isSuccess && pipelineRelease
-                ? pipelineRelease.metadata
-                : null
+              pipelineRelease?.metadata || pipeline.data?.metadata || null
             }
             className="h-[378px] w-full"
           />

--- a/packages/toolkit/src/view/settings/user/UserAPITokenTab.tsx
+++ b/packages/toolkit/src/view/settings/user/UserAPITokenTab.tsx
@@ -27,7 +27,7 @@ export const UserAPITokenTab = () => {
     if (apiTokens.isError) {
       router.push("/404");
     }
-  }, [apiTokens.error, router]);
+  }, [apiTokens.isError, router]);
 
   return (
     <Setting.TabRoot>

--- a/packages/toolkit/src/view/settings/user/UserProfileTab.tsx
+++ b/packages/toolkit/src/view/settings/user/UserProfileTab.tsx
@@ -79,7 +79,7 @@ export const UserProfileTab = () => {
     if (!me.isSuccess) return;
 
     reset(me.data);
-  }, [me.data, me.isSuccess, me.isError, reset]);
+  }, [me.data, me.isSuccess, me.isError, reset, router]);
 
   const updateAuthenticatedUser = useUpdateAuthenticatedUser();
 


### PR DESCRIPTION
Because

- close advanced configuration right panel after delete current node

This commit

- close advanced configuration right panel after delete current node
