### PR TITLE
fix: fix vscode settings to use tsconfigs in subfolders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,12 @@
 {
-  "typescript.tsdk": "./node_modules/typescript/lib"
+  "typescript.tsdk": "./node_modules/typescript/lib",
+  "eslint.workingDirectories": [
+    "./apps/console",
+    "./apps/instill-form-playground",
+    "./packages/eslint-config-cortex",
+    "./packages/design-system",
+    "./packages/design-tokens",
+    "./packages/prettier-config-cortex",
+    "./packages/toolkit"
+  ]
 }

--- a/apps/console/.eslintrc.cjs
+++ b/apps/console/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
   extends: ["next/core-web-vitals", "@instill-ai/eslint-config-cortex"],
+  ignorePatterns: [".eslintrc.cjs"],
 };

--- a/packages/design-system/.eslintrc.cjs
+++ b/packages/design-system/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
-  extends: ["@instill-ai/eslint-config-cortex", "plugin:storybook/recommended"]
+  extends: ["@instill-ai/eslint-config-cortex", "plugin:storybook/recommended"],
+  ignorePatterns: [".eslintrc.cjs"],
 };

--- a/packages/design-tokens/.eslintrc.cjs
+++ b/packages/design-tokens/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
   extends: ["@instill-ai/eslint-config-cortex"],
+  ignorePatterns: [".eslintrc.cjs"],
 };

--- a/packages/toolkit/.eslintrc.cjs
+++ b/packages/toolkit/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
   extends: ["@instill-ai/eslint-config-cortex"],
+  ignorePatterns: [".eslintrc.cjs"],
 };


### PR DESCRIPTION
Because

- vscode was throwing errors because it couldn't find the tsconfig files in nested package folders

This commit

- updates the vscode settings and eslintrc files, fixing errors