### PR TITLE
chore: adapt new pipeline.owner and connector.owner data format

### DIFF
--- a/packages/toolkit/src/components/card-pipeline/Head.tsx
+++ b/packages/toolkit/src/components/card-pipeline/Head.tsx
@@ -64,7 +64,7 @@ export const Head = ({
     <div className="flex flex-row p-3">
       <div className="mr-auto flex flex-row gap-x-2">
         <EntityAvatar
-          src={pipeline.owner?.profile_avatar ?? null}
+          src={pipeline.owner?.profile?.avatar ?? null}
           className="h-8 w-8"
           entityName={ownerID}
           fallbackImg={

--- a/packages/toolkit/src/components/card-pipeline/Head.tsx
+++ b/packages/toolkit/src/components/card-pipeline/Head.tsx
@@ -1,7 +1,10 @@
+import * as React from "react";
 import { useRouter } from "next/router";
 import {
   InstillStore,
+  OrganizationOwner,
   Pipeline,
+  UserOwner,
   toastInstillError,
   useDeleteUserPipeline,
   useInstillStore,
@@ -60,11 +63,26 @@ export const Head = ({
     }
   }
 
+  const pipelineAvatar = React.useMemo(() => {
+    if (pipeline.owner_name.split("/")[0] === "users") {
+      return (pipeline.owner as UserOwner).user.profile?.avatar ?? null;
+    }
+
+    if (pipeline.owner_name.split("/")[0] === "organizations") {
+      return (
+        (pipeline.owner as OrganizationOwner).organization.profile?.avatar ??
+        null
+      );
+    }
+
+    return null;
+  }, [pipeline]);
+
   return (
     <div className="flex flex-row p-3">
       <div className="mr-auto flex flex-row gap-x-2">
         <EntityAvatar
-          src={pipeline.owner?.profile?.avatar ?? null}
+          src={pipelineAvatar}
           className="h-8 w-8"
           entityName={ownerID}
           fallbackImg={

--- a/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 
-import { Spec } from "../types";
+import { Owner, Spec } from "../types";
 
 export type ConnectorState =
   | "STATE_CONNECTED"
@@ -36,6 +36,7 @@ export type Connector = {
   create_time: string;
   update_time: string;
   visibility: ConnectorVisibility;
+  owner: Owner;
 };
 
 export type ConnectorWithDefinition = Omit<

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -2,9 +2,11 @@
 
 import { OpenAPIV3 } from "openapi-types";
 import { ConnectorDefinition, Connector } from "../connector";
-import { Permission, Spec, Visibility } from "../types";
+import { Owner, Permission, Spec, Visibility } from "../types";
 import { GeneralRecord, Nullable } from "../../type";
 import { JSONSchema7TypeName } from "json-schema";
+import { User } from "../mgmt";
+import { Organization } from "../organization";
 
 export type PipelineMode = "MODE_UNSPECIFIED" | "MODE_SYNC" | "MODE_ASYNC";
 
@@ -59,7 +61,7 @@ export type Pipeline = {
   update_time: string;
   recipe: PipelineRecipe;
   openapi_schema: OpenAPIV3.Document;
-  owner: Record<string, any>;
+  owner: Owner;
   owner_name: string;
   releases: PipelineRelease[];
   sharing: PipelineSharing;

--- a/packages/toolkit/src/lib/vdp-sdk/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/types.ts
@@ -4,6 +4,8 @@ import { ModelState } from "./model";
 import { OpenAPIV3 } from "openapi-types";
 import { PipelineReleaseState } from "./pipeline";
 import { InstillJSONSchema } from "../use-instill-form";
+import { User } from "./mgmt";
+import { Organization } from "./organization";
 
 export type ErrorDetails = {
   "@type": string;
@@ -55,3 +57,5 @@ export type StripeSubscriptionStatus =
   | "STATUS_CANCELED"
   | "STATUS_UNPAID"
   | "STATUS_PAUSED";
+
+export type Owner = User | Organization;

--- a/packages/toolkit/src/lib/vdp-sdk/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/types.ts
@@ -58,4 +58,12 @@ export type StripeSubscriptionStatus =
   | "STATUS_UNPAID"
   | "STATUS_PAUSED";
 
-export type Owner = User | Organization;
+export type UserOwner = {
+  user: User;
+};
+
+export type OrganizationOwner = {
+  organization: Organization;
+};
+
+export type Owner = UserOwner | OrganizationOwner;

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
@@ -3,7 +3,9 @@ import { Button, Icons, Separator, useToast } from "@instill-ai/design-system";
 import {
   InstillStore,
   Nullable,
+  OrganizationOwner,
   UpdateUserPipelinePayload,
+  UserOwner,
   env,
   getInstillApiErrorMessage,
   sendAmplitudeData,
@@ -163,6 +165,25 @@ export const TabShare = () => {
     amplitudeIsInit,
   ]);
 
+  const pipelineAvatar = React.useMemo(() => {
+    if (!pipeline.isSuccess) {
+      return null;
+    }
+
+    if (pipeline.data.owner_name.split("/")[0] === "users") {
+      return (pipeline.data.owner as UserOwner).user.profile?.avatar ?? null;
+    }
+
+    if (pipeline.data.owner_name.split("/")[0] === "organizations") {
+      return (
+        (pipeline.data.owner as OrganizationOwner).organization.profile
+          ?.avatar ?? null
+      );
+    }
+
+    return null;
+  }, [pipeline.isSuccess, pipeline.data]);
+
   return (
     <div className="flex h-full w-full flex-col px-6 py-3">
       <div className="flex flex-row">
@@ -184,7 +205,7 @@ export const TabShare = () => {
       <div className="flex flex-row">
         <div className="mr-auto flex flex-row gap-x-2">
           <EntityAvatar
-            src={pipeline.data?.owner?.profile?.avatar ?? null}
+            src={pipelineAvatar}
             entityName={pipeline.data?.owner_name ?? ""}
             className="h-[30px] w-[30px]"
             fallbackImg={

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
@@ -184,7 +184,7 @@ export const TabShare = () => {
       <div className="flex flex-row">
         <div className="mr-auto flex flex-row gap-x-2">
           <EntityAvatar
-            src={pipeline.data?.owner?.profile_avatar ?? null}
+            src={pipeline.data?.owner?.profile?.avatar ?? null}
             entityName={pipeline.data?.owner_name ?? ""}
             className="h-[30px] w-[30px]"
             fallbackImg={


### PR DESCRIPTION
Because

- The old owner field is a struct, which is not type-safe. In this sprint, backend adapt new protobuf to make this field has more type safety

This commit

- adapt new pipeline.owner and connector.owner data format
