### PR TITLE
feat(pipeline-builder): display form condition's title if available

### DIFF
--- a/apps/console/integration-test/tests/should-change-component-id.test.ts
+++ b/apps/console/integration-test/tests/should-change-component-id.test.ts
@@ -37,33 +37,20 @@ export function shouldChangeComponentID() {
         .getByTestId(DataTestID.SelectComponentDialog)
         .getByText("Stability AI", { exact: true })
         .click();
-      const stComponent = page.locator(`[data-id='${oldSTComponentID}']`);
-      await stComponent
-        .getByRole("button", { name: "Create connector" })
-        .click();
-      const setupComponentDialog = page.getByTestId(
-        DataTestID.setupComponentDialog,
-      );
-      await setupComponentDialog
-        .locator("input[name='id']")
-        .fill(stConnectorID);
-      await setupComponentDialog
-        .locator("input[name='api_key']")
-        .fill(stConnectorID);
-      setupComponentDialog.getByRole("button", { name: "Save" }).click();
 
       // Configure new ST component
+      const stComponent = page.locator(`[data-id='${oldSTComponentID}']`);
       const stTaskSelectTrigger = stComponent.getByLabel(
-        "Stability AI Component",
+        "Stability AI Component"
       );
       await stTaskSelectTrigger.click();
       const stTaskContent = await getSelectContent(page, stTaskSelectTrigger);
-      await stTaskContent.getByText("TASK_TEXT_TO_IMAGE").click();
+      await stTaskContent.getByText("Text To Image").click();
       const stEngineSelectTrigger = stComponent.getByLabel("Engine");
       await stEngineSelectTrigger.click();
       const stEngineContent = await getSelectContent(
         page,
-        stEngineSelectTrigger,
+        stEngineSelectTrigger
       );
       await stEngineContent.getByText("stable-diffusion-xl-1024-v1-0").click();
       await page
@@ -82,10 +69,10 @@ export function shouldChangeComponentID() {
 
       // expect conection line is on pipeline-builder
       await expect(
-        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`),
+        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
-        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`),
+        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`)
       ).toHaveCount(1);
     });
 
@@ -101,29 +88,29 @@ export function shouldChangeComponentID() {
 
       // expect connection line is not on pipeline-builder
       await expect(
-        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`),
+        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`)
       ).toHaveCount(0);
       await expect(
-        page.locator(`g[aria-label='Edge from start to ${newSTComponentID}']`),
+        page.locator(`g[aria-label='Edge from start to ${newSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
-        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`),
+        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`)
       ).toHaveCount(0);
 
       // expect connection line is not on pipeline-builder after save
       await pipelineBuilderPage.expectToSave();
       await page.reload();
       await expect(
-        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`),
+        page.locator(`g[aria-label='Edge from start to ${oldSTComponentID}']`)
       ).toHaveCount(0);
       await expect(
-        page.locator(`g[aria-label='Edge from start to ${newSTComponentID}']`),
+        page.locator(`g[aria-label='Edge from start to ${newSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
-        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`),
+        page.locator(`g[aria-label='Edge from ${oldSTComponentID} to end']`)
       ).toHaveCount(0);
       await expect(newStComponent.locator("input[name='nodeID']")).toHaveValue(
-        newSTComponentID,
+        newSTComponentID
       );
     });
 

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
@@ -31,7 +31,10 @@ export const OneOfConditionField = ({
   setSelectedConditionMap: React.Dispatch<
     React.SetStateAction<Nullable<SelectedConditionMap>>
   >;
-  conditionComponentsMap: Record<string, React.ReactNode>;
+  conditionComponentsMap: Record<
+    string,
+    { component: React.ReactNode; title: Nullable<string> }
+  >;
   shortDescription?: string;
   disabled?: boolean;
 } & AutoFormFieldBaseProps) => {
@@ -39,7 +42,10 @@ export const OneOfConditionField = ({
     React.useState<Nullable<SelectedConditionMap>>(null);
 
   const conditionOptions = React.useMemo(() => {
-    return Object.entries(conditionComponentsMap).map(([k]) => k);
+    return Object.entries(conditionComponentsMap).map(([k, v]) => ({
+      key: k,
+      title: v.title,
+    }));
   }, [conditionComponentsMap]);
 
   // Once the condition is changed, we need to reset the child form data
@@ -111,8 +117,8 @@ export const OneOfConditionField = ({
                     {conditionOptions.map((option) => {
                       return (
                         <Select.Item
-                          key={option}
-                          value={option}
+                          key={option.key}
+                          value={option.key}
                           className={cn(
                             "my-auto text-semantic-fg-primary group-hover:text-semantic-bg-primary data-[highlighted]:text-semantic-bg-primary",
                             size === "sm"
@@ -120,7 +126,9 @@ export const OneOfConditionField = ({
                               : "product-body-text-4-regular"
                           )}
                         >
-                          <p className="my-auto">{option}</p>
+                          <p className="my-auto">
+                            {option.title ?? option.key}
+                          </p>
                         </Select.Item>
                       );
                     })}
@@ -140,7 +148,9 @@ export const OneOfConditionField = ({
           }}
         />
       )}
-      <div className="flex flex-col gap-y-4">{conditionComponents}</div>
+      <div className="flex flex-col gap-y-4">
+        {conditionComponents?.component}
+      </div>
     </div>
   );
 };

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -9,6 +9,7 @@ import { RegularFields } from "../components";
 import { GeneralUseFormReturn, Nullable } from "../../type";
 import { SmartHintFields } from "../components/smart-hint";
 import { pickDefaultCondition } from "./pickDefaultCondition";
+import { pickConstInfoFromOneOfCondition } from "./pickConstInfoFromOneOfCondition";
 
 export type PickRegularFieldsFromInstillFormTreeOptions = {
   disabledAll?: boolean;
@@ -63,8 +64,6 @@ export function pickRegularFieldsFromInstillFormTree(
       return null;
     }
 
-    console.log(tree);
-
     return tree.fieldKey ? (
       <div key={tree.path || tree.fieldKey}>
         <p
@@ -112,15 +111,20 @@ export function pickRegularFieldsFromInstillFormTree(
   if (tree._type === "formCondition") {
     const conditionComponents = Object.fromEntries(
       Object.entries(tree.conditions).map(([k, v]) => {
+        const constInfo = v.properties.find((e) => "const" in e);
+
         return [
           k,
-          pickRegularFieldsFromInstillFormTree(
-            v,
-            form,
-            selectedConditionMap,
-            setSelectedConditionMap,
-            options
-          ),
+          {
+            component: pickRegularFieldsFromInstillFormTree(
+              v,
+              form,
+              selectedConditionMap,
+              setSelectedConditionMap,
+              options
+            ),
+            title: constInfo?.title ?? null,
+          },
         ];
       })
     );

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
@@ -334,8 +334,6 @@ export function transformInstillJSONSchemaToZod({
       and template 
     * -----------------------------------------------------------------------*/
 
-    // console.log(instillZodSchema);
-
     instillZodSchema = instillZodSchema.superRefine((val, ctx) => {
       if (isHidden) {
         return;

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
@@ -88,7 +88,6 @@ export function useUpdaterOnNode({
     }
 
     timer.current = setTimeout(() => {
-      console.log("updated");
       const newNodes = nodes.map((node) => {
         if (
           isConnectorNode(node) &&


### PR DESCRIPTION
Because

- Previously condition field's condition is displayed with key, we want to make it more human-readable

This commit

- display form condition's title if available
