### PR TITLE
fix: fix ci and docker node version to adapt node20

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ (github.event_name == 'release') && startsWith(github.event.release.tag_name, 'v') }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v2.0.1
         if: ${{ (github.event_name == 'release') && startsWith(github.event.release.tag_name, 'v') }}

--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v2.0.1
         name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v2.0.1
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: pnpm/action-setup@v2.0.1
         name: Install pnpm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # Install dependencies only when needed
-FROM --platform=$BUILDPLATFORM node:18-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN npm install -g pnpm@8.1.1
+RUN npm install -g pnpm@8.8.0
 
 COPY . . 
 
@@ -13,7 +13,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm run build 
 
 # Production image, copy all the files and run next
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,11 +1,11 @@
 # pull playwright docker image
 # Install dependencies only when needed
-FROM --platform=$BUILDPLATFORM node:18-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN npm install -g pnpm@8.1.1
+RUN npm install -g pnpm@8.8.0
 
 COPY . . 
 
@@ -16,7 +16,7 @@ WORKDIR /app
 
 ARG TEST_USER="playwright"
 
-RUN npm install -g pnpm@8.1.1
+RUN npm install -g pnpm@8.8.0
 
 # Install vim for debugging
 RUN apt-get update

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -96,5 +96,5 @@
   "engines": {
     "node": ">=14.6.0"
   },
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.8.0"
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -145,7 +145,7 @@
       "eslint --cache --fix"
     ]
   },
-  "packageManager": "pnpm@7.5.0",
+  "packageManager": "pnpm@8.8.0",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Because

- Console now demand to use node 20, this PR updates the relative configuration in the GitHub CI and the docker

This commit

- fix ci and docker node version
