### PR TITLE
fix(pipeline-builder): fix wrongly roll back position when update node config

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineBuilderCanvas.tsx
@@ -118,6 +118,11 @@ export const PipelineBuilderCanvas = ({
         });
         onNodesChange(nextChanges);
       }}
+      onMove={() => {
+        if (pipelineIsReadOnly) return;
+        updateSelectedConnectorNodeId(() => null);
+        updateCurrentAdvancedConfigurationNodeID(() => null);
+      }}
       onEdgesChange={(changes) => {
         if (pipelineIsReadOnly) return;
         onEdgesChange(changes);


### PR DESCRIPTION
Because

- fix wrongly roll back position when update node config

This commit

- fix wrongly roll back position when update node config
