### PR TITLE
fix(pipeline-builder): fix console not correctly replace null with undefined when update the recipe

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.83.0-rc.5",
+  "version": "0.83.0-rc.7",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/SelectComponentDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/SelectComponentDialog.tsx
@@ -43,7 +43,7 @@ export const SelectComponentDialog = ({
             variant="primary"
             size="lg"
           >
-            Connector
+            Component
             <Icons.Plus
               className={cn(
                 "h-4 w-4",

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
@@ -109,7 +109,7 @@ export const IteratorEditor = ({
         </Button>
         <Icons.ChevronRight className="h-4 w-4 stroke-semantic-fg-disabled" />
         <Button size="md" variant="secondaryColour">
-          Iterator
+          {editingIteratorID}
         </Button>
       </div>
       <Separator className="mb-2" orientation="horizontal" />

--- a/packages/toolkit/src/view/pipeline-builder/lib/constructPipelineRecipe.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/constructPipelineRecipe.tsx
@@ -45,8 +45,10 @@ export function constructPipelineRecipe(
           connector_name: removeConnectorName
             ? ""
             : component.connector_component.connector_name,
-          input: recursiveHelpers.parseToNum(
-            structuredClone(component.connector_component.input)
+          input: recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
+            recursiveHelpers.parseToNum(
+              structuredClone(component.connector_component.input)
+            )
           ),
           definition: null,
           connector: null,
@@ -60,8 +62,10 @@ export function constructPipelineRecipe(
       id: component.id,
       operator_component: {
         ...component.operator_component,
-        input: recursiveHelpers.parseToNum(
-          structuredClone(component.operator_component.input)
+        input: recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
+          recursiveHelpers.parseToNum(
+            structuredClone(component.operator_component.input)
+          )
         ),
         definition: null,
       },

--- a/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceNullAndEmptyStringWithUndefined.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceNullAndEmptyStringWithUndefined.ts
@@ -1,6 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 
-type RecursiveReplaceNullAndEmptyStringWithUndefined<T> = T extends null
+export type RecursiveReplaceNullAndEmptyStringWithUndefined<T> = T extends null
   ? undefined
   : T extends (infer U)[]
     ? RecursiveReplaceNullAndEmptyStringWithUndefined<U>[]


### PR DESCRIPTION
Because

- Every component's input can only accept undefined as empty value

This commit

- fix console not correctly replace null with undefined when update the recipe
