### PR TITLE
fix(model-forms): fix model forms input descriptions font size

### DIFF
--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -397,7 +397,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
                           </Select.Content>
                         </Select.Root>
                       </Form.Control>
-                      <p className="text-semantic-fg-secondary product-body-text-3-regular">
+                      <p className="text-xs text-semantic-fg-secondary">
                         The kind of operations your model is going to perform.
                       </p>
                     </Form.Item>
@@ -499,7 +499,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
                           </Select.Content>
                         </Select.Root>
                       </Form.Control>
-                      <p className="text-semantic-fg-secondary product-body-text-3-regular">
+                      <p className="text-xs text-semantic-fg-secondary">
                         {`This will affect the model's performance and operational costs. Please refer to the documentation for detailed pricing information.`}
                       </p>
                     </Form.Item>
@@ -569,7 +569,7 @@ export const CreateModelForm = (props: CreateModelFormProps) => {
                           </Input.Root>
                         ) : null}
                         <Form.Message />
-                        <p className="text-semantic-fg-secondary product-body-text-3-regular">
+                        <p className="text-xs text-semantic-fg-secondary">
                           {`This will affect the model's performance and operational costs. Please refer to the documentation for detailed pricing information.`}
                         </p>
                       </Form.Item>

--- a/packages/toolkit/src/view/model/view-model/ModelSettingsEditForm.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelSettingsEditForm.tsx
@@ -395,7 +395,7 @@ export const ModelSettingsEditForm = ({
                       </Input.Root>
                     ) : null}
                     <Form.Message />
-                    <p className="text-semantic-fg-secondary product-body-text-3-regular">
+                    <p className="text-xs text-semantic-fg-secondary">
                       {`This will affect the model's performance and operational costs. Please refer to the documentation for detailed pricing information.`}
                     </p>
                   </Form.Item>


### PR DESCRIPTION
Because

- the model create and edit forms had wrong input description font size

This commit

- fixes create and edit forms input description font size
