### PR TITLE
feat(design-system): improve Select component to let it cover more use cases

### DIFF
--- a/packages/design-system/src/new-ui/Select/Select.stories.tsx
+++ b/packages/design-system/src/new-ui/Select/Select.stories.tsx
@@ -20,17 +20,11 @@ export const Regular: Story = {
       <Select.Content>
         <Select.Group>
           <Select.Label>Fruits</Select.Label>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="banana">Banana</Select.Item>
-          <Select.Item value="blueberry">Blueberry</Select.Item>
-          <Select.Item value="grapes">Grapes</Select.Item>
-          <Select.Item value="pineapple">Pineapple</Select.Item>
-          <Select.Item value="1">1</Select.Item>
-          <Select.Item value="2">2</Select.Item>
-          <Select.Item value="3">3</Select.Item>
-          <Select.Item value="4">4</Select.Item>
-          <Select.Item value="5">5</Select.Item>
-          <Select.Item value="6">6</Select.Item>
+          <Select.Item value="apple" label="Apple" />
+          <Select.Item value="banana" label="Banana" />
+          <Select.Item value="blueberry" label="Blueberry" />
+          <Select.Item value="grapes" label="Grapes" />
+          <Select.Item value="pineapple" label="Pineapple" />
         </Select.Group>
       </Select.Content>
     </Select.Root>
@@ -39,7 +33,7 @@ export const Regular: Story = {
 
 export const WithIcon: Story = {
   render: () => (
-    <Select.Root open={true}>
+    <Select.Root>
       <Select.Trigger className="w-full">
         <Select.Value placeholder="Select a fruit" />
       </Select.Trigger>
@@ -47,20 +41,26 @@ export const WithIcon: Story = {
         <Select.Group>
           <Select.Label>Fruits</Select.Label>
           <Select.Item value="Hello">
-            <div className="flex flex-row space-x-2">
-              <Icons.Box className="h-5 w-5 stroke-semantic-fg-primary group-hover:stroke-semantic-bg-primary" />
-              <p className=" text-semantic-fg-primary product-body-text-3-regular group-hover:text-semantic-bg-primary">
-                Hello
-              </p>
-            </div>
+            <Select.ItemText>
+              <div className="flex flex-row space-x-2">
+                <Icons.Box className="h-5 w-5 stroke-semantic-fg-primary group-hover:stroke-semantic-bg-primary" />
+
+                <p className=" text-semantic-fg-primary product-body-text-3-regular group-hover:text-semantic-bg-primary">
+                  Hello
+                </p>
+              </div>
+            </Select.ItemText>
           </Select.Item>
           <Select.Item value="YO">
-            <div className="flex flex-row space-x-2">
-              <ModelLogo variant="square" width={20} />
-              <p className=" text-semantic-fg-primary product-body-text-3-regular group-hover:text-semantic-bg-primary">
-                YO
-              </p>
-            </div>
+            <Select.ItemText>
+              <div className="flex flex-row space-x-2">
+                <ModelLogo variant="square" width={20} />
+
+                <p className=" text-semantic-fg-primary product-body-text-3-regular group-hover:text-semantic-bg-primary">
+                  YO
+                </p>
+              </div>
+            </Select.ItemText>
           </Select.Item>
         </Select.Group>
       </Select.Content>

--- a/packages/design-system/src/new-ui/Select/Select.tsx
+++ b/packages/design-system/src/new-ui/Select/Select.tsx
@@ -11,6 +11,8 @@ const Group = SelectPrimitive.Group;
 
 const Value = SelectPrimitive.Value;
 
+const ItemText = SelectPrimitive.ItemText;
+
 const Trigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
@@ -84,8 +86,12 @@ const Item = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
     disabledCheck?: boolean;
+
+    // You can use label to have the default ItemText, or you can use
+    // children to have a custom ItemText
+    label?: string;
   }
->(({ className, disabledCheck, children, ...props }, ref) => (
+>(({ className, label, disabledCheck, children, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
@@ -101,7 +107,10 @@ const Item = React.forwardRef<
         </SelectPrimitive.ItemIndicator>
       </span>
     )}
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    {children}
+    {label ? (
+      <SelectPrimitive.ItemText>{label}</SelectPrimitive.ItemText>
+    ) : null}
   </SelectPrimitive.Item>
 ));
 Item.displayName = SelectPrimitive.Item.displayName;
@@ -127,4 +136,5 @@ export const Select = {
   Label,
   Item,
   Separator,
+  ItemText,
 };

--- a/packages/toolkit/src/components/ClonePipelineDialog.tsx
+++ b/packages/toolkit/src/components/ClonePipelineDialog.tsx
@@ -298,32 +298,34 @@ export const ClonePipelineDialog = ({
                                               value={namespace.id}
                                               key={namespace.id}
                                             >
-                                              <div className="flex flex-row gap-x-2">
-                                                <span className="my-auto">
-                                                  {namespace.id}
-                                                </span>
-                                                <span className="my-auto">
-                                                  {namespace.name.includes(
-                                                    "organizations"
-                                                  ) ? (
-                                                    <Tag
-                                                      variant="lightBlue"
-                                                      size="sm"
-                                                      className="!py-0"
-                                                    >
-                                                      organization
-                                                    </Tag>
-                                                  ) : (
-                                                    <Tag
-                                                      size="sm"
-                                                      className="!py-0"
-                                                      variant="lightNeutral"
-                                                    >
-                                                      user
-                                                    </Tag>
-                                                  )}
-                                                </span>
-                                              </div>
+                                              <Select.ItemText>
+                                                <div className="flex flex-row gap-x-2">
+                                                  <span className="my-auto">
+                                                    {namespace.id}
+                                                  </span>
+                                                  <span className="my-auto">
+                                                    {namespace.name.includes(
+                                                      "organizations"
+                                                    ) ? (
+                                                      <Tag
+                                                        variant="lightBlue"
+                                                        size="sm"
+                                                        className="!py-0"
+                                                      >
+                                                        organization
+                                                      </Tag>
+                                                    ) : (
+                                                      <Tag
+                                                        size="sm"
+                                                        className="!py-0"
+                                                        variant="lightNeutral"
+                                                      >
+                                                        user
+                                                      </Tag>
+                                                    )}
+                                                  </span>
+                                                </div>
+                                              </Select.ItemText>
                                             </Select.Item>
                                           )
                                         )}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
@@ -125,11 +125,8 @@ export const OneOfConditionField = ({
                               ? "!product-body-text-4-regular"
                               : "product-body-text-4-regular"
                           )}
-                        >
-                          <p className="my-auto">
-                            {option.title ?? option.key}
-                          </p>
-                        </Select.Item>
+                          label={option.title ?? option.key}
+                        />
                       );
                     })}
                   </Select.Content>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
