### PR TITLE
feat(pipeline-builder): adapt figma-like zoom-in-out experience and enable multi-selection of nodes

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.87.0-rc.6",
+  "version": "0.87.0-rc.7",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
@@ -6,6 +6,7 @@ import ReactFlow, {
   Controls,
   MiniMap,
   ReactFlowInstance,
+  SelectionMode,
 } from "reactflow";
 import {
   InstillStore,
@@ -50,6 +51,8 @@ const nodeTypes = {
 const edgeTypes = {
   customEdge: CustomEdge,
 };
+
+const panOnDrag = [1, 2];
 
 export const PipelineBuilderCanvas = ({
   setReactFlowInstance,
@@ -133,6 +136,10 @@ export const PipelineBuilderCanvas = ({
         includeHiddenNodes: true,
         padding: 20,
       }}
+      // To enable Figma-like zoom-in-out experience
+      panOnScroll={true}
+      panOnDrag={panOnDrag}
+      selectionMode={SelectionMode.Partial}
       // We want to position node based on their center
       nodeOrigin={[0.5, 0.5]}
       nodeTypes={nodeTypes}

--- a/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
@@ -7,6 +7,7 @@ import ReactFlow, {
   BackgroundVariant,
   Controls,
   ReactFlowInstance,
+  SelectionMode,
   useEdgesState,
   useNodesState,
 } from "reactflow";
@@ -50,6 +51,8 @@ const nodeTypes = {
 const edgeTypes = {
   customEdge: CustomEdge,
 };
+
+const panOnDrag = [1, 2];
 
 export type ReadOnlyPipelineBuilderProps = {
   pipelineName: Nullable<string>;
@@ -136,6 +139,12 @@ export const ReadOnlyPipelineBuilder = ({
         onInit={setReactFlowInstance}
         proOptions={{ hideAttribution: true }}
         elevateNodesOnSelect={true}
+        // To enable Figma-like zoom-in-out experience
+        panOnScroll={true}
+        panOnDrag={panOnDrag}
+        selectionMode={SelectionMode.Partial}
+        selectionOnDrag={true}
+        nodeOrigin={[0.5, 0.5]}
       >
         <Background
           id={pipelineName ?? undefined}


### PR DESCRIPTION
Because

- adapt figma-like zoom-in-out experience and enable multi-selection of nodes

This commit

- adapt figma-like zoom-in-out experience and enable multi-selection of nodes
