### PR TITLE
feat(hub): add direct routes for explore/featured + pipelines/models

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -51,6 +51,7 @@
     "echarts": "^5.4.2",
     "elkjs": "^0.8.2",
     "next": "^14.1.3",
+    "next-easy-middlewares": "^1.1.2",
     "next-mdx-remote": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/console/src/app/hub/[type]/[list]/page.tsx
+++ b/apps/console/src/app/hub/[type]/[list]/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import { HubPageRender } from "./render";
-import { HubNavigationParams } from "@instill-ai/toolkit";
 
 export async function generateMetadata() {
   const metadata: Metadata = {

--- a/apps/console/src/app/hub/[type]/[list]/page.tsx
+++ b/apps/console/src/app/hub/[type]/[list]/page.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from "next";
+import { HubPageRender } from "./render";
+import { HubNavigationParams } from "@instill-ai/toolkit";
+
+export async function generateMetadata() {
+  const metadata: Metadata = {
+    title: `Instill Cloud | Hub`,
+    openGraph: {
+      images: ["/instill-open-graph.png"],
+    },
+  };
+
+  return Promise.resolve(metadata);
+}
+
+export default async function Page() {
+  return <HubPageRender />;
+}

--- a/apps/console/src/app/hub/[type]/[list]/render.tsx
+++ b/apps/console/src/app/hub/[type]/[list]/render.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Logo } from "@instill-ai/design-system";
+import { AppTopbar, HubView, PageBase } from "@instill-ai/toolkit";
+import { useAppAccessToken } from "lib/use-app-access-token";
+
+export const HubPageRender = () => {
+  useAppAccessToken({
+    disabledRedirectingVisitor: true,
+    forceQueryWithoutAccessToken: true,
+  });
+
+  return (
+    <PageBase>
+      <AppTopbar logo={<Logo variant="colourLogomark" width={38} />} />
+      <PageBase.Container>
+        <PageBase.Content contentPadding="!p-0">
+          <HubView />
+        </PageBase.Content>
+      </PageBase.Container>
+    </PageBase>
+  );
+};

--- a/apps/console/src/app/hub/page.tsx
+++ b/apps/console/src/app/hub/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next";
+
+export async function generateMetadata() {
+  const metadata: Metadata = {
+    title: `Instill Cloud | Hub`,
+    openGraph: {
+      images: ["/instill-open-graph.png"],
+    },
+  };
+
+  return Promise.resolve(metadata);
+}
+
+export default async function Page() {
+  return null;
+}

--- a/apps/console/src/lib/withMiddlewareHubRedirect.ts
+++ b/apps/console/src/lib/withMiddlewareHubRedirect.ts
@@ -1,11 +1,13 @@
-import { NextResponse, NextRequest } from 'next/server'
- 
+import { NextResponse, NextRequest } from "next/server";
+
 export function hubRedirect(request: NextRequest) {
   const { origin } = request.nextUrl;
-  const instillHubRoute = request.cookies.get('instill-hub-route');
+  const instillHubRoute = request.cookies.get("instill-hub-route");
 
   if (instillHubRoute?.value) {
-    return NextResponse.redirect(new URL(`/hub/${instillHubRoute.value}`, origin));
+    return NextResponse.redirect(
+      new URL(`/hub/${instillHubRoute.value}`, origin),
+    );
   }
 
   return NextResponse.redirect(new URL("/hub/explore/pipelines", origin));

--- a/apps/console/src/lib/withMiddlewareHubRedirect.ts
+++ b/apps/console/src/lib/withMiddlewareHubRedirect.ts
@@ -1,0 +1,12 @@
+import { NextResponse, NextRequest } from 'next/server'
+ 
+export function hubRedirect(request: NextRequest) {
+  const { origin } = request.nextUrl;
+  const instillHubRoute = request.cookies.get('instill-hub-route');
+
+  if (instillHubRoute?.value) {
+    return NextResponse.redirect(new URL(`/hub/${instillHubRoute.value}`, origin));
+  }
+
+  return NextResponse.redirect(new URL("/hub/explore/pipelines", origin));
+}

--- a/apps/console/src/lib/withMiddlewareHubSetRedirectCookie.ts
+++ b/apps/console/src/lib/withMiddlewareHubSetRedirectCookie.ts
@@ -1,10 +1,12 @@
-import { NextResponse, NextRequest } from 'next/server'
+import { NextResponse, NextRequest } from "next/server";
 
 export function hubRedirectSetCookie(request: NextRequest) {
-    const response = NextResponse.next()
-    const path = request.nextUrl.pathname.substring(request.nextUrl.pathname.indexOf('hub/') + 4)
+  const response = NextResponse.next();
+  const path = request.nextUrl.pathname.substring(
+    request.nextUrl.pathname.indexOf("hub/") + 4,
+  );
 
-    response.cookies.set('instill-hub-route', path);
+  response.cookies.set("instill-hub-route", path);
 
-    return response;
+  return response;
 }

--- a/apps/console/src/lib/withMiddlewareHubSetRedirectCookie.ts
+++ b/apps/console/src/lib/withMiddlewareHubSetRedirectCookie.ts
@@ -1,0 +1,10 @@
+import { NextResponse, NextRequest } from 'next/server'
+
+export function hubRedirectSetCookie(request: NextRequest) {
+    const response = NextResponse.next()
+    const path = request.nextUrl.pathname.substring(request.nextUrl.pathname.indexOf('hub/') + 4)
+
+    response.cookies.set('instill-hub-route', path);
+
+    return response;
+}

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -1,7 +1,7 @@
-import createMiddleware from 'next-easy-middlewares';
+import createMiddleware from "next-easy-middlewares";
 import { withMiddlewareAuthRequired } from "./lib";
-import { hubRedirect } from 'lib/withMiddlewareHubRedirect';
-import { hubRedirectSetCookie } from 'lib/withMiddlewareHubSetRedirectCookie';
+import { hubRedirect } from "lib/withMiddlewareHubRedirect";
+import { hubRedirectSetCookie } from "lib/withMiddlewareHubSetRedirectCookie";
 
 const middlewares = {
   // Authentication guard
@@ -22,12 +22,12 @@ export const middleware = createMiddleware(middlewares);
 
 export const config = {
   /*
-  * Match all paths except for:
-  * 1. /api/ routes
-  * 2. /_next/ (Next.js internals)
-  * 3. /_static (inside /public)
-  * 4. /_vercel (Vercel internals)
-  * 5. Static files (e.g. /favicon.ico, /sitemap.xml, /robots.txt, etc.)
-  */
-  matcher: ['/((?!api/|_next/|_static|_vercel|[\\w-]+\\.\\w+).*)'],
+   * Match all paths except for:
+   * 1. /api/ routes
+   * 2. /_next/ (Next.js internals)
+   * 3. /_static (inside /public)
+   * 4. /_vercel (Vercel internals)
+   * 5. Static files (e.g. /favicon.ico, /sitemap.xml, /robots.txt, etc.)
+   */
+  matcher: ["/((?!api/|_next/|_static|_vercel|[\\w-]+\\.\\w+).*)"],
 };

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -1,6 +1,7 @@
 import createMiddleware from 'next-easy-middlewares';
 import { withMiddlewareAuthRequired } from "./lib";
 import { hubRedirect } from 'lib/withMiddlewareHubRedirect';
+import { hubRedirectSetCookie } from 'lib/withMiddlewareHubSetRedirectCookie';
 
 const middlewares = {
   // Authentication guard
@@ -13,7 +14,8 @@ const middlewares = {
   "/settings": withMiddlewareAuthRequired(),
 
   // Hub redirect
-  "/hub": hubRedirect,  
+  "/hub": hubRedirect,
+  "/hub/(.*?)/:path*": hubRedirectSetCookie,
 };
 
 export const middleware = createMiddleware(middlewares);

--- a/apps/console/src/middleware.ts
+++ b/apps/console/src/middleware.ts
@@ -1,16 +1,31 @@
+import createMiddleware from 'next-easy-middlewares';
 import { withMiddlewareAuthRequired } from "./lib";
+import { hubRedirect } from 'lib/withMiddlewareHubRedirect';
 
-export default withMiddlewareAuthRequired();
+const middlewares = {
+  // Authentication guard
+  "/(.*?)/connectors/:path*": withMiddlewareAuthRequired(),
+  "/(.*?)/dashboard/:path*": withMiddlewareAuthRequired(),
+  "/(.*?)/pipelines": withMiddlewareAuthRequired(),
+  // For pipeline builder
+  "/(.*?)/pipelines/(.*?)/builder": withMiddlewareAuthRequired(),
+  "/(.*?)/models/:path*": withMiddlewareAuthRequired(),
+  "/settings": withMiddlewareAuthRequired(),
+
+  // Hub redirect
+  "/hub": hubRedirect,  
+};
+
+export const middleware = createMiddleware(middlewares);
 
 export const config = {
-  matcher: [
-    "/(.*?)/connectors/:path*",
-    "/(.*?)/dashboard/:path*",
-    "/(.*?)/pipelines",
-
-    // For pipeline editor
-    "/(.*?)/pipelines/(.*?)/editor",
-    "/(.*?)/models/:path*",
-    "/settings",
-  ],
+  /*
+  * Match all paths except for:
+  * 1. /api/ routes
+  * 2. /_next/ (Next.js internals)
+  * 3. /_static (inside /public)
+  * 4. /_vercel (Vercel internals)
+  * 5. Static files (e.g. /favicon.ico, /sitemap.xml, /robots.txt, etc.)
+  */
+  matcher: ['/((?!api/|_next/|_static|_vercel|[\\w-]+\\.\\w+).*)'],
 };

--- a/packages/toolkit/src/lib/type/general.ts
+++ b/packages/toolkit/src/lib/type/general.ts
@@ -32,3 +32,8 @@ export type GeneralAppPageProp = {
   enableQuery: boolean;
   accessToken: Nullable<string>;
 };
+
+export type HubNavigationParams = {
+  type: "explore" | "featured";
+  list: "pipelines" | "models";
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,10 @@ importers:
         version: 0.8.2
       next:
         specifier: ^14.1.3
+        version: 14.1.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      next-easy-middlewares:
+        specifier: ^1.1.2
+        version: 1.1.2(@playwright/test@1.41.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
         version: 14.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-mdx-remote:
         specifier: ^4.1.0
@@ -261,6 +265,7 @@ importers:
         version: 4.6.0(monaco-editor@0.45.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next:
         specifier: 14.1.3
+        version: 14.1.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
         version: 14.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18
@@ -452,6 +457,7 @@ importers:
         version: 1.1.0
       '@storybook/nextjs':
         specifier: ^8.1.4
+        version: 8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))
         version: 8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))
       '@storybook/react':
         specifier: ^8.1.4
@@ -2882,8 +2888,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.33.4':
+    resolution: {integrity: sha512-p0suNqXufJs9t3RqLBO6vvrgr5OhgbWp76s5gTRvdmxmuv9E1rcaqGUsl3l4mKVmXPkTkTErXediAui4x+8PSA==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.33.3':
     resolution: {integrity: sha512-2QeSl7QDK9ru//YBT4sQkoq7L0EAJZA3rtV+v9p8xTKl4U1bUqTIaCnoC7Ctx2kCjQgwFXDasOtPTCT8eCTXvw==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.4':
+    resolution: {integrity: sha512-0l7yRObwtTi82Z6ebVI2PnHT8EB2NxBgpK2MiKJZJ7cz32R4lxd001ecMhzzsZig3Yv9oclvqqdV93jo9hy+Dw==}
     engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [darwin]
@@ -2942,8 +2960,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-linux-arm64@0.33.4':
+    resolution: {integrity: sha512-2800clwVg1ZQtxwSoTlHvtm9ObgAax7V6MTAB/hDT945Tfyy3hVkmiHpeLPCKYqYR1Gcmv1uDZ3a4OFwkdBL7Q==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linux-arm@0.33.3':
     resolution: {integrity: sha512-Q7Ee3fFSC9P7vUSqVEF0zccJsZ8GiiCJYGWDdhEjdlOeS9/jdkyJ6sUSPj+bL8VuOYFSbofrW0t/86ceVhx32w==}
+    engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.4':
+    resolution: {integrity: sha512-RUgBD1c0+gCYZGCCe6mMdTiOFS0Zc/XrN0fYd6hISIKcDUbAW5NtSQW9g/powkrXYm6Vzwd6y+fqmExDuCdHNQ==}
     engines: {glibc: '>=2.28', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [arm]
     os: [linux]
@@ -2954,8 +2984,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@img/sharp-linux-s390x@0.33.4':
+    resolution: {integrity: sha512-h3RAL3siQoyzSoH36tUeS0PDmb5wINKGYzcLB5C6DIiAn2F3udeFAum+gj8IbA/82+8RGCTn7XW8WTFnqag4tQ==}
+    engines: {glibc: '>=2.31', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-linux-x64@0.33.3':
     resolution: {integrity: sha512-Q4I++herIJxJi+qmbySd072oDPRkCg/SClLEIDh5IL9h1zjhqjv82H0Seupd+q2m0yOfD+/fJnjSoDFtKiHu2g==}
+    engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.4':
+    resolution: {integrity: sha512-GoR++s0XW9DGVi8SUGQ/U4AeIzLdNjHka6jidVwapQ/JebGVQIpi52OdyxCNVRE++n1FCLzjDovJNozif7w/Aw==}
     engines: {glibc: '>=2.26', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
@@ -2966,8 +3008,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-arm64@0.33.4':
+    resolution: {integrity: sha512-nhr1yC3BlVrKDTl6cO12gTpXMl4ITBUZieehFvMntlCXFzH2bvKG76tBL2Y/OqhupZt81pR7R+Q5YhJxW0rGgQ==}
+    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-x64@0.33.3':
     resolution: {integrity: sha512-Jhchim8kHWIU/GZ+9poHMWRcefeaxFIs9EBqf9KtcC14Ojk6qua7ghKiPs0sbeLbLj/2IGBtDcxHyjCdYWkk2w==}
+    engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.4':
+    resolution: {integrity: sha512-uCPTku0zwqDmZEOi4ILyGdmW76tH7dm8kKlOIV1XC5cLyJ71ENAAqarOHQh0RLfpIpbV5KOpXzdU6XkJtS0daw==}
     engines: {musl: '>=1.2.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [linux]
@@ -2977,14 +3031,31 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.33.4':
+    resolution: {integrity: sha512-Bmmauh4sXUsUqkleQahpdNXKvo+wa1V9KhT2pDA4VJGKwnKMJXiSTGphn0gnJrlooda0QxCtXc6RX1XAU6hMnQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-ia32@0.33.3':
     resolution: {integrity: sha512-CyimAduT2whQD8ER4Ux7exKrtfoaUiVr7HG0zZvO0XTFn2idUWljjxv58GxNTkFb8/J9Ub9AqITGkJD6ZginxQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.4':
+    resolution: {integrity: sha512-99SJ91XzUhYHbx7uhK3+9Lf7+LjwMGQZMDlO/E/YVJ7Nc3lyDFZPGhjwiYdctoH2BOzW9+TnfqcaMKt0jHLdqw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.33.3':
     resolution: {integrity: sha512-viT4fUIDKnli3IfOephGnolMzhz5VaTvDRkYqtZxOMIoMQ4MrAziO7pT1nVnOt2FAm7qW5aa+CCc13aEY6Le0g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.4':
+    resolution: {integrity: sha512-3QLocdTRVIrFNye5YocZl+KKpYKP+fksi1QhmOArgx7GyhIbQp/WrJRu176jm8IxromS7RIkzMiMINVdBtC8Aw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0', yarn: '>=3.2.0'}
     cpu: [x64]
     os: [win32]
@@ -3075,6 +3146,9 @@ packages:
   '@next/env@14.1.3':
     resolution: {integrity: sha512-VhgXTvrgeBRxNPjyfBsDIMvgsKDxjlpw4IAUsHCX8Gjl1vtHUYRT3+xfQ/wwvLPDd/6kqfLqk9Pt4+7gysuCKQ==}
 
+  '@next/env@15.0.0-rc.0':
+    resolution: {integrity: sha512-6W0ndQvHR9sXcqcKeR/inD2UTRCs9+VkSK3lfaGmEuZs7EjwwXMO2BPYjz9oBrtfPL3xuTjtXsHKSsalYQ5l1Q==}
+
   '@next/eslint-plugin-next@13.5.6':
     resolution: {integrity: sha512-ng7pU/DDsxPgT6ZPvuprxrkeew3XaRf4LAT4FabaEO/hAbvVx4P7wqnqdbTdDn1kgTvsI4tpIgT4Awn/m0bGbg==}
 
@@ -3087,8 +3161,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@next/swc-darwin-arm64@15.0.0-rc.0':
+    resolution: {integrity: sha512-4OpTXvAWcSabXA5d688zdUwa3sfT9QrLnHMdpv4q2UDnnuqmOI0xLb6lrOxwpi+vHJNkneuNLqyc5HGBhkqL6A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@next/swc-darwin-x64@14.1.3':
     resolution: {integrity: sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.0.0-rc.0':
+    resolution: {integrity: sha512-/TD8M9DT244uhtFA8P/0DUbM7ftg2zio6yOo6ajV16vNjkcug9Kt9//Wa4SrJjWcsGZpViLctOlwn3/6JFAuAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3099,8 +3185,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@next/swc-linux-arm64-gnu@15.0.0-rc.0':
+    resolution: {integrity: sha512-3VTO32938AcqOlOI/U61/MIpeYrblP22VU1GrgmMQJozsAXEJgLCgf3wxZtn61/FG4Yc0tp7rPZE2t1fIGe0+w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@next/swc-linux-arm64-musl@14.1.3':
     resolution: {integrity: sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@15.0.0-rc.0':
+    resolution: {integrity: sha512-0kDnxM3AfrrHFJ/wTkjkv7cVHIaGwv+CzDg9lL2BoLEM4kMQhH20DTsBOMqpTpo1K2KCg67LuTGd3QOITT5uFQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3111,8 +3209,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@next/swc-linux-x64-gnu@15.0.0-rc.0':
+    resolution: {integrity: sha512-fPMNahzqYFjm5h0ncJ5+F3NrShmWhpusM+zrQl01MMU0Ed5xsL4pJJDSuXV4wPkNUSjCP3XstTjxR5kBdO4juQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@next/swc-linux-x64-musl@14.1.3':
     resolution: {integrity: sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@15.0.0-rc.0':
+    resolution: {integrity: sha512-7/FLgOqrrQAxOVQrxfr3bGgZ83pSCmc2S3TXBILnHw0S8qLxmFjhSjH5ogaDmjrES/PSYMaX1FsP5Af88hp7Gw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3123,14 +3233,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@15.0.0-rc.0':
+    resolution: {integrity: sha512-5wcqoYHh7hbdghjH6Xs3i5/f0ov+i1Xw2E3O+BzZNESYVLgCM1q7KJu5gdGFoXA2gz5XaKF/VBcYHikLzyjgmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-ia32-msvc@14.1.3':
     resolution: {integrity: sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
+  '@next/swc-win32-ia32-msvc@15.0.0-rc.0':
+    resolution: {integrity: sha512-/hqOmYRTvtBPToE4Dbl9n+sLYU7DPd52R+TtjIrrEzTMgFo2/d7un3sD7GKmb2OwOj/ExyGv6Bd/JzytBVxXlw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@14.1.3':
     resolution: {integrity: sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.0.0-rc.0':
+    resolution: {integrity: sha512-2Jly5nShvCUzzngP3RzdQ3JcuEcHcnIEvkvZDCXqFAK+bWks4+qOkEUO1QIAERQ99J5J9/1AN/8zFBme3Mm57A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4242,6 +4370,9 @@ packages:
 
   '@storybook/types@8.1.4':
     resolution: {integrity: sha512-QfTJg5Hu3c0eiD38Z75bZsw0iCIpruOTGV5O65vCpNun7D6WUyyMM0aUJN3ytujGiHfjsWVgiSe+WoHxdy/fEA==}
+
+  '@swc/helpers@0.5.11':
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
@@ -8135,6 +8266,9 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  next-easy-middlewares@1.1.2:
+    resolution: {integrity: sha512-cxiMJj+1POYWLb0+mi1SrWyhmH0IJcj5Yc0cQd8W/czWy/D3euJ7xpiojiVJ3fHksChvY6ZXfJKVcveMcPXnaQ==}
+
   next-mdx-remote@4.4.1:
     resolution: {integrity: sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ==}
     engines: {node: '>=14', npm: '>=7'}
@@ -8153,6 +8287,27 @@ packages:
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+
+  next@15.0.0-rc.0:
+    resolution: {integrity: sha512-IWcCvxUSCAuOK5gig4+9yiyt/dLKpIa+WT01Qcx4CBE4TtwJljyTDnCVVn64jDZ4qmSzsaEYXpb4DTI8qbk03A==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: 19.0.0-rc-f994737d14-20240522
+      react-dom: 19.0.0-rc-f994737d14-20240522
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
         optional: true
       sass:
         optional: true
@@ -8463,6 +8618,9 @@ packages:
 
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+
+  path-to-regexp@6.2.2:
+    resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -9386,6 +9544,10 @@ packages:
     resolution: {integrity: sha512-vHUeXJU1UvlO/BNwTpT0x/r53WkLUVxrmb5JTgW92fdFCFk0ispLMAeu/jPO2vjkXM1fYUi3K7/qcLF47pwM1A==}
     engines: {libvips: '>=8.15.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  sharp@0.33.4:
+    resolution: {integrity: sha512-7i/dt5kGl7qR4gwPRD2biwD2/SvBn3O04J77XKFgL2OnZtQw+AG9wnuS/csmu80nPRHLYE9E41fyEiG8nhH6/Q==}
+    engines: {libvips: '>=8.15.2', node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -9661,6 +9823,19 @@ packages:
       '@babel/core': '*'
       babel-plugin-macros: '*'
       react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  styled-jsx@5.1.3:
+    resolution: {integrity: sha512-qLRShOWTE/Mf6Bvl72kFeKBl8N2Eq9WIFfoAuvbtP/6tqlnj1SCjv117n2MIjOPpa1jTorYqLJgsHKy5Y3ziww==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -12974,7 +13149,17 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.0.2
     optional: true
 
+  '@img/sharp-darwin-arm64@0.33.4':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.2
+    optional: true
+
   '@img/sharp-darwin-x64@0.33.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.4':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.0.2
     optional: true
@@ -13008,7 +13193,17 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.0.2
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.2
+    optional: true
+
   '@img/sharp-linux-arm@0.33.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.4':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.0.2
     optional: true
@@ -13018,7 +13213,17 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.0.2
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.2
+    optional: true
+
   '@img/sharp-linux-x64@0.33.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.4':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.0.2
     optional: true
@@ -13028,7 +13233,17 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.0.2
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.4':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.2
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.33.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.4':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.0.2
     optional: true
@@ -13038,10 +13253,21 @@ snapshots:
       '@emnapi/runtime': 1.1.1
     optional: true
 
+  '@img/sharp-wasm32@0.33.4':
+    dependencies:
+      '@emnapi/runtime': 1.1.1
+    optional: true
+
   '@img/sharp-win32-ia32@0.33.3':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.4':
+    optional: true
+
   '@img/sharp-win32-x64@0.33.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.4':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -13166,6 +13392,8 @@ snapshots:
 
   '@next/env@14.1.3': {}
 
+  '@next/env@15.0.0-rc.0': {}
+
   '@next/eslint-plugin-next@13.5.6':
     dependencies:
       glob: 7.1.7
@@ -13177,28 +13405,55 @@ snapshots:
   '@next/swc-darwin-arm64@14.1.3':
     optional: true
 
+  '@next/swc-darwin-arm64@15.0.0-rc.0':
+    optional: true
+
   '@next/swc-darwin-x64@14.1.3':
+    optional: true
+
+  '@next/swc-darwin-x64@15.0.0-rc.0':
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.1.3':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@15.0.0-rc.0':
+    optional: true
+
   '@next/swc-linux-arm64-musl@14.1.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.0.0-rc.0':
     optional: true
 
   '@next/swc-linux-x64-gnu@14.1.3':
     optional: true
 
+  '@next/swc-linux-x64-gnu@15.0.0-rc.0':
+    optional: true
+
   '@next/swc-linux-x64-musl@14.1.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.0.0-rc.0':
     optional: true
 
   '@next/swc-win32-arm64-msvc@14.1.3':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@15.0.0-rc.0':
+    optional: true
+
   '@next/swc-win32-ia32-msvc@14.1.3':
     optional: true
 
+  '@next/swc-win32-ia32-msvc@15.0.0-rc.0':
+    optional: true
+
   '@next/swc-win32-x64-msvc@14.1.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.0.0-rc.0':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -14748,6 +15003,7 @@ snapshots:
 
   '@storybook/mdx2-csf@1.1.0': {}
 
+  '@storybook/nextjs@8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))':
   '@storybook/nextjs@8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))':
     dependencies:
       '@babel/core': 7.24.4
@@ -14781,6 +15037,8 @@ snapshots:
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.2.1
+      next: 15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.89.0(esbuild@0.17.19))
       next: 14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.89.0(esbuild@0.17.19))
       pnp-webpack-plugin: 1.7.0(typescript@5.4.2)
@@ -15005,6 +15263,10 @@ snapshots:
       '@storybook/channels': 8.1.4
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
+
+  '@swc/helpers@0.5.11':
+    dependencies:
+      tslib: 2.6.2
 
   '@swc/helpers@0.5.2':
     dependencies:
@@ -19813,7 +20075,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.7)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.6)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.1.3
       '@next/swc-darwin-x64': 14.1.3
@@ -20234,6 +20496,8 @@ snapshots:
       minipass: 7.0.4
 
   path-to-regexp@0.1.7: {}
+
+  path-to-regexp@6.2.2: {}
 
   path-type@3.0.0:
     dependencies:
@@ -21344,6 +21608,33 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.3
     optional: true
 
+  sharp@0.33.4:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.3
+      semver: 7.6.0
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.4
+      '@img/sharp-darwin-x64': 0.33.4
+      '@img/sharp-libvips-darwin-arm64': 1.0.2
+      '@img/sharp-libvips-darwin-x64': 1.0.2
+      '@img/sharp-libvips-linux-arm': 1.0.2
+      '@img/sharp-libvips-linux-arm64': 1.0.2
+      '@img/sharp-libvips-linux-s390x': 1.0.2
+      '@img/sharp-libvips-linux-x64': 1.0.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.2
+      '@img/sharp-linux-arm': 0.33.4
+      '@img/sharp-linux-arm64': 0.33.4
+      '@img/sharp-linux-s390x': 0.33.4
+      '@img/sharp-linux-x64': 0.33.4
+      '@img/sharp-linuxmusl-arm64': 0.33.4
+      '@img/sharp-linuxmusl-x64': 0.33.4
+      '@img/sharp-wasm32': 0.33.4
+      '@img/sharp-win32-ia32': 0.33.4
+      '@img/sharp-win32-x64': 0.33.4
+    optional: true
+
   shebang-command@1.2.0:
     dependencies:
       shebang-regex: 1.0.0
@@ -21635,21 +21926,21 @@ snapshots:
     dependencies:
       inline-style-parser: 0.1.1
 
-  styled-jsx@5.1.1(@babel/core@7.23.7)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.4)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
       '@babel/core': 7.23.7
 
-  styled-jsx@5.1.1(@babel/core@7.24.4)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.6)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
       '@babel/core': 7.24.4
 
-  styled-jsx@5.1.1(@babel/core@7.24.6)(react@18.2.0):
+  styled-jsx@5.1.3(@babel/core@7.23.7)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
@@ -21660,6 +21951,8 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.23.7
 
   sucrase@3.35.0:
     dependencies:
@@ -22494,13 +22787,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.0(@types/node@20.11.5):
+  vite-node@1.6.0(@types/node@20.11.5)(terser@5.27.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.12(@types/node@20.11.5)
+      vite: 5.2.12(@types/node@20.11.5)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -22539,7 +22832,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vite@5.2.12(@types/node@20.11.5):
+  vite@5.2.12(@types/node@20.11.5)(terser@5.27.0):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
@@ -22612,8 +22905,8 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.4
-      vite: 5.2.12(@types/node@20.11.5)
-      vite-node: 1.6.0(@types/node@20.11.5)
+      vite: 5.2.12(@types/node@20.11.5)(terser@5.27.0)
+      vite-node: 1.6.0(@types/node@20.11.5)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.11.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,7 +129,6 @@ importers:
       next-easy-middlewares:
         specifier: ^1.1.2
         version: 1.1.2(@playwright/test@1.41.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-        version: 14.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next-mdx-remote:
         specifier: ^4.1.0
         version: 4.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -266,7 +265,6 @@ importers:
       next:
         specifier: 14.1.3
         version: 14.1.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-        version: 14.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18
         version: 18.2.0
@@ -458,7 +456,6 @@ importers:
       '@storybook/nextjs':
         specifier: ^8.1.4
         version: 8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))
-        version: 8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))
       '@storybook/react':
         specifier: ^8.1.4
         version: 8.1.4(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.2)
@@ -15004,7 +15001,6 @@ snapshots:
   '@storybook/mdx2-csf@1.1.0': {}
 
   '@storybook/nextjs@8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))':
-  '@storybook/nextjs@8.1.4(@types/jest@29.5.11)(esbuild@0.17.19)(next@14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(type-fest@3.13.1)(typescript@5.4.2)(vitest@1.6.0(@types/node@20.11.5)(jsdom@21.1.2)(terser@5.27.0))(webpack-hot-middleware@2.26.0)(webpack@5.89.0(esbuild@0.17.19))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.24.4)
@@ -15038,8 +15034,6 @@ snapshots:
       image-size: 1.1.1
       loader-utils: 3.2.1
       next: 15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.89.0(esbuild@0.17.19))
-      next: 14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.89.0(esbuild@0.17.19))
       pnp-webpack-plugin: 1.7.0(typescript@5.4.2)
       postcss: 8.4.38
@@ -17921,7 +17915,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 8.56.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.2
@@ -17962,16 +17956,6 @@ snapshots:
       '@typescript-eslint/parser': 7.10.0(eslint@8.56.0)(typescript@5.4.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0))(eslint@8.56.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.10.0(eslint@8.56.0)(typescript@5.4.2)
-      eslint: 8.56.0
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@8.56.0)(typescript@5.4.2))(eslint-plugin-import@2.29.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
@@ -20054,6 +20038,20 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  next-easy-middlewares@1.1.2(@playwright/test@1.41.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      next: 15.0.0-rc.0(@playwright/test@1.41.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      path-to-regexp: 6.2.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@opentelemetry/api'
+      - '@playwright/test'
+      - babel-plugin-macros
+      - babel-plugin-react-compiler
+      - react
+      - react-dom
+      - sass
+
   next-mdx-remote@4.4.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@mdx-js/mdx': 2.3.0
@@ -20064,31 +20062,6 @@ snapshots:
       vfile-matter: 3.0.1
     transitivePeerDependencies:
       - supports-color
-
-  next@14.1.3(@babel/core@7.23.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
-    dependencies:
-      '@next/env': 14.1.3
-      '@swc/helpers': 0.5.2
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001579
-      graceful-fs: 4.2.11
-      postcss: 8.4.31
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.24.6)(react@18.2.0)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 14.1.3
-      '@next/swc-darwin-x64': 14.1.3
-      '@next/swc-linux-arm64-gnu': 14.1.3
-      '@next/swc-linux-arm64-musl': 14.1.3
-      '@next/swc-linux-x64-gnu': 14.1.3
-      '@next/swc-linux-x64-musl': 14.1.3
-      '@next/swc-win32-arm64-msvc': 14.1.3
-      '@next/swc-win32-ia32-msvc': 14.1.3
-      '@next/swc-win32-x64-msvc': 14.1.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   next@14.1.3(@babel/core@7.24.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -20115,27 +20088,56 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.1.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@15.0.0-rc.0(@babel/core@7.23.7)(@playwright/test@1.39.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@next/env': 14.1.3
-      '@swc/helpers': 0.5.2
+      '@next/env': 15.0.0-rc.0
+      '@swc/helpers': 0.5.11
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001579
+      caniuse-lite: 1.0.30001624
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(react@18.2.0)
+      styled-jsx: 5.1.3(@babel/core@7.23.7)(react@18.2.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.1.3
-      '@next/swc-darwin-x64': 14.1.3
-      '@next/swc-linux-arm64-gnu': 14.1.3
-      '@next/swc-linux-arm64-musl': 14.1.3
-      '@next/swc-linux-x64-gnu': 14.1.3
-      '@next/swc-linux-x64-musl': 14.1.3
-      '@next/swc-win32-arm64-msvc': 14.1.3
-      '@next/swc-win32-ia32-msvc': 14.1.3
-      '@next/swc-win32-x64-msvc': 14.1.3
+      '@next/swc-darwin-arm64': 15.0.0-rc.0
+      '@next/swc-darwin-x64': 15.0.0-rc.0
+      '@next/swc-linux-arm64-gnu': 15.0.0-rc.0
+      '@next/swc-linux-arm64-musl': 15.0.0-rc.0
+      '@next/swc-linux-x64-gnu': 15.0.0-rc.0
+      '@next/swc-linux-x64-musl': 15.0.0-rc.0
+      '@next/swc-win32-arm64-msvc': 15.0.0-rc.0
+      '@next/swc-win32-ia32-msvc': 15.0.0-rc.0
+      '@next/swc-win32-x64-msvc': 15.0.0-rc.0
+      '@playwright/test': 1.39.0
+      sharp: 0.33.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.0.0-rc.0(@playwright/test@1.41.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@next/env': 15.0.0-rc.0
+      '@swc/helpers': 0.5.11
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001624
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.3(@babel/core@7.23.7)(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.0.0-rc.0
+      '@next/swc-darwin-x64': 15.0.0-rc.0
+      '@next/swc-linux-arm64-gnu': 15.0.0-rc.0
+      '@next/swc-linux-arm64-musl': 15.0.0-rc.0
+      '@next/swc-linux-x64-gnu': 15.0.0-rc.0
+      '@next/swc-linux-x64-musl': 15.0.0-rc.0
+      '@next/swc-win32-arm64-msvc': 15.0.0-rc.0
+      '@next/swc-win32-ia32-msvc': 15.0.0-rc.0
+      '@next/swc-win32-x64-msvc': 15.0.0-rc.0
+      '@playwright/test': 1.41.1
+      sharp: 0.33.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -21931,23 +21933,16 @@ snapshots:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.7
+      '@babel/core': 7.24.4
 
   styled-jsx@5.1.1(@babel/core@7.24.6)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.24.4
-
-  styled-jsx@5.1.3(@babel/core@7.23.7)(react@18.2.0):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.2.0
-    optionalDependencies:
       '@babel/core': 7.24.6
 
-  styled-jsx@5.1.1(react@18.2.0):
+  styled-jsx@5.1.3(@babel/core@7.23.7)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
@@ -22803,24 +22798,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-    optional: true
-
-  vite-node@1.6.0(@types/node@20.11.5)(terser@5.27.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.4
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      vite: 5.2.12(@types/node@20.11.5)(terser@5.27.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vite@5.2.12(@types/node@18.19.8)(terser@5.27.0):
     dependencies:
@@ -22831,16 +22808,6 @@ snapshots:
       '@types/node': 18.19.8
       fsevents: 2.3.3
       terser: 5.27.0
-
-  vite@5.2.12(@types/node@20.11.5)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.18.0
-    optionalDependencies:
-      '@types/node': 20.11.5
-      fsevents: 2.3.3
-    optional: true
 
   vite@5.2.12(@types/node@20.11.5)(terser@5.27.0):
     dependencies:


### PR DESCRIPTION
Because

- we needed a way to directly share the url for explore/featured models/pipelines pages

This commit

- now the direct urls are shareable + we remember which page was visited last, so coming to /hub will seamlessly redirect to last visited section
