### PR TITLE
fix: fix initial instill credit hint issue and remaining credit text

### DIFF
--- a/apps/console/integration-test/tests/should-change-component-id.test.ts
+++ b/apps/console/integration-test/tests/should-change-component-id.test.ts
@@ -39,7 +39,7 @@ export function shouldChangeComponentID() {
       // Configure new ST component
       const stComponent = page.locator(`[data-id='${oldSTComponentID}']`);
       const stTaskSelectTrigger = stComponent.getByLabel(
-        "Stability AI Component"
+        "Stability AI Component",
       );
       await stTaskSelectTrigger.click();
       const stTaskContent = await getSelectContent(page, stTaskSelectTrigger);
@@ -48,7 +48,7 @@ export function shouldChangeComponentID() {
       await stEngineSelectTrigger.click();
       const stEngineContent = await getSelectContent(
         page,
-        stEngineSelectTrigger
+        stEngineSelectTrigger,
       );
       await stEngineContent.getByText("stable-diffusion-xl-1024-v1-0").click();
       await page
@@ -67,12 +67,14 @@ export function shouldChangeComponentID() {
 
       // expect conection line is on pipeline-builder
       await expect(
-        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
+        page.locator(
+          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
+        ),
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`
-        )
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
+        ),
       ).toHaveCount(1);
     });
 
@@ -88,33 +90,41 @@ export function shouldChangeComponentID() {
 
       // expect connection line is not on pipeline-builder
       await expect(
-        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
+        page.locator(
+          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
+        ),
       ).toHaveCount(0);
       await expect(
-        page.locator(`g[aria-label='Edge from trigger to ${newSTComponentID}']`)
+        page.locator(
+          `g[aria-label='Edge from trigger to ${newSTComponentID}']`,
+        ),
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`
-        )
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
+        ),
       ).toHaveCount(0);
 
       // expect connection line is not on pipeline-builder after save
       await pipelineBuilderPage.expectToSave();
       await page.reload();
       await expect(
-        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
+        page.locator(
+          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
+        ),
       ).toHaveCount(0);
       await expect(
-        page.locator(`g[aria-label='Edge from trigger to ${newSTComponentID}']`)
+        page.locator(
+          `g[aria-label='Edge from trigger to ${newSTComponentID}']`,
+        ),
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`
-        )
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
+        ),
       ).toHaveCount(0);
       await expect(newStComponent.locator("input[name='nodeID']")).toHaveValue(
-        newSTComponentID
+        newSTComponentID,
       );
     });
 

--- a/apps/console/integration-test/tests/should-change-component-id.test.ts
+++ b/apps/console/integration-test/tests/should-change-component-id.test.ts
@@ -39,7 +39,7 @@ export function shouldChangeComponentID() {
       // Configure new ST component
       const stComponent = page.locator(`[data-id='${oldSTComponentID}']`);
       const stTaskSelectTrigger = stComponent.getByLabel(
-        "Stability AI Component",
+        "Stability AI Component"
       );
       await stTaskSelectTrigger.click();
       const stTaskContent = await getSelectContent(page, stTaskSelectTrigger);
@@ -48,15 +48,12 @@ export function shouldChangeComponentID() {
       await stEngineSelectTrigger.click();
       const stEngineContent = await getSelectContent(
         page,
-        stEngineSelectTrigger,
+        stEngineSelectTrigger
       );
       await stEngineContent.getByText("stable-diffusion-xl-1024-v1-0").click();
       await page
         .locator("input[name='input.prompts']")
         .fill("${trigger." + startFieldKey + "}");
-      await page
-        .locator("input[name='connection.api_key']")
-        .fill("${secrets.TEST}");
 
       // Create output result field in the end operator
       await pipelineBuilderPage.createEndComponentField({
@@ -70,14 +67,12 @@ export function shouldChangeComponentID() {
 
       // expect conection line is on pipeline-builder
       await expect(
-        page.locator(
-          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
-        ),
+        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
-        ),
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`
+        )
       ).toHaveCount(1);
     });
 
