### PR TITLE
fix: fix owner and member can not edit their org's pipeline readme

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.87.0-rc.13",
+  "version": "0.87.0-rc.14",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Readme.tsx
@@ -26,10 +26,10 @@ const selector = (store: InstillStore) => ({
 });
 
 export const Readme = ({
-  isOwner,
+  isEditable,
   readme,
 }: {
-  isOwner: boolean;
+  isEditable: boolean;
   readme: Nullable<string>;
 }) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
@@ -107,7 +107,7 @@ export const Readme = ({
 
   const editor = useEditor({
     extensions: extensions,
-    editable: isOwner,
+    editable: isEditable,
     editorProps: {
       attributes: {
         class:
@@ -123,8 +123,8 @@ export const Readme = ({
   React.useEffect(() => {
     if (!editor) return;
 
-    editor.setEditable(isOwner);
-  }, [isOwner, editor]);
+    editor.setEditable(isEditable);
+  }, [isEditable, editor]);
 
   React.useEffect(() => {
     if (!readme || !editor || isInitialized) return;

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -95,7 +95,13 @@ export const ViewPipeline = () => {
             Pipeline Description
           </div>
           <Readme
-            isOwner={isOwner}
+            isEditable={
+              pipeline.isSuccess
+                ? pipeline.data.permission.can_edit
+                  ? true
+                  : false
+                : false
+            }
             readme={pipeline.isSuccess ? pipeline.data.readme : null}
           />
         </div>


### PR DESCRIPTION
Because

- fix owner and member can not edit their org's pipeline readme

This commit

- fix owner and member can not edit their org's pipeline readme
