### PR TITLE
fix: pipeline view head section clone button permission

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -326,21 +326,19 @@ export const Head = ({
               {pipeline.isSuccess ? (
                 <React.Fragment>
                   {me.isSuccess ? (
-                    !pipeline.data.permission.can_edit ? (
-                      <ClonePipelineDialog
-                        trigger={
-                          <Button
-                            className="items-center gap-x-2"
-                            size="sm"
-                            variant="secondaryGrey"
-                          >
-                            <Icons.Copy07 className="h-3 w-3 stroke-semantic-fg-secondary" />
-                            Clone
-                          </Button>
-                        }
-                        pipeline={pipeline.data}
-                      />
-                    ) : null
+                    <ClonePipelineDialog
+                      trigger={
+                        <Button
+                          className="items-center gap-x-2"
+                          size="sm"
+                          variant="secondaryGrey"
+                        >
+                          <Icons.Copy07 className="h-3 w-3 stroke-semantic-fg-secondary" />
+                          Clone
+                        </Button>
+                      }
+                      pipeline={pipeline.data}
+                    />
                   ) : (
                     <Button
                       onClick={() => {

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -326,7 +326,7 @@ export const Head = ({
               {pipeline.isSuccess ? (
                 <React.Fragment>
                   {me.isSuccess ? (
-                    pipeline.data.permission.can_edit ? (
+                    !pipeline.data.permission.can_edit ? (
                       <ClonePipelineDialog
                         trigger={
                           <Button


### PR DESCRIPTION
Because

- Login user can clone the pipeline no matter he is the owner or not

This commit

- Login user can clone the pipeline no matter he is the owner or not