@@ -68,9 +68,8 @@ export const SingleSelectField = ({
                             ? "!product-body-text-4-regular"
                             : "product-body-text-3-regular"
                         )}
-                      >
-                        <p className="my-auto">{option}</p>
-                      </Select.Item>
+                        label={option}
+                      />
                     );
                   })}
               </Select.Content>

--- a/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
+++ b/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
@@ -271,26 +271,6 @@ export const OneOfConditionSection = ({
               })}
             </Select.Content>
           </Select.Root>
-          {/* <Select.Root
-            onValueChange={onConditionChange}
-            value={selectedConditionOption?.value}
-            disabled={disableAll}
-          >
-            <Select.Trigger className="w-full !rounded-none">
-              <Select.Value />
-            </Select.Trigger>
-            <Select.Content>
-              {conditionOptions.map((option) => (
-                <Select.Item
-                  className="text-semantic-fg-primary product-body-text-2-regular group-hover:text-semantic-bg-primary data-[highlighted]:text-semantic-bg-primary"
-                  key={option.value}
-                  value={option.value}
-                >
-                  <p className="my-auto">{option.label}</p>
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select.Root> */}
           <p className="text-[#1D243380] product-body-text-3-regular">
             {formTree.description ?? ""}
           </p>

--- a/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
+++ b/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
@@ -251,9 +251,8 @@ export const pickComponent = (
                   className="text-semantic-fg-primary product-body-text-2-regular group-hover:text-semantic-bg-primary data-[highlighted]:text-semantic-bg-primary"
                   key={option.value}
                   value={option.value}
-                >
-                  <p className="my-auto">{option.label}</p>
-                </Select.Item>
+                  label={option.label ?? undefined}
+                />
               );
             })}
           </Select.Content>

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
@@ -140,9 +140,8 @@ export const IteratorInput = ({ className }: { className?: string }) => {
                 key={option.path}
                 value={option.path}
                 disabledCheck={true}
-              >
-                {option.path}
-              </Select.Item>
+                label={option.path}
+              />
             ))}
           </Select.Content>
         </Select.Root>

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
@@ -130,9 +130,8 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
             key={option.path}
             value={option.path}
             disabledCheck={true}
-          >
-            {option.path}
-          </Select.Item>
+            label={option.path}
+          />
         ))}
       </Select.Content>
     </Select.Root>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/trigger-node/TriggerNodeTypeSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/trigger-node/TriggerNodeTypeSelect.tsx
