### PR TITLE
fix(pipeline-builder): fix component output hint's type is not correct

### DIFF
--- a/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/useSmartHint.ts
@@ -44,7 +44,7 @@ export const useSmartHint = () => {
             {
               path: `${node.id}.output`,
               key: "output",
-              instillFormat: "null",
+              instillFormat: "semi-structured/json",
               type: "object",
               properties: [],
             },
@@ -86,7 +86,7 @@ export const useSmartHint = () => {
             {
               path: `${node.id}.output`,
               key: "output",
-              instillFormat: "null",
+              instillFormat: "semi-structured/json",
               type: "object",
               properties: [],
             },


### PR DESCRIPTION
Because

- When display the `component.output`, we display its type as null. Which is not correct, it should be `semi-structured/json`

This commit

- fix component output hint type is not correct
