### PR TITLE
fix: fix unsaved guard of pipeline-builder didnt navigate user to the page they want to go

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
@@ -160,7 +160,10 @@ export const PipelineBuilderMainView = () => {
               initPipelineBuilder();
               confirmNavigation();
             }}
-            onSave={savePipeline}
+            onSave={async () => {
+              await savePipeline();
+              confirmNavigation();
+            }}
           />
         </div>
       </PageBase.Container>


### PR DESCRIPTION

Because

- fix unsaved guard of pipeline-builder didnt navigate user to the page they want to go

This commit

- fix unsaved guard of pipeline-builder didnt navigate user to the page they want to go