@@ -54,12 +54,14 @@ export const TriggerNodeTypeSelect = ({
                   value={key}
                   disabledCheck={true}
                 >
-                  <div className="flex flex-row gap-x-1 rounded-full bg-[#F1F3F9] px-1.5 py-1">
-                    {field.icon}
-                    <p className="text-semantic-fg-primary product-button-button-2">
-                      {field.title}
-                    </p>
-                  </div>
+                  <Select.ItemText>
+                    <div className="flex flex-row gap-x-1 rounded-full bg-[#F1F3F9] px-1.5 py-1">
+                      {field.icon}
+                      <p className="text-semantic-fg-primary product-button-button-2">
+                        {field.title}
+                      </p>
+                    </div>
+                  </Select.ItemText>
                 </Select.Item>
               ))}
             </div>
@@ -85,12 +87,14 @@ export const TriggerNodeTypeSelect = ({
                   value={key}
                   disabledCheck={true}
                 >
-                  <div className="flex flex-row gap-x-1 rounded-full bg-[#F1F3F9] px-1.5 py-1">
-                    {field.icon}
-                    <p className="text-semantic-fg-primary product-button-button-2">
-                      {field.title}
-                    </p>
-                  </div>
+                  <Select.ItemText>
+                    <div className="flex flex-row gap-x-1 rounded-full bg-[#F1F3F9] px-1.5 py-1">
+                      {field.icon}
+                      <p className="text-semantic-fg-primary product-button-button-2">
+                        {field.title}
+                      </p>
+                    </div>
+                  </Select.ItemText>
                 </Select.Item>
               ))}
           </div>

--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -327,31 +327,33 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
                                                 value={namespace.id}
                                                 key={namespace.id}
                                               >
-                                                <div className="flex flex-row gap-x-2">
-                                                  <span className="my-auto">
-                                                    {namespace.id}
-                                                  </span>
-                                                  <span className="my-auto">
-                                                    {namespace.type ===
-                                                    "organization" ? (
-                                                      <Tag
-                                                        variant="lightBlue"
-                                                        size="sm"
-                                                        className="!py-0"
-                                                      >
-                                                        organization
-                                                      </Tag>
-                                                    ) : (
-                                                      <Tag
-                                                        size="sm"
-                                                        className="!py-0"
-                                                        variant="lightNeutral"
-                                                      >
-                                                        user
-                                                      </Tag>
-                                                    )}
-                                                  </span>
-                                                </div>
+                                                <Select.ItemText>
+                                                  <div className="flex flex-row gap-x-2">
+                                                    <span className="my-auto">
+                                                      {namespace.id}
+                                                    </span>
+                                                    <span className="my-auto">
+                                                      {namespace.type ===
+                                                      "organization" ? (
+                                                        <Tag
+                                                          variant="lightBlue"
+                                                          size="sm"
+                                                          className="!py-0"
+                                                        >
+                                                          organization
+                                                        </Tag>
+                                                      ) : (
+                                                        <Tag
+                                                          size="sm"
+                                                          className="!py-0"
+                                                          variant="lightNeutral"
+                                                        >
+                                                          user
+                                                        </Tag>
+                                                      )}
+                                                    </span>
+                                                  </div>
+                                                </Select.ItemText>
                                               </Select.Item>
                                             )
                                           )}

--- a/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
@@ -144,9 +144,9 @@ export const ViewPipelines = () => {
               </Select.Trigger>
               <Select.Content>
                 <Select.Group>
-                  <Select.Item value="VISIBILITY_UNSPECIFIED">All</Select.Item>
-                  <Select.Item value="VISIBILITY_PUBLIC">Public</Select.Item>
-                  <Select.Item value="VISIBILITY_PRIVATE">Private</Select.Item>
+                  <Select.Item value="VISIBILITY_UNSPECIFIED" label="All" />
+                  <Select.Item value="VISIBILITY_PUBLIC" label="Public" />
+                  <Select.Item value="VISIBILITY_PRIVATE" label="Private" />
                 </Select.Group>
               </Select.Content>
             </Select.Root>


### PR DESCRIPTION
Because

To properly support the complex pattern mentioned in [Radix-UI](https://www.radix-ui.com/primitives/docs/components/select#with-complex-items)

We will have two patterns in our Select component

- Using label props -> This will have default Select.ItemText component inside the default Select.Item
- Using children -> You need to manually wrap the whole select component into Select.ItemText

```typescript
 <Select.ItemText>
  <img src="…" />
  Adolfo Hess
</Select.ItemText>
```

This commit

- improve Select component to let it cover more use cases
