### PR TITLE
fix: hint semi-structured as input on iterator

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
@@ -40,10 +40,15 @@ export const IteratorInput = ({ className }: { className?: string }) => {
 
     const hints = pickSmartHintsFromNodes({
       nodes: tempSavedNodesForEditingIteratorFlow,
+      isEditingIterator: true,
     });
 
     return hints
-      .filter((hint) => hint.instillFormat.includes("array:"))
+      .filter(
+        (hint) =>
+          hint.instillFormat.includes("array:") ||
+          hint.instillFormat.includes("semi-structured")
+      )
       .map((hint) => ({
         path: hint.path,
         instill_format: hint.instillFormat,


### PR DESCRIPTION
Because

- iterator's input can also accept semi-structured/* type

This commit

- hint semi-structured as input on iterator
