### PR TITLE
fix(pipeline-builder): fix toolkit wrongly display null definition cause confusion

### DIFF
--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/types.ts
@@ -170,7 +170,7 @@ export type PipelineConnectorComponent = {
   metadata?: GeneralRecord;
   connector_component: {
     definition_name: string;
-    definition: Nullable<ConnectorDefinition>;
+    definition?: Nullable<ConnectorDefinition>;
     task: string;
     input: GeneralRecord;
     condition: Nullable<string>;
@@ -183,7 +183,7 @@ export type PipelineOperatorComponent = {
   metadata?: GeneralRecord;
   operator_component: {
     definition_name: string;
-    definition: Nullable<OperatorDefinition>;
+    definition?: Nullable<OperatorDefinition>;
     task: string;
     input: GeneralRecord;
     condition: Nullable<string>;

--- a/packages/toolkit/src/view/pipeline-builder/lib/constructPipelineRecipeFromNodes.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/constructPipelineRecipeFromNodes.tsx
@@ -32,6 +32,7 @@ export function constructPipelineRecipeFromNodes(
                   ...component,
                   connector_component: {
                     ...component.connector_component,
+                    definition: undefined,
                     input:
                       recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
                         recursiveHelpers.parseToNum(
@@ -46,7 +47,6 @@ export function constructPipelineRecipeFromNodes(
                           )
                         )
                       ),
-                    definition: null,
                   },
                 };
               }
@@ -56,13 +56,13 @@ export function constructPipelineRecipeFromNodes(
                   ...component,
                   operator_component: {
                     ...component.operator_component,
+                    definition: undefined,
                     input:
                       recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
                         recursiveHelpers.parseToNum(
                           structuredClone(component.operator_component.input)
                         )
                       ),
-                    definition: null,
                   },
                 };
               }
@@ -71,7 +71,7 @@ export function constructPipelineRecipeFromNodes(
             }
           ),
         },
-        metadata: node.data.metadata,
+        metadata: node.data.metadata ?? undefined,
       });
       continue;
     }
@@ -91,9 +91,9 @@ export function constructPipelineRecipeFromNodes(
               structuredClone(node.data.connector_component.connection)
             )
           ),
-          definition: null,
+          definition: undefined,
         },
-        metadata: node.data.metadata,
+        metadata: node.data.metadata ?? undefined,
       });
 
       continue;
@@ -109,9 +109,9 @@ export function constructPipelineRecipeFromNodes(
               structuredClone(node.data.operator_component.input)
             )
           ),
-          definition: null,
+          definition: undefined,
         },
-        metadata: node.data.metadata,
+        metadata: node.data.metadata ?? undefined,
       });
     }
   }


### PR DESCRIPTION
Because

- fix toolkit wrongly display null definition cause confusion

This commit

- fix toolkit wrongly display null definition cause confusion
