### PR TITLE
fix: dependabot alerts

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -103,7 +103,7 @@
     "tsup": "^6.7.0",
     "typescript": "^5.4.2",
     "vitest": "^1.2.1",
-    "webpack": "^5.70.0"
+    "webpack": "^5.76.0"
   },
   "peerDependencies": {
     "react": "^18.2.0",
@@ -135,7 +135,7 @@
     "react-hook-form": "^7.51.0",
     "sanitize-html": "^2.13.0",
     "tailwindcss-animate": "^1.0.6",
-    "zod": "^3.21.4"
+    "zod": "^3.22.3"
   },
   "engines": {
     "node": ">=14.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,7 +386,7 @@ importers:
         specifier: ^1.0.6
         version: 1.0.7(tailwindcss@3.4.1)
       zod:
-        specifier: ^3.21.4
+        specifier: ^3.22.3
         version: 3.22.4
     devDependencies:
       '@babel/core':
@@ -543,7 +543,7 @@ importers:
         specifier: ^1.2.1
         version: 1.2.1(@types/node@20.11.5)(jsdom@21.1.2)
       webpack:
-        specifier: ^5.70.0
+        specifier: ^5.76.0
         version: 5.89.0(esbuild@0.17.19)
 
   packages/design-tokens:


### PR DESCRIPTION
Because

- dependabot alerts
    - https://github.com/instill-ai/instill.tech/security/dependabot/36
    - https://github.com/instill-ai/instill.tech/security/dependabot/41

This commit

- dependabot alerts
