### PR TITLE
feat: adapt the retirement of api prefix

### DIFF
--- a/apps/console/src/app/render.tsx
+++ b/apps/console/src/app/render.tsx
@@ -7,16 +7,12 @@ import { useRouter } from "next/navigation";
 
 export const RootPageRender = () => {
   useAppAccessToken();
-  const trackToken = useAppTrackToken({ enabled: true });
+  useAppTrackToken({ enabled: true });
   const router = useRouter();
 
   React.useEffect(() => {
-    if (trackToken.isSuccess && trackToken.data) {
-      router.push("/admin/pipelines");
-    } else {
-      router.push("/login");
-    }
-  }, [trackToken.isSuccess, trackToken.data]);
+    router.push("/admin/pipelines");
+  }, [router]);
 
   return <div />;
 };

--- a/packages/toolkit/src/lib/vdp-sdk/connector/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/queries.ts
@@ -20,7 +20,7 @@ export async function listConnectorDefinitionsQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const connectorDefinitions: ConnectorDefinition[] = [];
 
     const queryString = getQueryString({
@@ -64,7 +64,7 @@ export async function getConnectorDefinitionQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetConnectorDefinitionResponse>(
       `/${connectorDefinitionName}?view=VIEW_FULL`

--- a/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
@@ -4,7 +4,7 @@ import { Nullable } from "../../type";
 
 export function createInstillAxiosClient(
   accessToken: Nullable<string>,
-  product: "core" | "model" | "vdp"
+  isModelEndpoint?: boolean
 ) {
   const headers = accessToken
     ? {
@@ -29,14 +29,14 @@ export function createInstillAxiosClient(
 
   let APIVersion = env("NEXT_PUBLIC_GENERAL_API_VERSION");
 
-  if (product === "model") {
+  if (isModelEndpoint) {
     APIVersion = env("NEXT_PUBLIC_MODEL_API_VERSION");
   }
 
   const baseURL: Nullable<string> = `${
     process.env.NEXT_SERVER_API_GATEWAY_URL ??
     env("NEXT_PUBLIC_API_GATEWAY_URL")
-  }/${product}/${APIVersion}`;
+  }/${APIVersion}`;
 
   return axios.create({
     baseURL,

--- a/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/queries.ts
@@ -34,7 +34,7 @@ export async function listPipelineTriggerRecordsQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const triggers: PipelineTriggerRecord[] = [];
 
     const queryString = getQueryString({
@@ -78,7 +78,7 @@ export async function listTriggeredPipelineQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const pipelines: TriggeredPipeline[] = [];
 
     const queryString = getQueryString({
@@ -122,7 +122,7 @@ export async function listTriggeredPipelineChartQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const pipelinesChart: PipelinesChart[] = [];
 
     const queryString = getQueryString({

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/actions.ts
@@ -8,7 +8,7 @@ export async function authLogoutAction({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.post("/auth/logout");
   } catch (err) {
@@ -31,7 +31,7 @@ export async function authLoginAction({
   payload: AuthLoginActionPayload;
 }) {
   try {
-    const client = createInstillAxiosClient(null, "core");
+    const client = createInstillAxiosClient(null);
 
     const { data } = await client.post<AuthLoginActionResponse>(
       "/auth/login",
@@ -50,7 +50,7 @@ export async function authValidateTokenAction({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     await client.post("/auth/validate_access_token");
   } catch (err) {
     return Promise.reject(err);
@@ -69,7 +69,7 @@ export async function checkNamespace({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const { data } = await client.post<CheckNamespaceResponse>(
       "/check-namespace",
       {

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
@@ -14,7 +14,7 @@ export async function updateAuthenticatedUserMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.patch<UpdateUserResponse>("/user", payload);
 
@@ -41,7 +41,7 @@ export async function createApiTokenMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<CreateApiTokenResponse>(
       "/tokens",
@@ -62,7 +62,7 @@ export async function deleteApiTokenMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/${tokenName}`);
   } catch (err) {
@@ -87,7 +87,7 @@ export async function changePasswordMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.post("/auth/change_password", payload);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/queries.ts
@@ -12,7 +12,7 @@ export async function getAuthenticatedUserQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetAuthenticatedResponse>("/user");
 
@@ -32,7 +32,7 @@ export async function getAuthenticatedUserSubscriptionsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } =
       await client.get<GetAuthenticatedUserSubscriptionsResponse>(
@@ -57,7 +57,7 @@ export async function getUserQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserResponse>(`/${userName}`);
 
@@ -79,7 +79,7 @@ export async function getApiTokenQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetApiTokenResponse>(`/${tokenName}`);
 
@@ -111,7 +111,7 @@ export async function listApiTokensQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const tokens: ApiToken[] = [];
 
     const queryString = getQueryString({
@@ -150,7 +150,7 @@ export async function listUsersQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const users: User[] = [];
 
     const queryString = getQueryString({

--- a/packages/toolkit/src/lib/vdp-sdk/model/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/actions.ts
@@ -13,7 +13,7 @@ export async function deployUserModelAction({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.post<DeployUserModelResponse>(
       `/${modelName}/deploy`
@@ -36,7 +36,7 @@ export async function undeployUserModeleAction({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.post<UndeployUserModelResponse>(
       `/${modelName}/undeploy`

--- a/packages/toolkit/src/lib/vdp-sdk/model/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/mutations.ts
@@ -75,7 +75,7 @@ export async function createUserModelMutation({
   payload: CreateUserModelPayload;
   accessToken: Nullable<string>;
 }) {
-  const client = createInstillAxiosClient(accessToken, "model");
+  const client = createInstillAxiosClient(accessToken, true);
   if (payload.type === "Local") {
     try {
       const formData = new FormData();
@@ -168,7 +168,7 @@ export async function updateModelMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.patch<UpdateUserModelResponse>(
       `/${payload.name}`,
@@ -188,7 +188,7 @@ export async function deleteUserModelMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     await client.delete(`/${modelName}`);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
@@ -23,7 +23,7 @@ export async function getModelDefinitionQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetModelDefinitionResponse>(
       `/${modelDefinitionName}`
@@ -51,7 +51,7 @@ export async function listModelDefinitionsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const modelDefinitions: ModelDefinition[] = [];
 
@@ -99,7 +99,7 @@ export async function getUserModelQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetUserModelResponse>(
       `/${modelName}?view=VIEW_FULL`
@@ -126,7 +126,7 @@ export async function listModelsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const models: Model[] = [];
 
@@ -175,7 +175,7 @@ export async function listUserModelsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const models: Model[] = [];
 
@@ -219,7 +219,7 @@ export async function getUserModelReadmeQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetUserModelReadmeQueryResponse>(
       `/${modelName}/readme`
@@ -242,7 +242,7 @@ export async function watchUserModel({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
     const { data } = await client.get<ModelWatchState>(`/${modelName}/watch`);
     return Promise.resolve(data);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
@@ -14,7 +14,7 @@ export async function getOperationQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "model");
+    const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetModelOperationResponse>(
       `/${operationName}`

--- a/packages/toolkit/src/lib/vdp-sdk/organization/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/organization/mutations.ts
@@ -26,7 +26,7 @@ export async function createOrganizationMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<CreateOrganizationResponse>(
       "/organizations",
@@ -56,7 +56,7 @@ export async function updateOrganizationMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.patch<UpdateOrganizationResponse>(
       `/organizations/${payload.id}`,
@@ -90,7 +90,7 @@ export async function updateOrganizationMembershipMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.put<UpdateOrganizationMembershipResponse>(
       `/organizations/${payload.organizationID}/memberships/${payload.userID}`,
@@ -115,7 +115,7 @@ export async function deleteOrganizationMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/organizations/${organizationID}`);
   } catch (err) {
@@ -133,7 +133,7 @@ export async function deleteOrganizationMembershipMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(
       `/organizations/${organizationID}/memberships/${userID}`
@@ -153,7 +153,7 @@ export async function deleteUserMembershipMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/users/${userID}/memberships/${organizationID}`);
   } catch (err) {
@@ -179,7 +179,7 @@ export async function updateUserMembershipMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.put<UpdateUserMembershipResponse>(
       `/users/${payload.userID}/memberships/${payload.organizationID}`,

--- a/packages/toolkit/src/lib/vdp-sdk/organization/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/organization/queries.ts
@@ -25,7 +25,7 @@ export async function listOrganizationsQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
     const organizations: Organization[] = [];
 
     const queryString = getQueryString({
@@ -68,7 +68,7 @@ export async function getOrganizationQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationResponse>(
       `/organizations/${organizationID}`
@@ -92,7 +92,7 @@ export async function getOrganizationSubscriptionQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationSubscriptionResponse>(
       `/organizations/${organizationID}/subscription`
@@ -116,7 +116,7 @@ export async function getOrganizationMembershipsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationMembershipsResponse>(
       `/organizations/${organizationID}/memberships`
@@ -142,7 +142,7 @@ export async function getOrganizationMembershipQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationMembershipResponse>(
       `/organizations/${organizationID}/memberships/${userID}`
@@ -166,7 +166,7 @@ export async function getUserMembershipsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserMembershipsResponse>(
       `users/${userID}/memberships`
@@ -192,7 +192,7 @@ export async function getUserMembershipQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "core");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserMembershipsResponse>(
       `users/${userID}/memberships/${organizationID}`

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/actions.ts
@@ -28,7 +28,7 @@ export async function triggerUserPipelineAction({
   shareCode?: string;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<TriggerUserPipelineResponse>(
       `/${pipelineName}/trigger`,
@@ -69,7 +69,7 @@ export async function triggerAsyncUserPipelineAction({
   returnTraces?: boolean;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<TriggerAsyncUserPipelineResponse>(
       `/${pipelineName}/triggerAsync`,
@@ -104,7 +104,7 @@ export async function setDefaultUserPipelineReleaseMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<SetDefaultUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}/setDefault`
@@ -127,7 +127,7 @@ export async function restoreUserPipelineReleaseMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<RestoreUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}/restore`
@@ -159,7 +159,7 @@ export async function triggerUserPipelineReleaseAction({
   returnTraces?: boolean;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<TriggerUserPipelineResponse>(
       `/${pipelineReleaseName}/trigger`,
@@ -198,7 +198,7 @@ export async function triggerAsyncUserPipelineReleaseAction({
   returnTraces?: boolean;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<TriggerAsyncUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}/triggerAsync`,

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
@@ -31,7 +31,7 @@ export async function createUserPipelineMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<CreatePipelineResponse>(
       `/${entityName}/pipelines`,
@@ -64,7 +64,7 @@ export async function updateUserPipelineMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.patch<UpdateUserPipelineResponse>(
       `/${payload.name}`,
@@ -84,7 +84,7 @@ export async function deleteUserPipelineMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/${pipelineName}`);
   } catch (err) {
@@ -109,7 +109,7 @@ export async function renameUserPipelineMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<RenameUserPipelineResponse>(
       `/${payload.name}/rename`,
@@ -146,7 +146,7 @@ export async function createUserPipelineReleaseMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<CreateUserPipelineReleaseResponse>(
       `${pipelineName}/releases`,
@@ -178,7 +178,7 @@ export async function updateUserPipelineReleaseMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.patch<UpdateUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}`,
@@ -198,7 +198,7 @@ export async function deleteUserPipelineReleaseMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/${pipelineReleaseName}`);
   } catch (err) {
@@ -226,7 +226,7 @@ export async function createUserSecretMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<CreateUserSecretResponse>(
       `/${entityName}/secrets`,
@@ -247,7 +247,7 @@ export async function deleteUserSecretMutation({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     await client.delete(`/${secretName}`);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
@@ -53,7 +53,7 @@ export async function listPipelinesQuery(
   } = props;
 
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const pipelines: Pipeline[] = [];
 
     const queryString = getQueryString({
@@ -138,7 +138,7 @@ export async function listUserPipelinesQuery(
     disabledViewFull,
   } = props;
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const pipelines: Pipeline[] = [];
 
     const queryString = getQueryString({
@@ -193,7 +193,7 @@ export async function getUserPipelineQuery({
   shareCode?: string;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserPipelineResponse>(
       `/${pipelineName}?view=VIEW_FULL`,
@@ -238,7 +238,7 @@ export async function ListUserPipelineReleasesQuery({
   shareCode?: string;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const releases: PipelineRelease[] = [];
 
     const queryString = getQueryString({
@@ -293,7 +293,7 @@ export async function getUserPipelineReleaseQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}?view=VIEW_FULL`
@@ -317,7 +317,7 @@ export async function watchUserPipelineReleaseQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const { data } = await client.get<WatchUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}/watch`
     );
@@ -349,7 +349,7 @@ export async function listOperatorDefinitionsQuery({
   filter: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const operatorDefinitions: OperatorDefinition[] = [];
 
     const queryString = getQueryString({
@@ -393,7 +393,7 @@ export async function getOperatorDefinitionQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOperatorDefinitionResponse>(
       `/${operatorDefinitionName}?view=VIEW_FULL`
@@ -421,7 +421,7 @@ export async function getUserSecretQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetSecretResponse>(`/${secretName}`);
 
@@ -449,7 +449,7 @@ export async function listUserSecretsQuery({
   accessToken: Nullable<string>;
 }) {
   try {
-    const client = createInstillAxiosClient(accessToken, "vdp");
+    const client = createInstillAxiosClient(accessToken);
     const secrets: Secret[] = [];
 
     const queryString = getQueryString({


### PR DESCRIPTION
Because

- Previously we have prefix in our API path like `/vdp/v1beta...`, now we are planning to retire this kind of structure

This commit

- adapt the retirement of api prefix
