### PR TITLE
fix(pipeline-builder): fix render bug caused by mis-align of smart hint and output rendering

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/TextsField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/TextsField.tsx
@@ -12,6 +12,8 @@ export type TextsFieldProps = {
 export const TextsField = (props: TextsFieldProps) => {
   const { title, texts, hideField } = props;
 
+  console.log(props.texts);
+
   const normalizedTexts = texts?.map((text) => String(text));
 
   return (

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -48,15 +48,15 @@ export function pickComponentOutputFieldsFromInstillFormTree(
     }
   } else if (tree._type === "formItem") {
     if (tree.path) {
-      if (tree.instillFormat?.includes("array:")) {
-        propertyValue = data;
-      } else {
-        propertyValue = data ? dot.getter(data, tree.path) ?? null : null;
-      }
+      propertyValue = data ? dot.getter(data, tree.path) ?? null : null;
     }
   } else if (tree._type === "arrayArray") {
     if (tree.fieldKey) {
-      propertyValue = data ? data[tree.fieldKey] : null;
+      propertyValue = data
+        ? Array.isArray(data[tree.fieldKey])
+          ? data[tree.fieldKey]
+          : null
+        : null;
     } else {
       propertyValue = null;
     }
@@ -141,14 +141,16 @@ export function pickComponentOutputFieldsFromInstillFormTree(
   if (tree._type === "arrayArray") {
     const arrayArrayData = propertyValue as GeneralRecord[];
 
-    return arrayArrayData ? (
+    return propertyValue && Array.isArray(arrayArrayData) ? (
       <div key={tree.path || tree.fieldKey} className="flex flex-col gap-y-2">
         {arrayArrayData.map((data, idx) => {
+          console.log("datas", data, tree);
           return pickComponentOutputFieldsFromInstillFormTree({
             ...props,
             tree: tree.items,
-            data: data,
-            objectArrayIndex: idx,
+            data: {
+              [tree.fieldKey as string]: data,
+            },
           });
         })}
       </div>

--- a/packages/toolkit/src/lib/use-instill-form/useComponentOutputFields.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useComponentOutputFields.tsx
@@ -29,6 +29,8 @@ export function useComponentOutputFields({
 
     const outputFormTree = transformInstillJSONSchemaToFormTree(schema);
 
+    console.log(outputFormTree);
+
     const fields = pickComponentOutputFieldsFromInstillFormTree({
       tree: outputFormTree,
       data,


### PR DESCRIPTION


Because

- fix render bug caused by mis-align of smart hint and output rendering

This commit

- fix render bug caused by mis-align of smart hint and output rendering