@@ -93,41 +88,33 @@ export function shouldChangeComponentID() {
 
       // expect connection line is not on pipeline-builder
       await expect(
-        page.locator(
-          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
-        ),
+        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
       ).toHaveCount(0);
       await expect(
-        page.locator(
-          `g[aria-label='Edge from trigger to ${newSTComponentID}']`,
-        ),
+        page.locator(`g[aria-label='Edge from trigger to ${newSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
-        ),
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`
+        )
       ).toHaveCount(0);
 
       // expect connection line is not on pipeline-builder after save
       await pipelineBuilderPage.expectToSave();
       await page.reload();
       await expect(
-        page.locator(
-          `g[aria-label='Edge from trigger to ${oldSTComponentID}']`,
-        ),
+        page.locator(`g[aria-label='Edge from trigger to ${oldSTComponentID}']`)
       ).toHaveCount(0);
       await expect(
-        page.locator(
-          `g[aria-label='Edge from trigger to ${newSTComponentID}']`,
-        ),
+        page.locator(`g[aria-label='Edge from trigger to ${newSTComponentID}']`)
       ).toHaveCount(1);
       await expect(
         page.locator(
-          `g[aria-label='Edge from ${oldSTComponentID} to response']`,
-        ),
+          `g[aria-label='Edge from ${oldSTComponentID} to response']`
+        )
       ).toHaveCount(0);
       await expect(newStComponent.locator("input[name='nodeID']")).toHaveValue(
-        newSTComponentID,
+        newSTComponentID
       );
     });
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.90.0-rc.2",
+  "version": "0.90.0-rc.3",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.90.0-rc.1",
+  "version": "0.90.0-rc.2",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.90.0-rc.3",
+  "version": "0.90.0-rc.4",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/components/top-bar/RemainingCredit.tsx
+++ b/packages/toolkit/src/components/top-bar/RemainingCredit.tsx
@@ -37,7 +37,7 @@ export const RemainingCreditCTA = ({
   return (
     <div className="flex w-full flex-row gap-x-2 rounded-sm bg-semantic-bg-base-bg px-3 py-4">
       {remainingCredit.isSuccess ? (
-        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
+        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data} credits left`}</p>
       ) : (
         <Skeleton className="my-auto h-5 w-[100px] rounded" />
       )}

--- a/packages/toolkit/src/components/top-bar/RemainingCredit.tsx
+++ b/packages/toolkit/src/components/top-bar/RemainingCredit.tsx
@@ -37,7 +37,7 @@ export const RemainingCreditCTA = ({
   return (
     <div className="flex w-full flex-row gap-x-2 rounded-sm bg-semantic-bg-base-bg px-3 py-4">
       {remainingCredit.isSuccess ? (
-        <p className=" font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
+        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
       ) : (
         <Skeleton className="my-auto h-5 w-[100px] rounded" />
       )}

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -236,7 +236,7 @@ export const TextArea = ({
                 size === "sm" ? "!product-body-text-4-regular" : ""
               )}
               text={
-                supportInstillCredit
+                supportInstillCredit && instillCredential
                   ? `${title} support Instill Credit. You can use Instill Credit by input ` +
                     "${" +
                     `secrets.${InstillCredit.key}` +

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -248,7 +248,7 @@ export const TextField = ({
                 size === "sm" ? "!product-body-text-4-regular" : ""
               )}
               text={
-                supportInstillCredit
+                supportInstillCredit && instillCredential
                   ? `${title} support Instill Credit. You can use Instill Credit by input ` +
                     "${" +
                     `secrets.${InstillCredit.key}` +

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -298,13 +298,13 @@ export function pickRegularFieldsFromInstillFormTree(
         isHidden={tree.isHidden}
         instillCredentialMap={tree.instillCredentialMap}
         updateSupportInstillCredit={updateSupportInstillCredit}
+        updateIsUsingInstillCredit={updateIsUsingInstillCredit}
         updateForceCloseCollapsibleFormGroups={
           updateForceCloseCollapsibleFormGroups
         }
         updateForceOpenCollapsibleFormGroups={
           updateForceOpenCollapsibleFormGroups
         }
-        updateIsUsingInstillCredit={updateIsUsingInstillCredit}
       />
     );
   }

--- a/packages/toolkit/src/view/pipeline-builder/components/RemainingCreditCTA.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/RemainingCreditCTA.tsx
@@ -35,7 +35,7 @@ export const RemainingCreditCTA = ({
   return (
     <div className="flex w-[232px] flex-row gap-x-2 rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-2">
       {remainingCredit.isSuccess ? (
-        <p className=" font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
+        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
       ) : (
         <Skeleton className="my-auto h-5 w-[100px] rounded" />
       )}

--- a/packages/toolkit/src/view/pipeline-builder/components/RemainingCreditCTA.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/RemainingCreditCTA.tsx
@@ -35,7 +35,7 @@ export const RemainingCreditCTA = ({
   return (
     <div className="flex w-[232px] flex-row gap-x-2 rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-2">
       {remainingCredit.isSuccess ? (
-        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data}`}</p>
+        <p className="my-auto font-mono text-[11px] font-medium text-[#344054]">{`${remainingCredit.data} credits left`}</p>
       ) : (
         <Skeleton className="my-auto h-5 w-[100px] rounded" />
       )}


### PR DESCRIPTION
Because

- When we first render the component, especially when user select text-generation, we should by default add instill-credit into api_key field

This commit

- fix initial instill credit hint issue and remaining credit text
