### PR TITLE
feat(pipeline-builder): dynamic switch smart-hint description for instill credit, and hint connector is using Instill Credit

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
@@ -17,21 +17,23 @@ export const SingleSelectField = ({
   size,
   isHidden,
   instillCredentialMap,
-  setSupportInstillCredit,
+  updateSupportInstillCredit,
   updateForceCloseCollapsibleFormGroups,
   updateForceOpenCollapsibleFormGroups,
+  updateIsUsingInstillCredit,
 }: {
   options: string[];
   shortDescription?: string;
   disabled?: boolean;
   instillCredentialMap?: InstillCredentialMap;
-  setSupportInstillCredit?: (value: boolean) => void;
+  updateSupportInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
   updateForceCloseCollapsibleFormGroups?: React.Dispatch<
     React.SetStateAction<string[]>
   >;
   updateForceOpenCollapsibleFormGroups?: React.Dispatch<
     React.SetStateAction<string[]>
   >;
+  updateIsUsingInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
 } & AutoFormFieldBaseProps) => {
   return isHidden ? null : (
     <Form.Field
@@ -78,8 +80,12 @@ export const SingleSelectField = ({
                       );
                     }
 
-                    if (setSupportInstillCredit) {
-                      setSupportInstillCredit(true);
+                    if (updateSupportInstillCredit) {
+                      updateSupportInstillCredit(true);
+                    }
+
+                    if (updateIsUsingInstillCredit) {
+                      updateIsUsingInstillCredit(true);
                     }
 
                     if (updateForceCloseCollapsibleFormGroups) {
@@ -99,8 +105,8 @@ export const SingleSelectField = ({
                       form.clearErrors(currentCredentialFieldPath);
                     }
 
-                    if (setSupportInstillCredit) {
-                      setSupportInstillCredit(false);
+                    if (updateSupportInstillCredit) {
+                      updateSupportInstillCredit(false);
                     }
 
                     if (updateForceOpenCollapsibleFormGroups) {

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -17,6 +17,7 @@ import { useValidateReferenceAndTemplate } from "./useValidateReferenceAndTempla
 import { getFieldPlaceholder } from "./getFieldPlaceholder";
 import { FieldDescriptionTooltip } from "../common";
 import { Secret } from "../../../vdp-sdk";
+import { InstillCredit } from "../../../../constant";
 
 export const TextArea = ({
   form,
@@ -35,6 +36,7 @@ export const TextArea = ({
   instillSecret,
   instillCredential,
   supportInstillCredit,
+  updateIsUsingInstillCredit,
 }: {
   instillAcceptFormats: string[];
   shortDescription?: string;
@@ -46,6 +48,7 @@ export const TextArea = ({
   instillSecret?: boolean;
   instillCredential?: boolean;
   supportInstillCredit?: boolean;
+  updateIsUsingInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
 } & AutoFormFieldBaseProps) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =
@@ -154,6 +157,8 @@ export const TextArea = ({
                         setCurrentCursorPos,
                         setSmartHintEnabledPos,
                         setSmartHintsPopoverIsOpen,
+                        updateIsUsingInstillCredit,
+                        supportInstillCredit,
                       });
                     }}
                     placeholder={placeholder}
@@ -230,7 +235,14 @@ export const TextArea = ({
                 "nodrag nopan cursor-text select-text",
                 size === "sm" ? "!product-body-text-4-regular" : ""
               )}
-              text={shortDescription ?? null}
+              text={
+                supportInstillCredit
+                  ? `${title} support Instill Credit. You can use Instill Credit by input ` +
+                    "${" +
+                    `secrets.${InstillCredit.key}` +
+                    "}. You can still bring your own key by input ${secrets.your_secret}"
+                  : shortDescription ?? null
+              }
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -17,6 +17,7 @@ import { useValidateReferenceAndTemplate } from "./useValidateReferenceAndTempla
 import { getFieldPlaceholder } from "./getFieldPlaceholder";
 import { FieldDescriptionTooltip } from "../common";
 import { Secret } from "../../../vdp-sdk";
+import { InstillCredit } from "../../../../constant";
 
 export const TextField = ({
   form,
@@ -35,6 +36,7 @@ export const TextField = ({
   instillSecret,
   instillCredential,
   supportInstillCredit,
+  updateIsUsingInstillCredit,
 }: {
   instillAcceptFormats: string[];
   shortDescription?: string;
@@ -46,6 +48,7 @@ export const TextField = ({
   instillSecret?: boolean;
   instillCredential?: boolean;
   supportInstillCredit?: boolean;
+  updateIsUsingInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
 } & AutoFormFieldBaseProps) => {
   const smartHints = useInstillStore((s) => s.smartHints);
   const [smartHintsPopoverIsOpen, setSmartHintsPopoverIsOpen] =
@@ -165,6 +168,8 @@ export const TextField = ({
                           setCurrentCursorPos,
                           setSmartHintEnabledPos,
                           setSmartHintsPopoverIsOpen,
+                          updateIsUsingInstillCredit,
+                          supportInstillCredit,
                         });
                       }}
                       onFocus={() => {
@@ -241,7 +246,14 @@ export const TextField = ({
                 "nodrag nopan cursor-text select-text",
                 size === "sm" ? "!product-body-text-4-regular" : ""
               )}
-              text={shortDescription ?? null}
+              text={
+                supportInstillCredit
+                  ? `${title} support Instill Credit. You can use Instill Credit by input ` +
+                    "${" +
+                    `secrets.${InstillCredit.key}` +
+                    "}. You can still bring your own key by input ${secrets.your_secret}"
+                  : shortDescription ?? null
+              }
             />
             <Form.Message
               className={size === "sm" ? "!product-body-text-4-medium" : ""}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputChange.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputChange.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { getReferencesFromString } from "../../../../view";
 import { ControllerRenderProps } from "react-hook-form";
 import { GeneralUseFormReturn, Nullable } from "../../../type";
+import { InstillCredit } from "../../../../constant";
 
 export function onInputChange({
   field,
@@ -12,6 +13,8 @@ export function onInputChange({
   setEnableSmartHints,
   setSmartHintEnabledPos,
   setCurrentCursorPos,
+  supportInstillCredit,
+  updateIsUsingInstillCredit,
 }: {
   field: ControllerRenderProps<
     {
@@ -29,6 +32,8 @@ export function onInputChange({
     React.SetStateAction<Nullable<number>>
   >;
   setCurrentCursorPos: React.Dispatch<React.SetStateAction<Nullable<number>>>;
+  supportInstillCredit?: boolean;
+  updateIsUsingInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const currentCursorPos = event.target.selectionStart;
 
@@ -72,6 +77,16 @@ export function onInputChange({
     if (event.target.value[currentCursorPos - 1] === "$") {
       setEnableSmartHints(false);
       setSmartHintEnabledPos(null);
+    }
+  }
+
+  console.log(supportInstillCredit, event.target.value);
+
+  if (supportInstillCredit && updateIsUsingInstillCredit) {
+    if (event.target.value !== "${" + InstillCredit.key + "}") {
+      updateIsUsingInstillCredit(false);
+    } else {
+      updateIsUsingInstillCredit(true);
     }
   }
 

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -30,7 +30,8 @@ export type PickRegularFieldsFromInstillFormTreeOptions = {
     React.SetStateAction<string[]>
   >;
   supportInstillCredit?: boolean;
-  setSupportInstillCredit?: (value: boolean) => void;
+  updateSupportInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
+  updateIsUsingInstillCredit?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export function pickRegularFieldsFromInstillFormTree(
@@ -49,7 +50,8 @@ export function pickRegularFieldsFromInstillFormTree(
   const size = options?.size;
   const secrets = options?.secrets ?? [];
   const supportInstillCredit = options?.supportInstillCredit ?? false;
-  const setSupportInstillCredit = options?.setSupportInstillCredit ?? undefined;
+  const updateSupportInstillCredit =
+    options?.updateSupportInstillCredit ?? undefined;
 
   const enabledCollapsibleFormGroup =
     options?.enabledCollapsibleFormGroup ?? false;
@@ -62,6 +64,7 @@ export function pickRegularFieldsFromInstillFormTree(
     options?.forceOpenCollapsibleFormGroups ?? [];
   const updateForceOpenCollapsibleFormGroups =
     options?.updateForceOpenCollapsibleFormGroups;
+  const updateIsUsingInstillCredit = options?.updateIsUsingInstillCredit;
 
   let title: Nullable<string> = null;
 
@@ -294,13 +297,14 @@ export function pickRegularFieldsFromInstillFormTree(
         size={size}
         isHidden={tree.isHidden}
         instillCredentialMap={tree.instillCredentialMap}
-        setSupportInstillCredit={setSupportInstillCredit}
+        updateSupportInstillCredit={updateSupportInstillCredit}
         updateForceCloseCollapsibleFormGroups={
           updateForceCloseCollapsibleFormGroups
         }
         updateForceOpenCollapsibleFormGroups={
           updateForceOpenCollapsibleFormGroups
         }
+        updateIsUsingInstillCredit={updateIsUsingInstillCredit}
       />
     );
   }
@@ -326,6 +330,7 @@ export function pickRegularFieldsFromInstillFormTree(
           instillSecret={tree.instillSecret}
           instillCredential={tree.instillCredential}
           supportInstillCredit={supportInstillCredit}
+          updateIsUsingInstillCredit={updateIsUsingInstillCredit}
         />
       );
     }
@@ -365,6 +370,7 @@ export function pickRegularFieldsFromInstillFormTree(
         instillSecret={tree.instillSecret}
         instillCredential={tree.instillCredential}
         supportInstillCredit={supportInstillCredit}
+        updateIsUsingInstillCredit={updateIsUsingInstillCredit}
       />
     );
   }

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
@@ -33,7 +33,8 @@ export type UseInstillFormOptions = {
   | "forceOpenCollapsibleFormGroups"
   | "updateForceOpenCollapsibleFormGroups"
   | "supportInstillCredit"
-  | "setSupportInstillCredit"
+  | "updateSupportInstillCredit"
+  | "updateIsUsingInstillCredit"
 >;
 
 export function useInstillForm(
@@ -52,7 +53,7 @@ export function useInstillForm(
     options?.enabledCollapsibleFormGroup ?? false;
   const collapsibleDefaultOpen = options?.collapsibleDefaultOpen ?? false;
   const supportInstillCredit = options?.supportInstillCredit ?? false;
-  const setSupportInstillCredit = options?.setSupportInstillCredit;
+  const updateSupportInstillCredit = options?.updateSupportInstillCredit;
   const forceCloseCollapsibleFormGroups =
     options?.forceCloseCollapsibleFormGroups ?? [];
   const updateForceCloseCollapsibleFormGroups =
@@ -61,6 +62,7 @@ export function useInstillForm(
     options?.forceOpenCollapsibleFormGroups ?? [];
   const updateForceOpenCollapsibleFormGroups =
     options?.updateForceOpenCollapsibleFormGroups;
+  const updateIsUsingInstillCredit = options?.updateIsUsingInstillCredit;
 
   const [formTree, setFormTree] = React.useState<InstillFormTree | null>(null);
   const [ValidatorSchema, setValidatorSchema] = React.useState<z.ZodTypeAny>(
@@ -157,11 +159,12 @@ export function useInstillForm(
         enabledCollapsibleFormGroup,
         collapsibleDefaultOpen,
         supportInstillCredit,
-        setSupportInstillCredit,
+        updateSupportInstillCredit,
         forceCloseCollapsibleFormGroups,
         updateForceCloseCollapsibleFormGroups,
         forceOpenCollapsibleFormGroups,
         updateForceOpenCollapsibleFormGroups,
+        updateIsUsingInstillCredit,
       }
     );
 
@@ -180,11 +183,12 @@ export function useInstillForm(
     enabledCollapsibleFormGroup,
     collapsibleDefaultOpen,
     supportInstillCredit,
-    setSupportInstillCredit,
+    updateSupportInstillCredit,
     forceCloseCollapsibleFormGroups,
     updateForceCloseCollapsibleFormGroups,
     forceOpenCollapsibleFormGroups,
     updateForceOpenCollapsibleFormGroups,
+    updateIsUsingInstillCredit,
   ]);
 
   return {

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
@@ -4,6 +4,7 @@ import cn from "clsx";
 import * as React from "react";
 import { useNodeBottomBarContext } from "./NodeBottomBarContext";
 import { useInstillStore } from "../../../../../../lib";
+import { Icons, Tooltip } from "@instill-ai/design-system";
 
 const NodeBottomBarMenuRootPrimitive = ({
   children,
@@ -48,7 +49,11 @@ export const NodeBottomBarMenuPrimitive = {
   Item: NodeBottomBarMenuItemPrimitive,
 };
 
-export const NodeBottomBarMenu = () => {
+export const NodeBottomBarMenu = ({
+  isUsingInstillCredit,
+}: {
+  isUsingInstillCredit?: boolean;
+}) => {
   const { setSelectedValue } = useNodeBottomBarContext();
   const pipelineIsReadOnly = useInstillStore(
     (store) => store.pipelineIsReadOnly
@@ -80,6 +85,37 @@ export const NodeBottomBarMenu = () => {
       >
         Schema
       </NodeBottomBarMenuPrimitive.Item>
+      {isUsingInstillCredit ? (
+        <Tooltip.Provider>
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <Icons.CoinsStacked01 className="my-auto ml-auto h-4 w-4 cursor-pointer stroke-semantic-fg-disabled" />
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                className="w-[320px]"
+                sideOffset={5}
+                side="right"
+              >
+                <div className="flex flex-col gap-y-1 rounded-sm bg-semantic-bg-primary p-3">
+                  <p className="text-semantic-fg-primary product-body-text-4-medium">
+                    Instill Credit
+                  </p>
+                  <p className="text-semantic-fg-primary product-body-text-4-medium">
+                    This connector is using Instill Credit
+                  </p>
+                </div>
+                <Tooltip.Arrow
+                  className="fill-white"
+                  offset={5}
+                  width={9}
+                  height={6}
+                />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>
+      ) : null}
     </NodeBottomBarMenuPrimitive.Root>
   );
 };

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/connector-node/ConnectorNode.tsx
@@ -56,7 +56,10 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     React.useState<string[]>([]);
   const [noteIsOpen, setNoteIsOpen] = React.useState(false);
   const [enableEdit, setEnableEdit] = React.useState(false);
-  const [supportInstillCredit, setSupportInstillCredit] = React.useState(false);
+  const [supportInstillCredit, updateSupportInstillCredit] =
+    React.useState(false);
+  const [isUsingInstillCredit, updateIsUsingInstillCredit] =
+    React.useState(false);
 
   React.useEffect(() => {
     setNodeIsCollapsed(collapseAllNodes);
@@ -87,7 +90,8 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
         forceOpenCollapsibleFormGroups,
         updateForceOpenCollapsibleFormGroups: setForceOpenCollapsibleFormGroups,
         supportInstillCredit,
-        setSupportInstillCredit,
+        updateSupportInstillCredit,
+        updateIsUsingInstillCredit,
       }
     );
 
@@ -115,7 +119,9 @@ export const ConnectorNode = ({ data, id }: NodeProps<ConnectorNodeData>) => {
     <NodeWrapper
       nodeData={data}
       noteIsOpen={noteIsOpen}
-      renderNodeBottomBar={() => <NodeBottomBarMenu />}
+      renderNodeBottomBar={() => (
+        <NodeBottomBarMenu isUsingInstillCredit={isUsingInstillCredit} />
+      )}
       renderBottomBarInformation={() => (
         <NodeBottomBarContent
           componentID={data.id}


### PR DESCRIPTION
Because

- We want to make sure the user understand when and how they are using Instill Credit, so we dynamically generate field description for field that support Instill Credit
- We hint connector is using Instill Credit

This commit

- dynamic switch smart-hint description for instill credit, and hint connector is using Instill Credit
