### PR TITLE
feat(pipeline-builder): support connecting edges for reference with square brace

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -57,7 +57,7 @@ jobs:
     with:
       target: latest
 
-  pr-head:z
+  pr-head:
     if: github.event_name == 'pull_request'
     name: PR head branch
     runs-on: ubuntu-latest

--- a/docs/test-coverage-list.md
+++ b/docs/test-coverage-list.md
@@ -1,0 +1,17 @@
+# Test coverage list
+
+This list is to estabilish a semantic meaning toward the unit/e2e test coverage
+
+## Unit test
+
+- [x] **pipeline-builder:** generate edges from given components [test](../packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.test.ts)
+
+## E2E test
+
+- [x] Create Pipeline
+- [x] Delete Pipeline
+- [x] Delete Connector
+- [x] **pipeline-builder:** should correctly change component's ID [test](../apps/console/integration-test/tests/should-change-component-id.test.ts)
+- [x] **pipeline-builder:** should correctly unmarshal input when trigger the pipeline [test](../apps/console/integration-test/tests/should-unmarshal.test.ts)
+- [x] **pipeline-builder:** should correctly create/edit fields in start and end operator [test](../apps/console/integration-test/tests/should-edit-create-start-end-field.test.ts)
+  - missing: delete fields in start and end operator

--- a/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.test.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.test.ts
@@ -1,0 +1,166 @@
+import { test, expect } from "vitest";
+import { PipelineComponent } from "../../../lib";
+import { composeEdgesFromComponents } from "./composeEdgesFromComponents";
+
+test("should get edges from basic components", () => {
+  const components: PipelineComponent[] = [
+    {
+      id: "start",
+      start_component: {
+        fields: {
+          texts: {
+            instill_format: "array:string",
+            title: "texts",
+            description: "",
+          },
+        },
+      },
+    },
+    {
+      id: "end",
+      end_component: {
+        fields: {
+          result: {
+            title: "result",
+            description: "",
+            value: "${start.texts}",
+          },
+        },
+      },
+    },
+  ];
+
+  const edges = composeEdgesFromComponents(components);
+
+  expect(edges[0].source).toBe("start");
+  expect(edges[0].target).toBe("end");
+
+  const wrongComponents: PipelineComponent[] = [
+    {
+      id: "start",
+      start_component: {
+        fields: {
+          texts: {
+            instill_format: "array:string",
+            title: "texts",
+            description: "",
+          },
+        },
+      },
+    },
+    {
+      id: "end",
+      end_component: {
+        fields: {
+          result: {
+            title: "result",
+            description: "",
+            value: "${foo.texts}",
+          },
+        },
+      },
+    },
+  ];
+
+  const wrongComponentsEdges = composeEdgesFromComponents(wrongComponents);
+
+  expect(wrongComponentsEdges.length).toBe(0);
+});
+
+test("should strictly check the reference field exist", () => {
+  const components: PipelineComponent[] = [
+    {
+      id: "start",
+      start_component: {
+        fields: {
+          texts: {
+            instill_format: "array:string",
+            title: "texts",
+            description: "",
+          },
+        },
+      },
+    },
+    {
+      id: "end",
+      end_component: {
+        fields: {
+          result: {
+            title: "result",
+            description: "",
+            value: "${start.foo}",
+          },
+        },
+      },
+    },
+  ];
+
+  const edges = composeEdgesFromComponents(components);
+
+  expect(edges.length).toBe(0);
+});
+
+test("should loosely check the reference field exist when reference has square brace", () => {
+  const components: PipelineComponent[] = [
+    {
+      id: "start",
+      start_component: {
+        fields: {
+          texts: {
+            instill_format: "array:string",
+            title: "texts",
+            description: "",
+          },
+        },
+      },
+    },
+    {
+      id: "end",
+      end_component: {
+        fields: {
+          result: {
+            title: "result",
+            description: "",
+            value: "${start['foo bar']['aaa']}",
+          },
+        },
+      },
+    },
+  ];
+
+  const edges = composeEdgesFromComponents(components);
+
+  expect(edges[0].source).toBe("start");
+  expect(edges[0].target).toBe("end");
+
+  const wrongComponents: PipelineComponent[] = [
+    {
+      id: "start",
+      start_component: {
+        fields: {
+          texts: {
+            instill_format: "array:string",
+            title: "texts",
+            description: "",
+          },
+        },
+      },
+    },
+    {
+      id: "end",
+      end_component: {
+        fields: {
+          result: {
+            title: "result",
+            description: "",
+            value: "${foo['foo bar']['aaa']}",
+          },
+        },
+      },
+    },
+  ];
+
+  const wrongComponentsEdges = composeEdgesFromComponents(wrongComponents);
+
+  expect(wrongComponentsEdges.length).toBe(0);
+});

