### PR TITLE
fix(pipeline-builder): fix read-only canvas pan on drag issue

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
@@ -24,6 +24,7 @@ import {
 } from "./nodes";
 import { CustomEdge } from "./CustomEdge";
 import { isResponseNode, isTriggerNode } from "../lib";
+import { canvasPanOnDrag } from "./canvasPanOnDrag";
 
 const selector = (store: InstillStore) => ({
   nodes: store.nodes,
@@ -51,8 +52,6 @@ const nodeTypes = {
 const edgeTypes = {
   customEdge: CustomEdge,
 };
-
-const panOnDrag = [0, 1];
 
 export const PipelineBuilderCanvas = ({
   setReactFlowInstance,
@@ -138,7 +137,7 @@ export const PipelineBuilderCanvas = ({
       }}
       // To enable Figma-like zoom-in-out experience
       panOnScroll={true}
-      panOnDrag={panOnDrag}
+      panOnDrag={canvasPanOnDrag}
       selectionMode={SelectionMode.Partial}
       // We want to position node based on their center
       nodeOrigin={[0.5, 0.5]}

--- a/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
@@ -31,6 +31,7 @@ import {
 } from "./nodes";
 import { CustomEdge } from "./CustomEdge";
 import { createNodesFromPipelineRecipe } from "../lib/createNodesFromPipelineRecipe";
+import { canvasPanOnDrag } from "./canvasPanOnDrag";
 
 const selector = (store: InstillStore) => ({
   updateCurrentVersion: store.updateCurrentVersion,
@@ -51,8 +52,6 @@ const nodeTypes = {
 const edgeTypes = {
   customEdge: CustomEdge,
 };
-
-const panOnDrag = [1, 2];
 
 export type ReadOnlyPipelineBuilderProps = {
   pipelineName: Nullable<string>;
@@ -141,7 +140,7 @@ export const ReadOnlyPipelineBuilder = ({
         elevateNodesOnSelect={true}
         // To enable Figma-like zoom-in-out experience
         panOnScroll={false}
-        panOnDrag={panOnDrag}
+        panOnDrag={canvasPanOnDrag}
         selectionMode={SelectionMode.Partial}
         selectionOnDrag={true}
         nodeOrigin={[0.5, 0.5]}

--- a/packages/toolkit/src/view/pipeline-builder/components/canvasPanOnDrag.ts
+++ b/packages/toolkit/src/view/pipeline-builder/components/canvasPanOnDrag.ts
@@ -1,0 +1,4 @@
+/**
+ * https://reactflow.dev/api-reference/react-flow#pan-on-drag
+ */
+export const canvasPanOnDrag = [0, 1];


### PR DESCRIPTION
Because

- User should be able to hold and drag the canvas with mouse click

This commit

- fix read-only canvas pan on drag issue
