### PR TITLE
fix: fix the wrong initialization of start operator type select

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/start-operator-node/StartOperatorNode.tsx
@@ -108,7 +108,14 @@ export const StartOperatorNode = ({ data }: NodeProps<StartNodeData>) => {
     });
     setIsEditing(true);
 
-    const newSelectedType = data.start_component.fields[key].instill_format;
+    let newSelectedType = data.start_component.fields[key].instill_format;
+
+    if (
+      newSelectedType === "string" &&
+      data.start_component.fields[key].instill_ui_multiline
+    ) {
+      newSelectedType = "long_string";
+    }
 
     setSelectedType(newSelectedType);
 


### PR DESCRIPTION
Because

- the user create a long_text start operator field, when they edit it, the initialization of the type is text, which is not correct

This commit

- fix the wrong initialization of start operator type select
