### PR TITLE
fix(pipeline-builder): better handle the enter experience in smart hint field

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -171,6 +171,7 @@ export const TextArea = ({
                     disabled={disabled}
                     onKeyDown={(e) => {
                       onInputKeydown({
+                        componentType: "TextArea",
                         event: e,
                         form,
                         field,

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -182,6 +182,7 @@ export const TextField = ({
                       disabled={disabled}
                       onKeyDown={(e) => {
                         onInputKeydown({
+                          componentType: "TextField",
                           event: e,
                           form,
                           field,

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputKeydown.tsx
@@ -4,6 +4,7 @@ import { ControllerRenderProps } from "react-hook-form";
 import { GeneralUseFormReturn, Nullable } from "../../../type";
 
 export function onInputKeydown({
+  componentType,
   field,
   event,
   path,
@@ -17,6 +18,7 @@ export function onInputKeydown({
   setEnableSmartHints,
   smartHintEnabledPos,
 }: {
+  componentType: "TextField" | "TextArea";
   form: GeneralUseFormReturn;
   field: ControllerRenderProps<
     {
@@ -75,9 +77,13 @@ export function onInputKeydown({
       break;
     }
     case "Enter": {
-      event.preventDefault();
+      if (componentType === "TextField") {
+        event.preventDefault();
+      }
 
       if (enableSmartHints) {
+        event.preventDefault();
+
         if (filteredHints.length > 0) {
           if (inputRef.current) {
             const cursorPosition = inputRef.current.selectionStart;


### PR DESCRIPTION
Because

- Previously user can not press enter in TextArea and if we wrongly preventDefault, the enter in TextField will cause page refresh

This commit

- better handle the enter experience in smart hint field
