### PR TITLE
fix: use non view_full query on hub to speed up request

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/model/useInfiniteModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useInfiniteModels.ts
@@ -11,6 +11,7 @@ export function useInfiniteModels({
   filter,
   visibility,
   order_by,
+  disabledViewFull,
 }: {
   pageSize?: number;
   accessToken: Nullable<string>;
@@ -19,6 +20,7 @@ export function useInfiniteModels({
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
   order_by: Nullable<string>;
+  disabledViewFull?: boolean;
 }) {
   const queryKey = ["models", "infinite"];
 
@@ -45,6 +47,7 @@ export function useInfiniteModels({
         visibility,
         enablePagination: true,
         order_by,
+        disabledViewFull,
       });
 
       return Promise.resolve(models);

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useInfinitePipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useInfinitePipelines.ts
@@ -18,6 +18,7 @@ export function useInfinitePipelines({
   visibility,
   filter,
   order_by,
+  disabledViewFull,
 }: {
   pageSize: number;
   enabledQuery: boolean;
@@ -25,6 +26,7 @@ export function useInfinitePipelines({
   visibility: Nullable<Visibility>;
   filter: Nullable<string>;
   order_by: Nullable<string>;
+  disabledViewFull?: boolean;
 }): UseInfiniteQueryResult<InfiniteData<ListPipelinesResponse>, Error> {
   const queryKey = ["pipelines", "infinite"];
 
@@ -51,6 +53,7 @@ export function useInfinitePipelines({
         visibility,
         filter,
         order_by,
+        disabledViewFull,
       });
 
       return Promise.resolve(pipelines);

--- a/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
@@ -127,6 +127,7 @@ export type listModelsQueryProps = {
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
   order_by?: Nullable<string>;
+  disabledViewFull?: boolean;
 };
 export type listUserModelsQueryProps = {
   userName: Nullable<string>;
@@ -177,6 +178,7 @@ export async function listModelsQuery({
   visibility,
   enablePagination,
   order_by,
+  disabledViewFull,
 }: listModelsQueryProps & {
   enablePagination?: boolean;
 }) {
@@ -186,7 +188,7 @@ export async function listModelsQuery({
     const models: Model[] = [];
 
     const queryString = getQueryString({
-      baseURL: "/models?view=VIEW_FULL",
+      baseURL: disabledViewFull ? "/models" : "/models?view=VIEW_FULL",
       pageSize,
       nextPageToken,
       queryParams: visibility ? `visibility=${visibility}` : undefined,
@@ -245,6 +247,7 @@ export async function listUserModelsQuery({
   filter,
   visibility,
   enablePagination,
+  disabledViewFull,
 }: listUserModelsQueryProps & {
   enablePagination?: boolean;
 }) {
@@ -253,7 +256,9 @@ export async function listUserModelsQuery({
     const models: Model[] = [];
 
     const queryString = getQueryString({
-      baseURL: `/${userName}/models?view=VIEW_FULL`,
+      baseURL: disabledViewFull
+        ? `/${userName}/models`
+        : `/${userName}/models?view=VIEW_FULL`,
       pageSize,
       nextPageToken,
       filter,

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
@@ -22,6 +22,7 @@ export type listPipelinesQueryParams = {
   visibility: Nullable<Visibility>;
   filter: Nullable<string>;
   order_by?: Nullable<string>;
+  disabledViewFull?: boolean;
 };
 
 export async function listPipelinesQuery(
@@ -52,6 +53,7 @@ export async function listPipelinesQuery(
     visibility,
     filter,
     order_by,
+    disabledViewFull,
   } = props;
 
   try {
@@ -59,7 +61,7 @@ export async function listPipelinesQuery(
     const pipelines: Pipeline[] = [];
 
     const queryString = getQueryString({
-      baseURL: "/pipelines?view=VIEW_FULL",
+      baseURL: disabledViewFull ? "/pipelines" : "/pipelines?view=VIEW_FULL",
       pageSize,
       nextPageToken,
       queryParams: visibility ? `visibility=${visibility}` : undefined,
@@ -85,6 +87,7 @@ export async function listPipelinesQuery(
           filter,
           visibility,
           order_by,
+          disabledViewFull,
         }))
       );
     }

--- a/packages/toolkit/src/view/hub/hub-view/Body.tsx
+++ b/packages/toolkit/src/view/hub/hub-view/Body.tsx
@@ -103,6 +103,7 @@ const ListSection: React.FC<{ tabValue: string; dataType?: DataType }> = ({
           ? `q="${searchCode}"`
           : "",
     order_by: selectedSortOption,
+    disabledViewFull: true,
   });
 
   const allPipelines = React.useMemo(() => {
@@ -133,6 +134,7 @@ const ListSection: React.FC<{ tabValue: string; dataType?: DataType }> = ({
           ? `q="${searchCode}"`
           : "",
     order_by: selectedSortOption,
+    disabledViewFull: true,
   });
 
   const allModels = React.useMemo(() => {


### PR DESCRIPTION
Because

- use non view_full query on hub to speed up request

This commit

- use non view_full query on hub to speed up request