### PR TITLE
fix: fix missing notification title when delete api token

### DIFF
--- a/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
@@ -77,7 +77,7 @@ export const CreateAPITokenDialog = () => {
 
       toast({
         variant: "alert-success",
-        description: "Token created successfully",
+        title: "Token created successfully",
         size: "small",
       });
     } catch (error) {

--- a/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/DeleteAPITokenDialog.tsx
@@ -58,6 +58,11 @@ export const DeleteAPITokenDialog = ({ tokenName }: { tokenName: string }) => {
       }
 
       setOpen(false);
+      toast({
+        title: "API token deleted successfully",
+        variant: "alert-success",
+        size: "small",
+      });
     } catch (error) {
       const description = isAxiosError(error)
         ? getInstillApiErrorMessage(error)


### PR DESCRIPTION
Because

- fix missing notification title when delete api token

This commit

- fix missing notification title when delete api token
