### PR TITLE
fix(pipeline-builder): stop user from opening more options when requirement not met

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
@@ -152,7 +152,6 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
                 const values = getValues();
 
                 const parsedResult = ValidatorSchema.safeParse(values);
-                updateCurrentAdvancedConfigurationNodeID(() => id);
 
                 if (parsedResult.success) {
                   updateCurrentAdvancedConfigurationNodeID(() => id);


### PR DESCRIPTION
Because

- stop user from opening more options when requirement not met

This commit

- stop user from opening more options when requirement not met
