### PR TITLE
fix(pipeline-builder): fix the outdated trigger api path in the builder's toolkit

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippets.ts
+++ b/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippets.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-useless-escape */
 
-export const core = `curl -X POST '{vdp-pipeline-base-url}/vdp/v1beta/{pipeline-name}/{trigger-endpoint}' \\
+export const core = `curl -X POST '{vdp-pipeline-base-url}/v1beta/{pipeline-name}/{trigger-endpoint}' \\
 --header 'Content-Type: application/json' \\
 --data \'{input-array}'
 `;
 
-export const cloud = `curl -X POST '{vdp-pipeline-base-url}/vdp/v1beta/{pipeline-name}/{trigger-endpoint}' \\
+export const cloud = `curl -X POST '{vdp-pipeline-base-url}/v1beta/{pipeline-name}/{trigger-endpoint}' \\
 --header 'Content-Type: application/json' \\
 --header 'Authorization: Bearer <api_token>' \\
 --data \ '{input-array}'


### PR DESCRIPTION
Because

- fix the outdated trigger api path in the builder's toolkit

This commit

- fix the outdated trigger api path in the builder's toolkit