### PR TITLE
feat: using none complete pipeline request to compose user active pipeline counts

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipelines/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipelines/client.ts
@@ -13,12 +13,16 @@ export function useUserPipelines({
   retry,
   filter,
   visibility,
+  disabledViewFull,
+  pageSize,
 }: {
   userName: Nullable<string>;
   enabled: boolean;
   accessToken: Nullable<string>;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
+  disabledViewFull?: boolean;
+  pageSize?: number;
   /**
    * - Default is 3
    * - Set to false to disable retry
@@ -43,6 +47,8 @@ export function useUserPipelines({
         accessToken,
         filter,
         visibility,
+        disabledViewFull,
+        pageSize,
       });
       return Promise.resolve(pipelines);
     },

--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipelines/server.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipelines/server.ts
@@ -7,11 +7,15 @@ export async function fetchUserPipelines({
   accessToken,
   filter,
   visibility,
+  disabledViewFull,
+  pageSize,
 }: {
   userName: Nullable<string>;
   accessToken: Nullable<string>;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
+  disabledViewFull?: boolean;
+  pageSize?: number;
 }) {
   if (!userName) {
     return Promise.reject(new Error("userName not provided"));
@@ -19,12 +23,13 @@ export async function fetchUserPipelines({
 
   const pipelines = await listUserPipelinesQuery({
     userName,
-    pageSize: env("NEXT_PUBLIC_QUERY_PAGE_SIZE"),
+    pageSize: pageSize ?? env("NEXT_PUBLIC_QUERY_PAGE_SIZE"),
     nextPageToken: null,
     accessToken,
     enablePagination: false,
     filter,
     visibility,
+    disabledViewFull,
   });
 
   return Promise.resolve(pipelines);

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
@@ -103,6 +103,7 @@ export type listUserPipelinesQueryProps = {
   userName: string;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
+  disabledViewFull?: boolean;
 };
 
 export async function listUserPipelinesQuery(
@@ -133,13 +134,16 @@ export async function listUserPipelinesQuery(
     enablePagination,
     filter,
     visibility,
+    disabledViewFull,
   } = props;
   try {
     const client = createInstillAxiosClient(accessToken, "vdp");
     const pipelines: Pipeline[] = [];
 
     const queryString = getQueryString({
-      baseURL: `${userName}/pipelines?view=VIEW_FULL`,
+      baseURL: disabledViewFull
+        ? `${userName}/pipelines`
+        : `${userName}/pipelines?view=VIEW_FULL`,
       pageSize,
       nextPageToken,
       queryParams: visibility ? `visibility=${visibility}` : undefined,

--- a/packages/toolkit/src/view/hub/hub-view/Body.tsx
+++ b/packages/toolkit/src/view/hub/hub-view/Body.tsx
@@ -58,6 +58,10 @@ export const Body = ({
     accessToken,
     filter: null,
     visibility: null,
+
+    // Use these parameters to speed up request
+    disabledViewFull: true,
+    pageSize: 100,
   });
 
   const userPublicPipelines = React.useMemo(() => {

--- a/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
@@ -13,6 +13,7 @@ import {
   useAuthenticatedUser,
   useAppEntity,
   Visibility,
+  useUserPipelines,
 } from "../../../lib";
 import {
   LoadingSpin,
@@ -65,6 +66,18 @@ export const ViewPipelines = ({
     enabledQuery: enabledQuery && entity.isSuccess,
     filter: searchCode ? `q="${searchCode}"` : null,
     visibility: selectedVisibilityOption ?? null,
+  });
+
+  const userPipelines = useUserPipelines({
+    userName: me.isSuccess ? me.data.name : null,
+    enabled: enabledQuery && me.isSuccess,
+    accessToken,
+    filter: null,
+    visibility: null,
+
+    // Use these parameters to speed up request
+    disabledViewFull: true,
+    pageSize: 100,
   });
 
   const allPipelines = React.useMemo(() => {


### PR DESCRIPTION
Because

- Try to reduce the response payload to speed up request

This commit

- using none complete pipeline request to compose user active pipeline counts
