### PR TITLE
fix(pipeline-builder): adapt backend return data_specification can be null

### DIFF
--- a/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickOutputReferenceHintsFromComponent.tsx
+++ b/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickOutputReferenceHintsFromComponent.tsx
@@ -88,7 +88,7 @@ export function pickOutputReferenceHintsFromComponent({
       );
     } else {
       const outputSchema =
-        component.iterator_component.data_specification.output;
+        component.iterator_component.data_specification?.output;
 
       if (outputSchema) {
         const outputFormTree =

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -202,7 +202,7 @@ export type PipelineIteratorComponent = {
     output_elements: Record<string, string>;
     components: PipelineComponent[];
     condition: Nullable<string>;
-    data_specification: DataSpecification;
+    data_specification: Nullable<DataSpecification>;
   };
 };
 

--- a/packages/toolkit/src/lib/vdp-sdk/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/types.ts
@@ -29,7 +29,7 @@ export type DataSpecification = {
 export type Spec = {
   resource_specification: InstillJSONSchema;
   component_specification: InstillJSONSchema;
-  data_specifications: Record<string, DataSpecification>;
+  data_specifications: Nullable<Record<string, DataSpecification>>;
 };
 
 export type Visibility =

--- a/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
@@ -81,7 +81,7 @@ export const PipelineBuilderMainView = () => {
     if (!pipeline.isSuccess) return;
 
     updatePipelineOpenAPIOutputSchema(
-      () => pipeline.data.data_specification.output as InstillJSONSchema
+      () => pipeline.data.data_specification?.output ?? null
     );
   }, [pipeline.isSuccess, pipeline.data, updatePipelineOpenAPIOutputSchema]);
 

--- a/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.ts
@@ -150,7 +150,8 @@ function getAvailableReferences(components: PipelineComponent[]) {
     let outputSchema: Nullable<InstillJSONSchema> = null;
 
     if (isIteratorComponent(component)) {
-      outputSchema = component.iterator_component.data_specification.output;
+      outputSchema =
+        component.iterator_component.data_specification?.output ?? null;
     }
 
     if (isOperatorComponent(component)) {

--- a/packages/toolkit/src/view/pipeline-builder/lib/getConnectorInputOutputSchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getConnectorInputOutputSchema.ts
@@ -28,6 +28,7 @@ export function getConnectorInputOutputSchema(
   // definition is not support anymore. Console need to check this.
   if (
     targetTask &&
+    component?.connector_component.definition?.spec.data_specifications &&
     component?.connector_component.definition?.spec.data_specifications[
       targetTask
     ]
@@ -54,10 +55,12 @@ export function getConnectorInputOutputSchema(
       return { outputSchema, inputSchema };
     }
 
-    inputSchema = inputSchema = component?.connector_component.definition?.spec
-      .data_specifications[defaultTask].input as InstillJSONSchema;
-    outputSchema = inputSchema = component?.connector_component.definition?.spec
-      .data_specifications[defaultTask].output as InstillJSONSchema;
+    if (component?.connector_component.definition?.spec.data_specifications) {
+      inputSchema = component?.connector_component.definition?.spec
+        .data_specifications[defaultTask].input as InstillJSONSchema;
+      outputSchema = component?.connector_component.definition?.spec
+        .data_specifications[defaultTask].output as InstillJSONSchema;
+    }
   }
 
   return { outputSchema, inputSchema };

--- a/packages/toolkit/src/view/pipeline-builder/lib/getOperatorInputOutputSchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getOperatorInputOutputSchema.ts
@@ -28,6 +28,7 @@ export function getOperatorInputOutputSchema(
   // definition is not support anymore. Console need to check this.
   if (
     targetTask &&
+    component?.operator_component.definition?.spec.data_specifications &&
     component?.operator_component.definition?.spec.data_specifications[
       targetTask
     ]
@@ -54,10 +55,12 @@ export function getOperatorInputOutputSchema(
       return { outputSchema, inputSchema };
     }
 
-    inputSchema = component?.operator_component.definition?.spec
-      .data_specifications[defaultTask].input as InstillJSONSchema;
-    outputSchema = component?.operator_component.definition?.spec
-      .data_specifications[defaultTask].output as InstillJSONSchema;
+    if (component?.operator_component.definition?.spec.data_specifications) {
+      inputSchema = component?.operator_component.definition?.spec
+        .data_specifications[defaultTask].input as InstillJSONSchema;
+      outputSchema = component?.operator_component.definition?.spec
+        .data_specifications[defaultTask].output as InstillJSONSchema;
+    }
   }
 
   return { outputSchema, inputSchema };

--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -302,9 +302,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
           ) : (
             <ComponentOutputs
               componentID="end"
-              outputSchema={
-                pipeline.data.data_specification.output as InstillJSONSchema
-              }
+              outputSchema={pipeline.data.data_specification?.output ?? null}
               nodeType="end"
               chooseTitleFrom="title"
               response={response}


### PR DESCRIPTION
Because

- adapt backend return data_specification can be null

This commit

- adapt backend return data_specification can be null
