### PR TITLE
fix: enable view-full of model request on hub

### DIFF
--- a/packages/toolkit/src/view/hub/hub-view/Body.tsx
+++ b/packages/toolkit/src/view/hub/hub-view/Body.tsx
@@ -134,7 +134,6 @@ const ListSection: React.FC<{ tabValue: string; dataType?: DataType }> = ({
           ? `q="${searchCode}"`
           : "",
     order_by: selectedSortOption,
-    disabledViewFull: true,
   });
 
   const allModels = React.useMemo(() => {


### PR DESCRIPTION
Because

- enable view-full of model request on hub since BE didn't support this option with returning full owner object

This commit

- enable view-full of model request on hub
