### PR TITLE
feat(pipeline-builder): make description on node selectable

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/regular/BooleanField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/BooleanField.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import cn from "clsx";
 import { Form, Switch } from "@instill-ai/design-system";
 import type { AutoFormFieldBaseProps } from "../../types";
 import { FieldDescriptionTooltip } from "../common";
@@ -49,7 +50,10 @@ export const BooleanField = ({
               text={shortDescription ?? null}
             />
             <Form.Message
-              className={size === "sm" ? "!product-body-text-4-medium" : ""}
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-medium" : ""
+              )}
             />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
@@ -74,9 +74,11 @@ export const CredentialTextField = ({
                 />
               </Input.Root>
             </Form.Control>
-            <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
-              text={shortDescription ?? null}
+            <Form.Message
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-medium" : ""
+              )}
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
@@ -134,11 +134,12 @@ export const OneOfConditionField = ({
                     })}
                   </Select.Content>
                 </Select.Root>
-                <Form.Description
-                  className={
-                    size === "sm" ? "!product-body-text-4-regular" : ""
-                  }
-                  text={shortDescription ?? null}
+
+                <Form.Message
+                  className={cn(
+                    "nodrag nopan cursor-text select-text",
+                    size === "sm" ? "!product-body-text-4-medium" : ""
+                  )}
                 />
                 <Form.Message
                   className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
@@ -75,9 +75,11 @@ export const SingleSelectField = ({
                   })}
               </Select.Content>
             </Select.Root>
-            <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
-              text={shortDescription ?? null}
+            <Form.Message
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-medium" : ""
+              )}
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
@@ -59,9 +59,11 @@ export const TextAreaField = ({
                 }}
               />
             </Form.Control>
-            <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
-              text={shortDescription ?? null}
+            <Form.Message
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-medium" : ""
+              )}
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
@@ -61,9 +61,11 @@ export const TextField = ({
                 />
               </Input.Root>
             </Form.Control>
-            <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
-              text={shortDescription ?? null}
+            <Form.Message
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-medium" : ""
+              )}
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -220,7 +220,10 @@ export const TextArea = ({
               </Popover.Content>
             </Popover.Root>
             <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-regular" : ""
+              )}
               text={shortDescription ?? null}
             />
             <Form.Message

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -228,7 +228,10 @@ export const TextField = ({
               </Popover.Content>
             </Popover.Root>
             <Form.Description
-              className={size === "sm" ? "!product-body-text-4-regular" : ""}
+              className={cn(
+                "nodrag nopan cursor-text select-text",
+                size === "sm" ? "!product-body-text-4-regular" : ""
+              )}
               text={shortDescription ?? null}
             />
             <Form.Message

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudioField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudioField.tsx
@@ -79,7 +79,10 @@ export const AudioField = ({
                 }}
               />
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
@@ -130,7 +130,10 @@ export const AudiosField = ({
                 </div>
               </ScrollArea.Root>
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/BooleanField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/BooleanField.tsx
@@ -45,7 +45,10 @@ export const BooleanField = ({
                 }}
               />
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FileField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FileField.tsx
@@ -77,7 +77,10 @@ export const FileField = ({
                 }}
               />
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
@@ -128,7 +128,10 @@ export const FilesField = ({
                 </div>
               </ScrollArea.Root>
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImageField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImageField.tsx
@@ -102,7 +102,10 @@ export const ImageField = ({
                 }}
               />
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
@@ -174,7 +174,10 @@ export const ImagesField = ({
                 </div>
               </ScrollArea.Root>
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/LongTextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/LongTextField.tsx
@@ -74,7 +74,10 @@ export const LongTextField = ({
             <Form.Control>
               <EditorContent disabled={disabled} editor={editor} />
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumberField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumberField.tsx
@@ -58,7 +58,10 @@ export const NumberField = ({
                 />
               </Input.Root>
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumbersField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumbersField.tsx
@@ -142,7 +142,10 @@ export const NumbersField = ({
                 Add field
               </button>
             </div>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
           </div>
         );
       }}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ObjectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ObjectField.tsx
@@ -47,7 +47,10 @@ export const ObjectField = ({
                 disabled={disabled}
               />
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextField.tsx
@@ -55,7 +55,10 @@ export const TextField = ({
                 />
               </Input.Root>
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextareaField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextareaField.tsx
@@ -47,7 +47,10 @@ export const TextareaField = ({
                 disabled={disabled}
               />
             </Form.Control>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextsField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextsField.tsx
@@ -163,7 +163,10 @@ export const TextsField = ({
                 Add field
               </button>
             </div>
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideoField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideoField.tsx
@@ -98,7 +98,10 @@ export const VideoField = ({
                 }}
               />
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
@@ -174,7 +174,10 @@ export const VideosField = ({
                 </div>
               </ScrollArea.Root>
             ) : null}
-            <Form.Description className="!text-xs" text={description} />
+            <Form.Description
+              className="nodrag nopan cursor-text select-text !text-xs"
+              text={description}
+            />
             <Form.Message />
           </Form.Item>
         );


### PR DESCRIPTION
Because

- make description on node selectable. In this way, user can better copy description as they wish

This commit

- make description on node selectable