### PR TITLE
fix: fix not correctly block create pipeline action when entity is missing

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -90,29 +90,43 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
     accessToken,
   });
 
-  const organizations = useUserMemberships({
+  const userMemberships = useUserMemberships({
     enabled: entity.isSuccess,
     userID: me.isSuccess ? me.data.id : null,
     accessToken,
   });
 
   const organizationsAndUserList = React.useMemo(() => {
-    const orgsAndUserList = [];
-    if (organizations.isSuccess && organizations.data) {
-      organizations.data.forEach((org) => {
-        orgsAndUserList.push(org.organization);
-      });
+    if (!userMemberships.isSuccess || !entity.isSuccess) {
+      return [];
     }
-    if (entity.isSuccess && entity.data.entity) {
+
+    const orgsAndUserList: {
+      id: string;
+      name: string;
+      type: "user" | "organization";
+    }[] = [];
+
+    userMemberships.data.forEach((org) => {
+      orgsAndUserList.push({
+        id: org.organization.id,
+        name: org.organization.name,
+        type: "organization",
+      });
+    });
+
+    if (entity.data.entity && entity.data.entityName) {
       orgsAndUserList.push({
         id: entity.data.entity,
         name: entity.data.entityName,
+        type: "user",
       });
     }
+
     return orgsAndUserList;
   }, [
-    organizations.isSuccess,
-    organizations.data,
+    userMemberships.isSuccess,
+    userMemberships.data,
     entity.isSuccess,
     entity.data,
   ]);
@@ -276,15 +290,10 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
                                               : field.value}
                                           </span>
                                           <span className="my-auto">
-                                            {organizationsAndUserList?.length &&
-                                            organizationsAndUserList
-                                              ?.find(
-                                                (namespace) =>
-                                                  namespace.id === field.value
-                                              )
-                                              ?.name?.includes(
-                                                "organizations"
-                                              ) ? (
+                                            {organizationsAndUserList.find(
+                                              (namespace) =>
+                                                namespace.id === field.value
+                                            )?.type === "organization" ? (
                                               <Tag
                                                 variant="lightBlue"
                                                 size="sm"
@@ -319,9 +328,8 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
                                                     {namespace.id}
                                                   </span>
                                                   <span className="my-auto">
-                                                    {namespace.name?.includes(
-                                                      "organizations"
-                                                    ) ? (
+                                                    {namespace.type ===
+                                                    "organization" ? (
                                                       <Tag
                                                         variant="lightBlue"
                                                         size="sm"
@@ -483,7 +491,7 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
 
             <div className="flex flex-row-reverse px-6 pb-6 pt-8">
               <Button
-                disabled={creating}
+                disabled={creating || organizationsAndUserList.length === 0}
                 form={formID}
                 variant="primary"
                 size="lg"

--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -212,7 +212,7 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
     } else {
       setCreating(false);
       toastInstillError({
-        title: "Failed to create pipeline",
+        title: "Please choose a valid namespace to create your pipeline",
         error: null,
         toast,
       });

--- a/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../../components";
 import { CreatePipelineDialog } from "./CreatePipelineDialog";
 import debounce from "lodash.debounce";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 
 const selector = (store: InstillStore) => ({
   accessToken: store.accessToken,
@@ -35,8 +35,8 @@ export const ViewPipelines = ({
 }: {
   organizations?: UserProfileCardProps["organizations"];
 }) => {
-  const params = useParams();
-  const visibility = params.visibility ? String(params.visibility) : null;
+  const searchParams = useSearchParams();
+  const visibility = searchParams.get("visibility");
   const [searchCode, setSearchCode] = React.useState<Nullable<string>>(null);
   const [searchInputValue, setSearchInputValue] =
     React.useState<Nullable<string>>(null);

--- a/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
@@ -23,7 +23,7 @@ import {
 } from "../../../components";
 import { CreatePipelineDialog } from "./CreatePipelineDialog";
 import debounce from "lodash.debounce";
-import { useParams, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 const selector = (store: InstillStore) => ({
   accessToken: store.accessToken,


### PR DESCRIPTION
Because

- This is a pre-caution, for example in helm environment, every request is slow so the entity may be missing, this will cause the test to fall

This commit

- fix not correctly block create pipeline action when entity is missing