--- a/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromComponents.ts
@@ -209,8 +209,12 @@ function composeEdgeForReference({
 }) {
   const newEdges: Edge[] = [];
 
+  console.log(reference);
+
   // check whether the referenced target is available for start operator
-  if (reference.referenceValue.withoutCurlyBraces.split(".")[0] === "start") {
+  if (
+    reference.referenceValue.withoutCurlyBraces.split(".")[0].includes("start")
+  ) {
     const referenceIsAvailable = startNodeAvailableRefernces.some(
       (availableReference) =>
         checkReferenceIsAvailable(
@@ -236,6 +240,7 @@ function composeEdgeForReference({
 
     // Here is for other nodes
   } else {
+    console.log("otherNodesAvailableReferences", otherNodesAvailableReferences);
     const referenceIsAvailable = otherNodesAvailableReferences.some(
       (availableReference) =>
         checkReferenceIsAvailable(
@@ -270,6 +275,19 @@ function checkReferenceIsAvailable(
   availableReference: string
 ): boolean {
   const referenceValueWithoutArray = value.replaceAll(/\[[^\]]+\]/g, "");
+
+  // Once a value includes [], we will loosely check the reference.
+  // For example, we will connect st_1.output["Foo"], even st_1 don't have
+  // Foo field
+  if (value.includes("[") || value.includes("]")) {
+    const valueComponentID = referenceValueWithoutArray.split(".")[0];
+    const avaiableReferenceComponentID = availableReference.split(".")[0];
+    if (valueComponentID === avaiableReferenceComponentID) {
+      return true;
+    }
+
+    return false;
+  }
 
   if (availableReference === referenceValueWithoutArray) {
     return true;

--- a/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromString.test.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromString.test.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "vitest";
+import { getReferencesFromString } from "./getReferencesFromString";
+
+test("should get reference from basic string", () => {
+  const value = "${hello.world}";
+
+  const references = getReferencesFromString(value);
+
+  expect(references).toStrictEqual([
+    {
+      originalValue: value,
+      referenceValue: {
+        withCurlyBraces: value,
+        withoutCurlyBraces: "hello.world",
+      },
+    },
+  ]);
+});
+
+test("should not get reference from basic string without correct syntax", () => {
+  const valueWithoutDollar = "{hello.world}";
+  expect(getReferencesFromString(valueWithoutDollar)).toStrictEqual([]);
+  const valueWithoutCurlyBrace = "$hello.world";
+  expect(getReferencesFromString(valueWithoutCurlyBrace)).toStrictEqual([]);
+  const valueWithBrokenCurlyBrace = "${hello.world";
+  expect(getReferencesFromString(valueWithBrokenCurlyBrace)).toStrictEqual([]);
+});
+
+test("should get reference from string with space", () => {
+  const value = "${hello world}";
+
+  const references = getReferencesFromString(value);
+
+  expect(references).toStrictEqual([
+    {
+      originalValue: value,
+      referenceValue: {
+        withCurlyBraces: value,
+        withoutCurlyBraces: "hello world",
+      },
+    },
+  ]);
+});
+
+test("should get reference from string with square brace", () => {
+  const value = "${foo.output['yolo']}";
+
+  const references = getReferencesFromString(value);
+
+  expect(references).toStrictEqual([
+    {
+      originalValue: value,
+      referenceValue: {
+        withCurlyBraces: value,
+        withoutCurlyBraces: "foo.output['yolo']",
+      },
+    },
+  ]);
+});
+
+test("should get reference from string with multiple square brace", () => {
+  const value = "${foo.output['yolo']['bar']}";
+
+  const references = getReferencesFromString(value);
+
+  expect(references).toStrictEqual([
+    {
+      originalValue: value,
+      referenceValue: {
+        withCurlyBraces: value,
+        withoutCurlyBraces: "foo.output['yolo']['bar']",
+      },
+    },
+  ]);
+});
+
+test("should get reference from string with space in square brace", () => {
+  const value = "${foo.output['yolo bar']}";
+
+  const references = getReferencesFromString(value);
+
+  expect(references).toStrictEqual([
+    {
+      originalValue: value,
+      referenceValue: {
+        withCurlyBraces: value,
+        withoutCurlyBraces: "foo.output['yolo bar']",
+      },
+    },
+  ]);
+});

--- a/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromString.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromString.ts
@@ -2,7 +2,7 @@ import { InstillReference } from "../type";
 
 export function getReferencesFromString(value: string): InstillReference[] {
   const dollarBraceReferences: InstillReference[] = [];
-  const dollarBraceRegex = /\$\{\s*([^}\s]+)\s*\}/gm;
+  const dollarBraceRegex = /\$\{\s*([^}]+)\s*\}/gm;
   const dollarBraceMatches = String(value).match(dollarBraceRegex);
 
   if (dollarBraceMatches) {


### PR DESCRIPTION
Because

- We are going to support connecting references like `start["texts"]`, `st_0.output["foo"]`

This commit

- support connecting edges for reference with square brace
