### PR TITLE
fix: fix wording of upgrade to starter plan button

### DIFF
--- a/packages/toolkit/src/components/top-bar/CloudTopbarDropdown.tsx
+++ b/packages/toolkit/src/components/top-bar/CloudTopbarDropdown.tsx
@@ -214,7 +214,7 @@ export const CloudTopbarDropdown = () => {
                   className="flex w-full items-center"
                   variant="secondaryColour"
                 >
-                  Upgrade to Pro
+                  Upgrade to Starter Plan
                 </Button>
               </TopbarDropdownItem>
             </TopbarDropdownGroup>


### PR DESCRIPTION
Because

- fix wording of upgrade to starter plan button

This commit

- fix wording of upgrade to starter plan button
