### PR TITLE
fix: fix iterator not correctly hint the output user can select

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
@@ -32,13 +32,16 @@ export const IteratorOutput = () => {
         </p>
       </div>
       <div className="mb-2 flex flex-col gap-y-2">
-        <OutputSet outputKey="result_0" disabledDeleteButton={true} />
         {targetIteratorNode?.data.iterator_component.output_elements
           ? Object.entries(
               targetIteratorNode?.data.iterator_component.output_elements
-            )
-              .filter(([key]) => key !== "result_0")
-              .map(([key]) => <OutputSet key={key} outputKey={key} />)
+            ).map(([key]) => (
+              <OutputSet
+                key={key}
+                outputKey={key}
+                disabledDeleteButton={key === "result_0"}
+              />
+            ))
           : null}
       </div>
       <AddOutputButton targetIteratorNode={targetIteratorNode} />

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
@@ -35,18 +35,16 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
 
   const availableOutputOptions = React.useMemo(() => {
     // User can only set the output from the iterator's components
-    const smartHints = pickSmartHintsFromNodes({
+    const hints = pickSmartHintsFromNodes({
       nodes,
       includeEditorElement: false,
     });
 
-    return smartHints
-      .filter((hint) => hint.instillFormat.includes("array:"))
-      .map((hint) => ({
-        path: hint.path,
-        instill_format: hint.instillFormat,
-        description: hint.description,
-      }));
+    return hints.map((hint) => ({
+      path: hint.path,
+      instill_format: hint.instillFormat,
+      description: hint.description,
+    }));
   }, [nodes]);
 
   React.useEffect(() => {

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useConstructNodeFromDefinition.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useConstructNodeFromDefinition.tsx
@@ -117,7 +117,10 @@ export function useConstructNodeFromDefinition({
               id: nodeID,
               iterator_component: {
                 input: "",
-                output_elements: {},
+                output_elements: {
+                  // This is the default output element
+                  result_0: "",
+                },
                 components: [],
                 condition: null,
                 data_specification: {


### PR DESCRIPTION
Because

- In the previous implementation, user can only select array type in the iterator's output_element, this is not correct. User can select any data to put into output_element

This commit

- fix iterator not correctly hint the output user can select
