### PR TITLE
fix(pipeline-builder): fix wrongly update the recipe when pipeline is readonly

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
@@ -30,6 +30,7 @@ const selector = (store: InstillStore) => ({
   currentAdvancedConfigurationNodeID: store.currentAdvancedConfigurationNodeID,
   updateCurrentAdvancedConfigurationNodeID:
     store.updateCurrentAdvancedConfigurationNodeID,
+  pipelineIsReadOnly: store.pipelineIsReadOnly,
 });
 
 export function useUpdaterOnNode({
@@ -48,6 +49,7 @@ export function useUpdaterOnNode({
     updatePipelineRecipeIsDirty,
     currentAdvancedConfigurationNodeID,
     updateCurrentAdvancedConfigurationNodeID,
+    pipelineIsReadOnly,
   } = useInstillStore(useShallow(selector));
 
   const { getValues } = form;
@@ -110,6 +112,10 @@ export function useUpdaterOnNode({
   // We don't rely on the react-hook-form isValid and isDirty state
   // because the isHidden fields make the formStart inacurate.
   React.useEffect(() => {
+    if (pipelineIsReadOnly) {
+      return;
+    }
+
     const parsed = ValidatorSchema.safeParse(values);
     const configuration =
       getConnectorOperatorComponentConfiguration(currentNodeData);
@@ -153,5 +159,6 @@ export function useUpdaterOnNode({
     nodes,
     updateEdges,
     debounceUpdater,
+    pipelineIsReadOnly,
   ]);
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnRightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnRightPanel.tsx
@@ -25,6 +25,7 @@ const selector = (store: InstillStore) => ({
   nodes: store.nodes,
   updateNodes: store.updateNodes,
   updateEdges: store.updateEdges,
+  pipelineIsReadOnly: store.pipelineIsReadOnly,
   updatePipelineRecipeIsDirty: store.updatePipelineRecipeIsDirty,
 });
 
@@ -37,8 +38,13 @@ export function useUpdaterOnRightPanel({
   ValidatorSchema: ZodAnyValidatorSchema;
   currentNodeData: ConnectorNodeData | OperatorNodeData;
 }) {
-  const { nodes, updateNodes, updateEdges, updatePipelineRecipeIsDirty } =
-    useInstillStore(useShallow(selector));
+  const {
+    nodes,
+    updateNodes,
+    updateEdges,
+    pipelineIsReadOnly,
+    updatePipelineRecipeIsDirty,
+  } = useInstillStore(useShallow(selector));
 
   const {
     getValues,
@@ -109,6 +115,10 @@ export function useUpdaterOnRightPanel({
   // We don't fully rely on the react-hook-form isValid and isDirty state
   // because the isHidden fields make the formStart inacurate.
   React.useEffect(() => {
+    if (pipelineIsReadOnly) {
+      return;
+    }
+
     const parsed = ValidatorSchema.safeParse(values);
 
     const configuration =
@@ -140,5 +150,6 @@ export function useUpdaterOnRightPanel({
     isDirty,
     trigger,
     debounceUpdater,
+    pipelineIsReadOnly,
   ]);
 }


### PR DESCRIPTION
Because

- fix wrongly update the recipe when pipeline is readonly

This commit

- fix wrongly update the recipe when pipeline is readonly
