### PR TITLE
fix(ci): fix workflow that trigger e2e in instill-core

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -37,39 +37,15 @@ jobs:
           cache-from: type=registry,ref=instill/console:buildcache
           cache-to: type=registry,ref=instill/console:buildcache,mode=max
 
-  base:
+  backends:
     needs: build-push-image
     if: github.ref == 'refs/heads/main'
-    name: Base Backends
+    name: Backends
     strategy:
       fail-fast: false
       matrix:
-        component: [mgmt-backend]
-    uses: instill-ai/base/.github/workflows/integration-test-backend.yml@main
-    with:
-      component: ${{ matrix.component }}
-      target: latest
-  vdp:
-    needs: build-push-image
-    if: github.ref == 'refs/heads/main'
-    name: VDP Backends
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [pipeline-backend, controller-vdp]
-    uses: instill-ai/vdp/.github/workflows/integration-test-backend.yml@main
-    with:
-      component: ${{ matrix.component }}
-      target: latest
-  model:
-    needs: build-push-image
-    if: github.ref == 'refs/heads/main'
-    name: Model Backends
-    strategy:
-      fail-fast: false
-      matrix:
-        component: [model-backend, controller-model]
-    uses: instill-ai/model/.github/workflows/integration-test-backend.yml@main
+        component: [pipeline-backend]
+    uses: instill-ai/instill-core/.github/workflows/integration-test-backend.yml@main
     with:
       component: ${{ matrix.component }}
       target: latest
@@ -77,11 +53,11 @@ jobs:
     needs: build-push-image
     if: github.ref == 'refs/heads/main'
     name: Console
-    uses: instill-ai/base/.github/workflows/integration-test-console.yml@main
+    uses: instill-ai/instill-core/.github/workflows/integration-test-console.yml@main
     with:
       target: latest
 
-  pr-head:
+  pr-head:z
     if: github.event_name == 'pull_request'
     name: PR head branch
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because

- There are old workflow from old VDP repo being triggered. We should trigger the new workflow instead

This commit

- fix workflow that trigger e2e in instill-core
