### PR TITLE
fix(pipeline-builder): fix a bug when user duplicate component, the configuration will be wrongly synced

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.90.0-rc.4",
+  "version": "0.90.0-rc.5",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ConnectorOperatorControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/ConnectorOperatorControlPanel.tsx
@@ -112,7 +112,7 @@ export const ConnectorOperatorControlPanel = ({
 
   const handleCopyNode = React.useCallback(() => {
     let nodePrefix: Nullable<string> = null;
-    let nodeType = "connectorNode";
+    let nodeType: Nullable<string> = null;
 
     if (isOperatorComponent(nodeData)) {
       if (!nodeData.operator_component.definition) {
@@ -134,6 +134,8 @@ export const ConnectorOperatorControlPanel = ({
       nodePrefix = transformConnectorDefinitionIDToComponentIDPrefix(
         nodeData.connector_component.definition.id
       );
+
+      nodeType = "connectorNode";
     }
 
     if (isIteratorComponent(nodeData)) {
@@ -142,7 +144,7 @@ export const ConnectorOperatorControlPanel = ({
       nodeType = "iteratorNode";
     }
 
-    if (!nodePrefix) {
+    if (!nodePrefix || !nodeType) {
       return;
     }
 
@@ -167,7 +169,10 @@ export const ConnectorOperatorControlPanel = ({
         targetPosition: Position.Right,
         position: { x: 0, y: 0 },
         zIndex: 30,
-        data: nodeData,
+        data: {
+          ...nodeData,
+          id: nodeID,
+        },
       },
     ];
     const newEdges = composeEdgesFromNodes(newNodes);


### PR DESCRIPTION
Because

- fix a bug when user duplicate component, the configuration will be wrongly synced

This commit

- fix a bug when user duplicate component, the configuration will be wrongly synced
