### PR TITLE
 fix(pipeline-builder): fix save pipeline in the warn unsaved change dialog not clean up state

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
@@ -177,6 +177,7 @@ export const PipelineBuilderMainView = () => {
             }}
             onSave={async () => {
               await savePipeline();
+              initPipelineBuilder();
               if (warnUnsavedChangesDialogState.confirmNavigation) {
                 warnUnsavedChangesDialogState.confirmNavigation();
               }


### PR DESCRIPTION
Because

- fix save pipeline in the warn unsaved change dialog not clean up state, this cause the state "isEditingIterator" not correctly clean up

This commit

- fix save pipeline in the warn unsaved change dialog not clean up state
