### PR TITLE
fix: fix typo in the instill credit hint

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
@@ -151,9 +151,9 @@ export const SmartHintList = ({
           <p className="text-semantic-accent-default product-body-text-3-semibold">
             {instillCredential
               ? supportInstillCredit
-                ? "This configuration support Instill Credit, you can use ${" +
+                ? "This configuration supports Instill Credit, You can use Instill Credit by input ${secrets." +
                   InstillCredit.key +
-                  "} to reference it"
+                  "}."
                 : "This configuration didn't support Instill Credit, please reference your own secret"
               : humanReadableAcceptFormatString}
           </p>

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -238,7 +238,7 @@ export const TextArea = ({
               )}
               text={
                 supportInstillCredit && instillCredential
-                  ? `${title} support Instill Credit. You can use Instill Credit by input ` +
+                  ? `${title} supports Instill Credit. You can use Instill Credit by input ` +
                     "${" +
                     `secrets.${InstillCredit.key}` +
                     "}. You can still bring your own key by input ${secrets.your_secret}"

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -250,7 +250,7 @@ export const TextField = ({
               )}
               text={
                 supportInstillCredit && instillCredential
-                  ? `${title} support Instill Credit. You can use Instill Credit by input ` +
+                  ? `${title} supports Instill Credit. You can use Instill Credit by input ` +
                     "${" +
                     `secrets.${InstillCredit.key}` +
                     "}. You can still bring your own key by input ${secrets.your_secret}"

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
@@ -102,7 +102,7 @@ export const NodeBottomBarMenu = ({
                     Instill Credit
                   </p>
                   <p className="text-semantic-fg-primary product-body-text-4-medium">
-                    This connector is using Instill Credit
+                    This component is using Instill Credit
                   </p>
                 </div>
                 <Tooltip.Arrow


### PR DESCRIPTION
Because

- fix typo in the instill credit hint

This commit

- fix typo in the instill credit hint