### PR TITLE
feat: make the pipeline overview cleaner by collapsing and auto-arranging nodes

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeDropdownMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeDropdownMenu.tsx
@@ -21,7 +21,7 @@ const NodeDropdownMenuRoot = ({
 
   return (
     <Popover.Root open={isOpen} onOpenChange={(open) => setIsOpen(open)}>
-      <Popover.Trigger>
+      <Popover.Trigger disabled={pipelineIsReadOnly}>
         <Tooltip.Provider>
           <Tooltip.Root>
             <Tooltip.Trigger asChild>
@@ -36,7 +36,8 @@ const NodeDropdownMenuRoot = ({
                   type="button"
                   disabled={pipelineIsReadOnly}
                   onClick={() => {
-                    setIsOpen(!isOpen);
+                    if (pipelineIsReadOnly) return;
+                    setIsOpen(true);
                   }}
                 >
                   <Icons.DotsHorizontal className="h-4 w-4 stroke-semantic-fg-secondary" />

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ConnectorOperatorControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ConnectorOperatorControlPanel.tsx
@@ -190,10 +190,9 @@ export const ConnectorOperatorControlPanel = ({
     <ControlPanel.Root>
       <ControlPanel.Toggle
         isCollapsed={nodeIsCollapsed}
-        onTrigger={() => {
+        onClick={() => {
           setNodeIsCollapsed(!nodeIsCollapsed);
         }}
-        disabled={pipelineIsReadOnly}
       />
       <NodeDropdownMenu.Root
         isOpen={moreOptionsIsOpen}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ControlPanel.tsx
@@ -9,11 +9,11 @@ const ControlPanelRoot = ({ children }: { children: React.ReactNode }) => {
 
 const ControlPanelToggle = ({
   isCollapsed,
-  onTrigger,
+  onClick,
   disabled,
 }: {
   isCollapsed: boolean;
-  onTrigger: () => void;
+  onClick: () => void;
   disabled?: boolean;
 }) => {
   return (
@@ -31,7 +31,7 @@ const ControlPanelToggle = ({
               disabled={disabled}
               onClick={(e) => {
                 e.stopPropagation();
-                onTrigger();
+                onClick();
               }}
             >
               {isCollapsed ? (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/StartEndOperatorControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/StartEndOperatorControlPanel.tsx
@@ -35,12 +35,9 @@ export function StartEndOperatorControlPanel({
     <ControlPanel.Root>
       <ControlPanel.Toggle
         isCollapsed={nodeIsCollapsed}
-        onTrigger={() => {
-          if (pipelineIsReadOnly) return;
-
+        onClick={() => {
           setNodeIsCollapsed(!nodeIsCollapsed);
         }}
-        disabled={pipelineIsReadOnly}
       />
 
       {type === "start" ? (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/end-operator-node/EndOperatorNode.tsx
@@ -252,13 +252,15 @@ export const EndOperatorNode = ({ data }: NodeProps<EndNodeData>) => {
           </p>
         </div>
         <div className="flex flex-row gap-x-3">
-          <button
-            type="button"
-            className="my-auto flex cursor-pointer rounded-full bg-semantic-accent-bg px-2 py-0.5 text-semantic-accent-default product-body-text-4-semibold hover:bg-semantic-accent-bg-alt"
-            onClick={() => setIsViewResultMode(!isViewResultMode)}
-          >
-            {isViewResultMode ? "Edit" : "See Result"}
-          </button>
+          {pipelineIsReadOnly ? null : (
+            <button
+              type="button"
+              className="my-auto flex cursor-pointer rounded-full bg-semantic-accent-bg px-2 py-0.5 text-semantic-accent-default product-body-text-4-semibold hover:bg-semantic-accent-bg-alt"
+              onClick={() => setIsViewResultMode(!isViewResultMode)}
+            >
+              {isViewResultMode ? "Edit" : "See Result"}
+            </button>
+          )}
           <StartEndOperatorControlPanel
             type="end"
             nodeIsCollapsed={nodeIsCollapsed}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/iterator-node/IteratorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/iterator-node/IteratorNode.tsx
@@ -23,6 +23,7 @@ const selector = (store: InstillStore) => ({
   updateTempSavedNodesForEditingIteratorFlow:
     store.updateTempSavedNodesForEditingIteratorFlow,
   updateEditingIteratorID: store.updateEditingIteratorID,
+  collapseAllNodes: store.collapseAllNodes,
 });
 
 export const IteratorNode = ({ data, id }: NodeProps<IteratorNodeData>) => {
@@ -36,7 +37,12 @@ export const IteratorNode = ({ data, id }: NodeProps<IteratorNodeData>) => {
     updateEdges,
     updateTempSavedNodesForEditingIteratorFlow,
     updateEditingIteratorID,
+    collapseAllNodes,
   } = useInstillStore(useShallow(selector));
+
+  React.useEffect(() => {
+    setNodeIsCollapsed(collapseAllNodes);
+  }, [collapseAllNodes]);
 
   const editIterator = React.useCallback(
     function () {

--- a/packages/toolkit/src/view/pipeline-builder/lib/createGraphLayout.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/createGraphLayout.tsx
@@ -3,17 +3,63 @@ import { Edge, Node, Position } from "reactflow";
 import { NodeData } from "../type";
 
 // This is the default dimension of a connector node we have right now
-const CONNECTOR_NODE_DIMENSION = {
-  width: 340,
-  height: 305,
+const START_END_COMPONENT = {
+  width: 318,
+  height: 54,
+};
+
+const OTHER_COMPONENT = {
+  width: 318,
+  height: 77,
 };
 
 const elk = new ELK({
   defaultLayoutOptions: {
     "elk.algorithm": "layered",
     "elk.direction": "RIGHT",
-    "elk.spacing.nodeNode": "50",
-    "elk.layered.spacing.nodeNodeBetweenLayers": "200",
+
+    /**
+     * The minimal distance to be preserved between each two nodes.
+     */
+    "spacing.nodeNode": "50",
+
+    /**
+     * Spacing to be preserved between nodes and edges.
+     */
+    "spacing.edgeNode": "50",
+
+    /**
+     * Spacing to be preserved between any two edges. Note that while
+     * this can somewhat easily be satisfied for the segments of orthogonally
+     * drawn edges, it is harder for general polylines or splines.
+     */
+    "spacing.edgeEdge": "100",
+
+    /**
+     * Spacing to be preserved between pairs of edges that are routed between
+     * the same pair of layers. Note that ‘spacing.edgeEdge’ is used for the
+     * spacing between pairs of edges crossing the same layer.
+     */
+    "spacing.edgeEdgeBetweenLayers": "50",
+
+    /**
+     * The spacing to be preserved between nodes and edges that are routed
+     * next to the node’s layer. For the spacing between nodes and edges
+     * that cross the node’s layer ‘spacing.edgeNode’ is used.
+     */
+    "spacing.edgeNodeBetweenLayers": "50",
+
+    /**
+     * Spacing to be preserved between pairs of connected components.
+     * This option is only relevant if ‘separateConnectedComponents’ is activated.
+     */
+    "spacing.componentComponent": "100",
+
+    /**
+     * The spacing to be preserved between any pair of nodes of two adjacent layers.
+     * Note that ‘spacing.nodeNode’ is used for the spacing between nodes within the layer itself.
+     */
+    "spacing.nodeNodeBetweenLayers": "100",
   },
 });
 
@@ -25,11 +71,19 @@ export async function createGraphLayout(
   const elkEdges: ElkExtendedEdge[] = [];
 
   nodes.forEach((node) => {
-    elkNodes.push({
-      id: node.id,
-      width: CONNECTOR_NODE_DIMENSION.width,
-      height: CONNECTOR_NODE_DIMENSION.height,
-    });
+    if (node.data.id === "start" || node.data.id === "end") {
+      elkNodes.push({
+        id: node.id,
+        width: START_END_COMPONENT.width,
+        height: START_END_COMPONENT.height,
+      });
+    } else {
+      elkNodes.push({
+        id: node.id,
+        width: OTHER_COMPONENT.width,
+        height: OTHER_COMPONENT.height,
+      });
+    }
   });
 
   edges.forEach((edge) => {
@@ -62,9 +116,18 @@ export async function createGraphLayout(
 
       // We are shifting the dagre node position (anchor=center center) to the top left
       // so it matches the React Flow node anchor point (top left).
+
+      if (node.data.id === "start" || node.data.id === "end") {
+        node.position = {
+          x: elkNode.x - START_END_COMPONENT.width / 2,
+          y: elkNode.y - START_END_COMPONENT.height / 2,
+        };
+        return node;
+      }
+
       node.position = {
-        x: elkNode.x - CONNECTOR_NODE_DIMENSION.width / 2,
-        y: elkNode.y - CONNECTOR_NODE_DIMENSION.height / 2,
+        x: elkNode.x - OTHER_COMPONENT.width / 2,
+        y: elkNode.y - OTHER_COMPONENT.height / 2,
       };
       return node;
     }),


### PR DESCRIPTION
Because

- make the pipeline overview cleaner by collapse and auto-arrange nodes

This commit

- make the pipeline overview cleaner by collapse and auto-arrange nodes
