### PR TITLE
fix(pipeline-builder): fix when select a model not support instill credit the api_key keep flushed away

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.91.0-rc.0",
+  "version": "0.91.0-rc.1",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
@@ -74,7 +74,6 @@ export const SingleSelectField = ({
         }
       }
 
-      // name === "task" is a workaround for top level task selection
       if (isInstillCreditField && instillCredentialMap) {
         const currentCredentialFieldPath = instillCredentialMap.targets[0];
 
@@ -82,10 +81,14 @@ export const SingleSelectField = ({
           values,
           currentCredentialFieldPath
         );
+
         // Deal with case that support instill credit, if the secret field
         // is empty, we will fill in the instill credit key into that field
         if (instillCredentialMap.values.includes(fieldValue)) {
-          if (!currentCredentialFieldValue) {
+          if (
+            !currentCredentialFieldValue &&
+            name !== currentCredentialFieldPath
+          ) {
             form.setValue(
               currentCredentialFieldPath,
               "${secrets." + `${InstillCredit.key}` + "}"
@@ -111,7 +114,11 @@ export const SingleSelectField = ({
           // Deal with case that don't support instil credit. We
           // will focus on the secret field and clear the value
 
-          if (currentCredentialFieldValue) {
+          if (
+            currentCredentialFieldValue &&
+            name &&
+            name !== currentCredentialFieldPath
+          ) {
             form.setValue(currentCredentialFieldPath, "");
             form.clearErrors(currentCredentialFieldPath);
           }

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputChange.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/onInputChange.tsx
@@ -81,7 +81,10 @@ export function onInputChange({
   }
 
   if (supportInstillCredit && updateIsUsingInstillCredit) {
-    if (event.target.value !== "${" + InstillCredit.key + "}") {
+    if (
+      event.target.value.trim().replace("${", "").replace("}", "") !==
+      `secrets.${InstillCredit.key}`
+    ) {
       updateIsUsingInstillCredit(false);
     } else {
       updateIsUsingInstillCredit(true);


### PR DESCRIPTION
Because

- fix when select a model not support instill credit the api_key keep flushed away

This commit

- fix when select a model not support instill credit the api_key keep flushed away
