### PR TITLE
fix: fix prettier issue around root folder and vscode plugin

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -94,5 +94,10 @@
   },
   "engines": {
     "node": ">=14.6.0"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ]
   }
 }

--- a/apps/console/src/components/ModelReadmeMarkdown.tsx
+++ b/apps/console/src/components/ModelReadmeMarkdown.tsx
@@ -44,7 +44,7 @@ export const ModelReadmeMarkdown = ({
           <h3 className="text-instillGrey90 text-instill-h3 mx-auto mt-auto">
             There is no Model card
           </h3>
-          <p className="mx-auto mb-auto text-semantic-node-disconnected-default-stroke text-instill-body">
+          <p className="text-semantic-node-disconnected-default-stroke text-instill-body mx-auto mb-auto">
             You can add a README.md to describe the model.
           </p>
         </React.Fragment>

--- a/apps/instill-form-playground/package.json
+++ b/apps/instill-form-playground/package.json
@@ -31,5 +31,10 @@
     "eslint-config-next": "13.5.6",
     "@instill-ai/eslint-config-cortex": "workspace:*",
     "@instill-ai/prettier-config-cortex": "workspace:*"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "js-yaml": "^4.1.0",
     "lint-staged": ">=10",
     "prettier": "latest",
-    "prettier-plugin-tailwindcss": "latest",
     "@instill-ai/prettier-config-cortex": "workspace:*",
     "turbo": "latest",
     "typescript": "^5.4.2"
@@ -46,12 +45,10 @@
       "express": "4.19.2"
     }
   },
+  "prettier": "@instill-ai/prettier-config-cortex",
   "lint-staged": {
-    "**/*.{ts,tsx}": [
-      "prettier --write"
-    ],
     "**/*.{js,jsx,ts,tsx}": [
-      "eslint --cache --fix"
+      "prettier --write"
     ]
   }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -143,5 +143,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ]
   }
 }

--- a/packages/design-system/src/new-ui/Button/Button.tsx
+++ b/packages/design-system/src/new-ui/Button/Button.tsx
@@ -39,7 +39,7 @@ const buttonVariants = cva(
       variant: "primary",
       size: "md",
     },
-  }
+  },
 );
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
@@ -57,7 +57,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       />
     );
-  }
+  },
 );
 Button.displayName = "Button";
 

--- a/packages/design-system/src/new-ui/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/new-ui/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ const checkboxStyle = cn(
   "hover:border-semantic-accent-hover hover:bg-semantic-accent-bg hover:data-[state=checked]:bg-semantic-accent-hover hover:data-[state=checked]:border-semantic-accent-hover",
   "data-[state=checked]:bg-semantic-accent-default data-[state=checked]:border-semantic-accent-default",
   "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-semantic-accent-default focus-visible:ring-offset-2",
-  "disabled:cursor-not-allowed disabled:!bg-semantic-bg-secondary disabled:!border-semantic-bg-line"
+  "disabled:cursor-not-allowed disabled:!bg-semantic-bg-secondary disabled:!border-semantic-bg-line",
 );
 
 const Checkbox = React.forwardRef<

--- a/packages/design-system/src/new-ui/Combobox/Combobox.tsx
+++ b/packages/design-system/src/new-ui/Combobox/Combobox.tsx
@@ -45,7 +45,7 @@ export function Combobox({
                 <Icons.Check
                   className={cn(
                     "h-4 w-4 stroke-semantic-fg-secondary",
-                    value === item.value ? "opacity-100" : "opacity-0"
+                    value === item.value ? "opacity-100" : "opacity-0",
                   )}
                 />
 

--- a/packages/design-system/src/new-ui/Command/Command.tsx
+++ b/packages/design-system/src/new-ui/Command/Command.tsx
@@ -15,7 +15,7 @@ const CommandRoot = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-semantic-bg-primary text-semantic-fg-secondary",
-      className
+      className,
     )}
     {...props}
   />
@@ -39,7 +39,7 @@ const CommandDialog = ({
         <CommandRoot
           className={cn(
             "[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5",
-            commandRootClassName
+            commandRootClassName,
           )}
         >
           {children}
@@ -65,7 +65,7 @@ const CommandInput = React.forwardRef<
       ref={ref}
       className={cn(
         "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-semantic-fg-disabled disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
@@ -108,7 +108,7 @@ const CommandGroup = React.forwardRef<
     ref={ref}
     className={cn(
       "overflow-hidden p-1 text-semantic-fg-secondary [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-semantic-fg-secondary",
-      className
+      className,
     )}
     {...props}
   />
@@ -136,7 +136,7 @@ const CommandItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-pointer select-none items-center gap-x-2 rounded-sm px-2 py-1.5 text-sm text-semantic-fg-primary outline-none product-body-text-3-medium aria-selected:bg-semantic-accent-bg data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   />
@@ -152,7 +152,7 @@ const CommandShortcut = ({
     <span
       className={cn(
         "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
+        className,
       )}
       {...props}
     />

--- a/packages/design-system/src/new-ui/DataTable/DataTable.tsx
+++ b/packages/design-system/src/new-ui/DataTable/DataTable.tsx
@@ -57,7 +57,7 @@ const DataTable = <TData, TValue>({
   const [rowSelection, setRowSelection] = React.useState({});
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
-    []
+    [],
   );
 
   const table = useReactTable({
@@ -167,7 +167,7 @@ const DataTable = <TData, TValue>({
                       ? null
                       : flexRender(
                           header.column.columnDef.header,
-                          header.getContext()
+                          header.getContext(),
                         )}
                   </Table.Head>
                 );
@@ -204,7 +204,7 @@ const DataTable = <TData, TValue>({
                       <Table.Cell key={cell.id}>
                         {flexRender(
                           cell.column.columnDef.cell,
-                          cell.getContext()
+                          cell.getContext(),
                         )}
                       </Table.Cell>
                     ))}

--- a/packages/design-system/src/new-ui/DataTable/DataTablePagination.tsx
+++ b/packages/design-system/src/new-ui/DataTable/DataTablePagination.tsx
@@ -10,7 +10,7 @@ interface DataTablePaginationProps<TData> {
 export function createPaginationArray(
   currentPage: number,
   totalPages: number,
-  maxVisiblePages = 10
+  maxVisiblePages = 10,
 ): (number | string)[] {
   const paginationArray: (number | string)[] = [];
 
@@ -35,7 +35,7 @@ export function createPaginationArray(
     const startPage: number = Math.max(2, currentPage - numPagesBefore);
     const endPage: number = Math.min(
       totalPages - 2,
-      currentPage + numPagesAfter
+      currentPage + numPagesAfter,
     );
 
     // Add visible pages to the pagination array
@@ -79,12 +79,12 @@ export function DataTablePagination<TData>({
         ? createPaginationArray(
             (table.options.state.pagination?.pageIndex || 0) + 1,
             table.getPageCount(),
-            8
+            8,
           ).map((e, index) => (
             <Button
               className={cn(
                 "!rounded-none border-l-0 !border-semantic-bg-line !py-2.5 px-2.5",
-                table.getPageCount() - 1 === e && "border-r-0"
+                table.getPageCount() - 1 === e && "border-r-0",
               )}
               variant="secondaryGrey"
               size="sm"
@@ -105,7 +105,7 @@ export function DataTablePagination<TData>({
       <Button
         className={cn(
           "gap-x-2 !rounded-l-none rounded-r-sm !border-semantic-bg-line !py-2.5 px-4",
-          !showPageNumbers ? "border-l-0" : null
+          !showPageNumbers ? "border-l-0" : null,
         )}
         variant="secondaryGrey"
         size="sm"

--- a/packages/design-system/src/new-ui/Dialog/Dialog.tsx
+++ b/packages/design-system/src/new-ui/Dialog/Dialog.tsx
@@ -29,7 +29,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-semantic-fg-disabled transition-all duration-100 data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
-      className
+      className,
     )}
     {...props}
   />
@@ -48,7 +48,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         "fixed z-50 grid w-full gap-4 rounded bg-semantic-bg-primary p-6 shadow-lg animate-in data-[state=open]:fade-in-90 data-[state=open]:slide-in-from-bottom-10 sm:max-w-lg sm:zoom-in-90 data-[state=open]:sm:slide-in-from-bottom-0 lg:max-w-4xl",
-        className
+        className,
       )}
       {...props}
     >
@@ -67,7 +67,7 @@ const DialogClose = React.forwardRef<
     ref={ref}
     className={cn(
       "absolute right-4 top-4 rounded opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-semantic-accent-hover focus:ring-offset-2 disabled:pointer-events-none",
-      className
+      className,
     )}
   >
     <Icons.X className="h-5 w-5 stroke-semantic-fg-primary" />
@@ -91,7 +91,7 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col sm:flex-row sm:justify-end sm:space-x-2",
-      className
+      className,
     )}
     {...props}
   />
@@ -118,7 +118,7 @@ const DialogDescription = React.forwardRef<
     ref={ref}
     className={cn(
       "text-semantic-fg-secondary product-body-text-2-regular",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/DropdownMenu/DropdownMenu.tsx
+++ b/packages/design-system/src/new-ui/DropdownMenu/DropdownMenu.tsx
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[state=open]:bg-semantic-accent-bg",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   >
@@ -52,7 +52,7 @@ const DropdownMenuSubContent = React.forwardRef<
       "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
       "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
       "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   />
@@ -74,7 +74,7 @@ const DropdownMenuContent = React.forwardRef<
         "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
         "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
+        className,
       )}
       {...props}
     />
@@ -95,7 +95,7 @@ const DropdownMenuItem = React.forwardRef<
       "text-semantic-fg-primary transition-colors focus:bg-semantic-accent-bg focus:text-semantic-accent-default",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
@@ -112,7 +112,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
       "text-semantic-fg-primary transition-colors focus:bg-semantic-accent-bg focus:text-semantic-accent-default",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     checked={checked}
     {...props}
@@ -138,7 +138,7 @@ const DropdownMenuRadioItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
       "focus:text-semantic-accent-defaul text-semantic-fg-primary transition-colors focus:bg-semantic-accent-bg",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -163,7 +163,7 @@ const DropdownMenuLabel = React.forwardRef<
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-semantic-fg-primary",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/Field.tsx
+++ b/packages/design-system/src/new-ui/Field.tsx
@@ -25,7 +25,7 @@ const Description = React.forwardRef<
     <p
       className={cn(
         "flex text-[#1D2433CC] product-body-text-3-regular",
-        className
+        className,
       )}
       ref={ref}
       {...props}
@@ -44,7 +44,7 @@ const Label = React.forwardRef<
     <label
       className={cn(
         "flex text-semantic-fg-primary product-body-text-2-semibold",
-        className
+        className,
       )}
       ref={ref}
       {...props}

--- a/packages/design-system/src/new-ui/Form/Form.tsx
+++ b/packages/design-system/src/new-ui/Form/Form.tsx
@@ -27,7 +27,7 @@ type FormFieldContextValue<
 };
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue
+  {} as FormFieldContextValue,
 );
 
 const FormField = <
@@ -71,7 +71,7 @@ type FormItemContextValue = {
 };
 
 const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue
+  {} as FormItemContextValue,
 );
 
 const FormItem = React.forwardRef<
@@ -149,7 +149,7 @@ const FormDescription = React.forwardRef<
       className={cn(
         // We use hex code temporary, until our design-token support opacity
         "text-[#1D243380] product-body-text-3-regular",
-        className
+        className,
       )}
     />
   );
@@ -173,7 +173,7 @@ const FormMessage = React.forwardRef<
       id={formMessageId}
       className={cn(
         "text-semantic-error-default product-body-text-3-regular",
-        className
+        className,
       )}
       {...props}
     >

--- a/packages/design-system/src/new-ui/Icons/IconBase/IconBase.tsx
+++ b/packages/design-system/src/new-ui/Icons/IconBase/IconBase.tsx
@@ -22,6 +22,6 @@ export const IconBase = React.forwardRef<SVGSVGElement, IconBaseProps>(
         {children}
       </svg>
     );
-  }
+  },
 );
 IconBase.displayName = "IconBase";

--- a/packages/design-system/src/new-ui/Input/Input.tsx
+++ b/packages/design-system/src/new-ui/Input/Input.tsx
@@ -11,7 +11,7 @@ const Root = React.forwardRef<
     <div
       className={cn(
         "relative flex flex-row space-x-2 rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-2 focus-within:border-semantic-accent-default focus-within:outline focus-within:outline-1 focus-within:outline-semantic-accent-default focus-within:ring-0 disabled-within:cursor-not-allowed disabled-within:bg-semantic-bg-secondary",
-        className
+        className,
       )}
       ref={ref}
       {...props}
@@ -31,13 +31,13 @@ const Core = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         className={cn(
           "flex w-full border-0 bg-semantic-bg-primary text-semantic-fg-primary product-body-text-2-regular file:border-0 file:bg-semantic-bg-primary file:product-body-text-2-semibold placeholder:text-[#1D243380] focus-visible:outline-0 focus-visible:ring-0 disabled:cursor-not-allowed disabled:bg-semantic-bg-secondary",
-          className
+          className,
         )}
         ref={ref}
         {...props}
       />
     );
-  }
+  },
 );
 Core.displayName = "InputCore";
 

--- a/packages/design-system/src/new-ui/Label/Label.tsx
+++ b/packages/design-system/src/new-ui/Label/Label.tsx
@@ -12,7 +12,7 @@ export const Label = React.forwardRef<
     ref={ref}
     className={cn(
       "flex text-semantic-fg-primary product-body-text-2-regular",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/LinkButton/LinkButton.tsx
+++ b/packages/design-system/src/new-ui/LinkButton/LinkButton.tsx
@@ -29,7 +29,7 @@ const linkButtonVariants = cva(
       variant: "primary",
       size: "md",
     },
-  }
+  },
 );
 
 export type LinkButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
@@ -47,7 +47,7 @@ const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
         {...props}
       />
     );
-  }
+  },
 );
 LinkButton.displayName = "Button";
 

--- a/packages/design-system/src/new-ui/Logos/LogoBase/LogoBase.tsx
+++ b/packages/design-system/src/new-ui/Logos/LogoBase/LogoBase.tsx
@@ -22,6 +22,6 @@ export const LogoBase = React.forwardRef<SVGSVGElement, LogoBaseProps>(
         {children}
       </svg>
     );
-  }
+  },
 );
 LogoBase.displayName = "LogoBase";

--- a/packages/design-system/src/new-ui/Menubar/Menubar.tsx
+++ b/packages/design-system/src/new-ui/Menubar/Menubar.tsx
@@ -23,7 +23,7 @@ const MenubarRoot = React.forwardRef<
     ref={ref}
     className={cn(
       "flex items-center space-x-1 rounded border bg-semantic-bg-primary p-1 shadow-sm",
-      className
+      className,
     )}
     {...props}
   />
@@ -42,7 +42,7 @@ const MenubarTrigger = React.forwardRef<
       "focus:bg-semantic-accent-bg focus:text-semantic-accent-on-bg",
       "hover:bg-[#f5f5f5] hover:text-semantic-fg-primary",
       "disabled:pointer-events-none disabled:text-[#bfbfbf] disabled:hover:!bg-semantic-bg-primary disabled:hover:!text-semantic-fg-primary",
-      className
+      className,
     )}
     {...props}
   />
@@ -62,7 +62,7 @@ const MenubarSubTrigger = React.forwardRef<
       "focus:bg-semantic-accent-bg focus:text-semantic-accent-on-bg",
       "data-[state=open]:bg-semantic-accent-bg data-[state=open]:text-semantic-accent-on-bg",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   >
@@ -86,7 +86,7 @@ const MenubarSubContent = React.forwardRef<
       "data-[side=left]:slide-in-from-right-2",
       "data-[side=right]:slide-in-from-left-2",
       "data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   />
@@ -99,7 +99,7 @@ const MenubarContent = React.forwardRef<
 >(
   (
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
-    ref
+    ref,
   ) => (
     <MenubarPrimitive.Portal>
       <MenubarPrimitive.Content
@@ -115,12 +115,12 @@ const MenubarContent = React.forwardRef<
           "data-[side=left]:slide-in-from-right-2",
           "data-[side=right]:slide-in-from-left-2",
           "data-[side=top]:slide-in-from-bottom-2",
-          className
+          className,
         )}
         {...props}
       />
     </MenubarPrimitive.Portal>
-  )
+  ),
 );
 MenubarContent.displayName = MenubarPrimitive.Content.displayName;
 
@@ -137,7 +137,7 @@ const MenubarItem = React.forwardRef<
       "focus:bg-semantic-accent-bg focus:text-semantic-accent-on-bg",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
@@ -154,7 +154,7 @@ const MenubarCheckboxItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded py-1.5 pl-8 pr-2 outline-none product-body-text-3-regular",
       "focus:bg-semantic-accent-bg focus:text-semantic-accent-on-bg",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     checked={checked}
     {...props}
@@ -179,7 +179,7 @@ const MenubarRadioItem = React.forwardRef<
       "relative flex cursor-default select-none items-center rounded py-1.5 pl-8 pr-2 outline-none product-body-text-3-regular",
       "focus:bg-semantic-accent-bg focus:text-semantic-accent-on-bg",
       "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -204,7 +204,7 @@ const MenubarLabel = React.forwardRef<
     className={cn(
       "px-2 py-1.5 product-body-text-3-semibold",
       inset && "pl-8",
-      className
+      className,
     )}
     {...props}
   />
@@ -231,7 +231,7 @@ const MenubarShortcut = ({
     <span
       className={cn(
         "ml-auto tracking-widest text-semantic-fg-secondary product-body-text-4-regular",
-        className
+        className,
       )}
       {...props}
     />

--- a/packages/design-system/src/new-ui/MultiSelect/MultiSelect.tsx
+++ b/packages/design-system/src/new-ui/MultiSelect/MultiSelect.tsx
@@ -45,7 +45,7 @@ export function MultiSelect({
           variant="secondaryGrey"
           className={cn(
             "w-full justify-between",
-            selectedOptions.length > 0 ? "h-full" : "h-10"
+            selectedOptions.length > 0 ? "h-full" : "h-10",
           )}
         >
           {selectedOptions.length > 0 ? (
@@ -117,7 +117,7 @@ export function MultiSelect({
                   onChange(
                     selectedOptions.includes(option.value)
                       ? selectedOptions.filter((item) => item !== option.value)
-                      : [...selectedOptions, option.value]
+                      : [...selectedOptions, option.value],
                   );
                   setOpen(true);
                 }}
@@ -127,7 +127,7 @@ export function MultiSelect({
                     "h-4 w-4 stroke-semantic-fg-secondary",
                     selectedOptions.includes(option.value)
                       ? "opacity-100"
-                      : "opacity-0"
+                      : "opacity-0",
                   )}
                 />
                 {option.startIcon}

--- a/packages/design-system/src/new-ui/Pagination/Pagination.tsx
+++ b/packages/design-system/src/new-ui/Pagination/Pagination.tsx
@@ -36,7 +36,7 @@ const PaginationContent = React.forwardRef<
       "[&>li:nth-child(2)]:data-[align=left]:ml-auto",
       "[&>li:nth-child(2)]:data-[align=right]:order-first",
       "[&>li:nth-child(2)]:data-[align=right]:mr-auto",
-      className
+      className,
     )}
     data-align={align}
     {...props}
@@ -59,7 +59,7 @@ const PaginationPrevious = ({
   <Button
     className={cn(
       "gap-x-2 rounded-l-sm rounded-r-none !border-semantic-bg-line !py-2.5 px-4",
-      className
+      className,
     )}
     variant="secondaryGrey"
     size="sm"
@@ -79,7 +79,7 @@ const PaginationNext = ({
   <Button
     className={cn(
       "gap-x-2 rounded-l-none rounded-r-sm border-l-0 !border-semantic-bg-line !py-2.5 px-4",
-      className
+      className,
     )}
     variant="secondaryGrey"
     size="sm"

--- a/packages/design-system/src/new-ui/Popover/Popover.tsx
+++ b/packages/design-system/src/new-ui/Popover/Popover.tsx
@@ -12,7 +12,7 @@ const popoverStyle = cn(
   "z-50 w-72 rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-4 shadow-md outline-none",
   "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
   "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-  "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 );
 
 const PopoverContent = React.forwardRef<

--- a/packages/design-system/src/new-ui/Progress/Progress.tsx
+++ b/packages/design-system/src/new-ui/Progress/Progress.tsx
@@ -12,7 +12,7 @@ const Progress = React.forwardRef<
     ref={ref}
     className={cn(
       "relative h-2 w-full overflow-hidden rounded-full bg-[#1D2433] bg-opacity-30",
-      className
+      className,
     )}
     {...props}
   >

--- a/packages/design-system/src/new-ui/ScrollArea/ScrollArea.stories.tsx
+++ b/packages/design-system/src/new-ui/ScrollArea/ScrollArea.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
 };
 
 const tags = Array.from({ length: 50 }).map(
-  (_, i, a) => `v1.2.0-beta.${a.length - i}`
+  (_, i, a) => `v1.2.0-beta.${a.length - i}`,
 );
 
 export const DynamicHeight: Story = {

--- a/packages/design-system/src/new-ui/ScrollArea/ScrollArea.tsx
+++ b/packages/design-system/src/new-ui/ScrollArea/ScrollArea.tsx
@@ -41,7 +41,7 @@ const ScrollBar = React.forwardRef<
         "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&
         "h-2.5 border-t border-t-transparent p-[1px]",
-      className
+      className,
     )}
     {...props}
   >

--- a/packages/design-system/src/new-ui/Select/Select.tsx
+++ b/packages/design-system/src/new-ui/Select/Select.tsx
@@ -23,7 +23,7 @@ const Trigger = React.forwardRef<
     ref={ref}
     className={cn(
       "flex h-10 w-full items-center justify-between rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-2 product-body-text-2-regular focus:border-semantic-accent-default focus:outline-none focus:ring-2 focus:ring-semantic-accent-default focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-[#1D2433CC]",
-      className
+      className,
     )}
     {...props}
   >
@@ -47,7 +47,7 @@ const Content = React.forwardRef<
 >(
   (
     { className, viewportClassName, children, position = "popper", ...props },
-    ref
+    ref,
   ) => (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -55,7 +55,7 @@ const Content = React.forwardRef<
         className={cn(
           "relative z-50 max-h-[320px] min-w-[8rem] overflow-y-scroll rounded-sm border bg-semantic-bg-primary text-semantic-fg-primary shadow-md animate-in fade-in-80",
           position === "popper" && "translate-y-1",
-          className
+          className,
         )}
         position={position}
         {...props}
@@ -65,14 +65,14 @@ const Content = React.forwardRef<
             "p-1",
             position === "popper" &&
               "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
-            viewportClassName
+            viewportClassName,
           )}
         >
           {children}
         </SelectPrimitive.Viewport>
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  ),
 );
 Content.displayName = SelectPrimitive.Content.displayName;
 
@@ -103,7 +103,7 @@ const Item = React.forwardRef<
     ref={ref}
     className={cn(
       "group relative flex w-full cursor-pointer select-none items-center rounded stroke-semantic-fg-primary py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-semantic-accent-default focus:text-semantic-bg-primary data-[disabled]:pointer-events-none data-[highlighted]:stroke-semantic-bg-primary data-[disabled]:opacity-50",
-      className
+      className,
     )}
     {...props}
   >
@@ -111,7 +111,7 @@ const Item = React.forwardRef<
       <span
         className={cn(
           "absolute flex h-4 w-4 items-center justify-center",
-          tailCheck ? "right-2" : "left-2"
+          tailCheck ? "right-2" : "left-2",
         )}
       >
         <SelectPrimitive.ItemIndicator>

--- a/packages/design-system/src/new-ui/Separator/Separator.tsx
+++ b/packages/design-system/src/new-ui/Separator/Separator.tsx
@@ -10,7 +10,7 @@ const Separator = React.forwardRef<
 >(
   (
     { className, orientation = "horizontal", decorative = true, ...props },
-    ref
+    ref,
   ) => (
     <SeparatorPrimitive.Root
       ref={ref}
@@ -19,11 +19,11 @@ const Separator = React.forwardRef<
       className={cn(
         "shrink-0 bg-semantic-bg-line",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  ),
 );
 Separator.displayName = SeparatorPrimitive.Root.displayName;
 

--- a/packages/design-system/src/new-ui/Switch/Switch.tsx
+++ b/packages/design-system/src/new-ui/Switch/Switch.tsx
@@ -13,7 +13,7 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     className={cn(
       "peer inline-flex h-[21px] w-[36px] shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-semantic-fg-disabled data-[state=checked]:bg-semantic-accent-default data-[state=unchecked]:bg-semantic-info-secondary-text-on-bg hover:data-[state=checked]:bg-semantic-accent-hover hover:data-[state=unchecked]:bg-semantic-fg-primary focus-visible:data-[state=checked]:ring-semantic-accent-hover focus-visible:data-[state=unchecked]:ring-semantic-fg-primary",
-      className
+      className,
     )}
     {...props}
     ref={ref}
@@ -21,7 +21,7 @@ const Switch = React.forwardRef<
     <SwitchPrimitives.Thumb
       className={cn(
         "pointer-events-none block h-[15px] w-[15px] rounded-full bg-semantic-bg-primary shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-[18px] data-[state=unchecked]:translate-x-[3px]",
-        thumbClassName
+        thumbClassName,
       )}
     />
   </SwitchPrimitives.Root>

--- a/packages/design-system/src/new-ui/Table/Table.tsx
+++ b/packages/design-system/src/new-ui/Table/Table.tsx
@@ -10,7 +10,7 @@ const TableRoot = React.forwardRef<
   <div
     className={cn(
       "w-full overflow-auto rounded-b-sm border border-semantic-bg-line",
-      wrapperClassName
+      wrapperClassName,
     )}
   >
     <table
@@ -66,7 +66,7 @@ const TableFoot = React.forwardRef<
     ref={ref}
     className={cn(
       "px-6 py-3 text-semantic-fg-secondary product-body-text-4-semibold [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      className,
     )}
     {...props}
   />
@@ -81,7 +81,7 @@ const TableRow = React.forwardRef<
     ref={ref}
     className={cn(
       "border-b transition-colors hover:bg-semantic-bg-alt-primary data-[state=selected]:bg-semantic-bg-alt-primary",
-      className
+      className,
     )}
     {...props}
   />
@@ -96,7 +96,7 @@ const TableHead = React.forwardRef<
     ref={ref}
     className={cn(
       "px-6 py-3 text-semantic-fg-secondary product-body-text-4-semibold [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      className,
     )}
     {...props}
   />
@@ -111,7 +111,7 @@ const TableCell = React.forwardRef<
     ref={ref}
     className={cn(
       "p-6 align-middle text-semantic-fg-primary product-body-text-3-semibold [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      className,
     )}
     {...props}
   />
@@ -126,7 +126,7 @@ const TableCaption = React.forwardRef<
     ref={ref}
     className={cn(
       "mt-4 text-semantic-fg-secondary product-body-text-4-semibold",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/Tabs/Tabs.stories.tsx
+++ b/packages/design-system/src/new-ui/Tabs/Tabs.stories.tsx
@@ -76,7 +76,7 @@ export const Regular: Story = {
               ],
             },
             null,
-            2
+            2,
           )}
         </pre>
       </Tabs.Content>

--- a/packages/design-system/src/new-ui/Tag/Tag.tsx
+++ b/packages/design-system/src/new-ui/Tag/Tag.tsx
@@ -57,7 +57,7 @@ const Tag = React.forwardRef<HTMLDivElement, TagProps>(
         {...props}
       />
     );
-  }
+  },
 );
 Tag.displayName = "Tag";
 

--- a/packages/design-system/src/new-ui/TagButton/TagButton.tsx
+++ b/packages/design-system/src/new-ui/TagButton/TagButton.tsx
@@ -23,7 +23,7 @@ const tagButtonVariants = cva(
       variant: "default",
       size: "md",
     },
-  }
+  },
 );
 
 export type TagButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
@@ -41,7 +41,7 @@ const TagButton = React.forwardRef<HTMLButtonElement, TagButtonProps>(
         {...props}
       />
     );
-  }
+  },
 );
 TagButton.displayName = "TagButton";
 

--- a/packages/design-system/src/new-ui/Textarea/Textarea.tsx
+++ b/packages/design-system/src/new-ui/Textarea/Textarea.tsx
@@ -11,13 +11,13 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           "flex min-h-[80px] w-full rounded-sm border bg-semantic-bg-primary p-2 text-sm text-semantic-fg-primary product-body-text-2-regular placeholder:text-[#1D243380] focus-visible:border-semantic-accent-default focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-semantic-accent-default disabled:cursor-not-allowed disabled:bg-semantic-bg-secondary",
-          className
+          className,
         )}
         ref={ref}
         {...props}
       />
     );
-  }
+  },
 );
 
 Textarea.displayName = "Textarea";

--- a/packages/design-system/src/new-ui/Toast/Toast.tsx
+++ b/packages/design-system/src/new-ui/Toast/Toast.tsx
@@ -18,7 +18,7 @@ const ToastViewport = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col space-y-5 p-4 sm:bottom-auto sm:left-1/2 sm:top-0 sm:-translate-x-1/2 sm:flex-col md:max-w-[420px]",
-      className
+      className,
     )}
     {...props}
   />
@@ -33,7 +33,7 @@ const toastMainStyle = cn(
   "data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full",
   "data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none",
   "data-[swipe=cancel]:translate-x-0",
-  "data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=end]:animate-out"
+  "data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=end]:animate-out",
 );
 
 const toastVariants = cva(toastMainStyle, {
@@ -87,7 +87,7 @@ const ToastClose = React.forwardRef<
     ref={ref}
     className={cn(
       "rounded active:ring-1 active:ring-semantic-bg-line",
-      className
+      className,
     )}
     toast-close=""
     {...props}
@@ -105,7 +105,7 @@ const ToastTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-semantic-fg-primary product-body-text-2-semibold",
-      className
+      className,
     )}
     {...props}
   />
@@ -120,7 +120,7 @@ const ToastDescription = React.forwardRef<
     ref={ref}
     className={cn(
       "text-semantic-fg-secondary product-body-text-3-regular",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/Toast/Toaster.tsx
+++ b/packages/design-system/src/new-ui/Toast/Toaster.tsx
@@ -29,7 +29,7 @@ export function Toaster(props: ToasterProps) {
 
         if (variant === "notification-icon" && !icon) {
           throw new Error(
-            "Toaster: variant `notification-icon` requires `icon` prop"
+            "Toaster: variant `notification-icon` requires `icon` prop",
           );
         }
 
@@ -102,7 +102,7 @@ export function Toaster(props: ToasterProps) {
 
 function getToasterIcon(
   variant: ToastProps["variant"],
-  icon?: ToasterToast["icon"]
+  icon?: ToasterToast["icon"],
 ) {
   if (variant?.includes("success")) {
     return (

--- a/packages/design-system/src/new-ui/Toast/use-toast.tsx
+++ b/packages/design-system/src/new-ui/Toast/use-toast.tsx
@@ -88,7 +88,7 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         toasts: state.toasts.map((t) =>
-          t.id === action.toast.id ? { ...t, ...action.toast } : t
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
         ),
       };
 
@@ -113,7 +113,7 @@ export const reducer = (state: State, action: Action): State => {
                 ...t,
                 open: false,
               }
-            : t
+            : t,
         ),
       };
     }

--- a/packages/design-system/src/new-ui/ToggleGroup/ToggleGroup.tsx
+++ b/packages/design-system/src/new-ui/ToggleGroup/ToggleGroup.tsx
@@ -10,7 +10,7 @@ const ToggleGroupRoot = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex flex-row space-x-px rounded bg-semantic-bg-line p-px",
-      className
+      className,
     )}
     {...props}
   />
@@ -26,7 +26,7 @@ const ToggleGroupItem = React.forwardRef<
     className={cn(
       "flex h-full cursor-pointer items-center justify-center bg-semantic-bg-primary px-4 py-2 text-base font-semibold",
       "first:rounded-l last:rounded-r focus:outline-none data-[state=on]:cursor-default data-[state=on]:bg-semantic-accent-bg data-[state=on]:text-semantic-accent-default",
-      className
+      className,
     )}
     {...props}
   />

--- a/packages/design-system/src/new-ui/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/new-ui/Tooltip/Tooltip.tsx
@@ -29,7 +29,7 @@ const TooltipContent = React.forwardRef<
       "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
       "animate-in data-[state=delayed-open]:fade-in data-[state=delayed-open]:zoom-in-105",
       "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
+      className,
     )}
     {...props}
   >

--- a/packages/design-system/src/new-ui/radio-group/RadioGroup.tsx
+++ b/packages/design-system/src/new-ui/radio-group/RadioGroup.tsx
@@ -30,7 +30,7 @@ const RadioGroupItem = React.forwardRef<
       className={cn(
         "aspect-square h-4 w-4 shrink-0 rounded-full border border-semantic-fg-secondary text-semantic-fg-primary focus:outline-none focus-visible:ring-1 focus-visible:ring-semantic-accent-default disabled:cursor-not-allowed disabled:opacity-50",
         "data-[state=checked]:border-semantic-accent-default data-[state=checked]:bg-semantic-accent-default",
-        className
+        className,
       )}
       {...props}
     >

--- a/packages/design-system/src/new-ui/tab-menu/TabMenu.tsx
+++ b/packages/design-system/src/new-ui/tab-menu/TabMenu.tsx
@@ -44,7 +44,7 @@ const TabMenuRoot = ({
         onValueChange(value);
       },
     }),
-    [value, onValueChange, disabledDeSelect]
+    [value, onValueChange, disabledDeSelect],
   );
 
   return (
@@ -61,7 +61,7 @@ const TabMenuItem = (
     children: React.ReactNode;
     value: string;
     className?: string;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { children, className, value, onClick, ...passThrough } = props;
 
@@ -75,7 +75,7 @@ const TabMenuItem = (
         "flex flex-row items-center gap-x-2",
         "h-8 border-b-2 border-[#1D2433] border-opacity-0 text-semantic-fg-disabled product-button-button-3 hover:text-semantic-fg-primary [&>svg]:stroke-semantic-fg-disabled [&>svg]:hover:stroke-semantic-fg-primary",
         "data-[selected=true]:pointer-events-none data-[selected=true]:border-semantic-accent-default data-[selected=true]:border-opacity-100 data-[selected=true]:text-semantic-fg-primary [&>svg]:data-[selected=true]:stroke-semantic-fg-primary",
-        className
+        className,
       )}
       data-selected={selectedValue === value}
       onClick={(e) => {

--- a/packages/design-system/src/ui/Accordion/AccordionBase/AccordionBase.tsx
+++ b/packages/design-system/src/ui/Accordion/AccordionBase/AccordionBase.tsx
@@ -164,7 +164,7 @@ const AccordionBase = (props: AccordionBaseProps) => {
         }
       });
     },
-    [setActiveIndex, allowMultiItems]
+    [setActiveIndex, allowMultiItems],
   );
 
   return (
@@ -174,7 +174,7 @@ const AccordionBase = (props: AccordionBaseProps) => {
           key={e.header}
           className={cn(
             "flex flex-col overflow-hidden",
-            type === "withIcon" ? "relative" : ""
+            type === "withIcon" ? "relative" : "",
           )}
         >
           {type === "withIcon" ? (
@@ -194,7 +194,7 @@ const AccordionBase = (props: AccordionBaseProps) => {
               headerStyle.headerPadding,
               activeIndex.includes(i)
                 ? e.headerActiveBgColor
-                : e.headerInActiveBgColor
+                : e.headerInActiveBgColor,
             )}
           >
             <div
@@ -205,7 +205,7 @@ const AccordionBase = (props: AccordionBaseProps) => {
                 headerStyle.headerFontWeight,
                 activeIndex.includes(i)
                   ? e.headerActiveTextColor
-                  : e.headerInActiveTextColor
+                  : e.headerInActiveTextColor,
               )}
             >
               {e.header}

--- a/packages/design-system/src/ui/Buttons/ButtonBase/ButtonBase.tsx
+++ b/packages/design-system/src/ui/Buttons/ButtonBase/ButtonBase.tsx
@@ -206,7 +206,7 @@ const ButtonBase = (props: ButtonBaseProps) => {
               disabledBgOpacity,
               disabledTextColor,
               disabledBorderColor,
-              "cursor-not-allowed"
+              "cursor-not-allowed",
             )
           : cn(
               bgColor,
@@ -216,7 +216,7 @@ const ButtonBase = (props: ButtonBaseProps) => {
               textColor,
               hoveredTextColor,
               borderColor,
-              hoveredBorderColor
+              hoveredBorderColor,
             ),
         position,
         padding,
@@ -225,7 +225,7 @@ const ButtonBase = (props: ButtonBaseProps) => {
         borderSize,
         borderRadius,
         shadow,
-        hoveredShadow
+        hoveredShadow,
       )}
     >
       {startIcon}

--- a/packages/design-system/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.stories.tsx
+++ b/packages/design-system/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.stories.tsx
@@ -12,7 +12,7 @@ const Template: StoryFn<typeof CollapseSidebarButton> = (args) => (
   <CollapseSidebarButton {...args} />
 );
 export const Playground: StoryFn<typeof CollapseSidebarButton> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Buttons/OutlineButton/OutlineButton.tsx
+++ b/packages/design-system/src/ui/Buttons/OutlineButton/OutlineButton.tsx
@@ -144,7 +144,7 @@ const OutlineButton = (props: OutlineButtonProps) => {
     }
     default: {
       throw new Error(
-        `Button variant ${props.color} not support, OutlineButton only support variant=primary`
+        `Button variant ${props.color} not support, OutlineButton only support variant=primary`,
       );
     }
   }

--- a/packages/design-system/src/ui/Buttons/SolidButton/SolidButton.tsx
+++ b/packages/design-system/src/ui/Buttons/SolidButton/SolidButton.tsx
@@ -137,7 +137,7 @@ const SolidButton = (props: SolidButtonProps) => {
     // }
     default: {
       throw new Error(
-        `Button variant ${props.color} not support, SolidButton only support variant=primary | primaryLight`
+        `Button variant ${props.color} not support, SolidButton only support variant=primary | primaryLight`,
       );
     }
   }

--- a/packages/design-system/src/ui/Buttons/TextButton/TextButton.tsx
+++ b/packages/design-system/src/ui/Buttons/TextButton/TextButton.tsx
@@ -96,7 +96,7 @@ const TextButton = (props: TextButtonProps) => {
     // }
     default: {
       throw new Error(
-        `Button variant ${props.color} not support, TextButton only support variant=primary`
+        `Button variant ${props.color} not support, TextButton only support variant=primary`,
       );
     }
   }

--- a/packages/design-system/src/ui/FormRoot.tsx
+++ b/packages/design-system/src/ui/FormRoot.tsx
@@ -31,7 +31,7 @@ export const FormRoot = ({
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
     },
-    []
+    [],
   );
 
   return formLess ? (

--- a/packages/design-system/src/ui/Icons/DataDestinationIcon/DataDestinationIcon.stories.tsx
+++ b/packages/design-system/src/ui/Icons/DataDestinationIcon/DataDestinationIcon.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof DataDestinationIcon> = (args) => (
 );
 
 export const Playground: StoryFn<typeof DataDestinationIcon> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Icons/IconBase/IconBase.tsx
+++ b/packages/design-system/src/ui/Icons/IconBase/IconBase.tsx
@@ -55,13 +55,13 @@ const IconBase = ({
   if (style) {
     if (width) {
       throw new Error(
-        "Should not use style props together with utility class - width"
+        "Should not use style props together with utility class - width",
       );
     }
 
     if (height) {
       throw new Error(
-        "Should not use style props together with utility class - height"
+        "Should not use style props together with utility class - height",
       );
     }
   }

--- a/packages/design-system/src/ui/Icons/ImageClassificationIcon/ImageClassificationIcon.tsx
+++ b/packages/design-system/src/ui/Icons/ImageClassificationIcon/ImageClassificationIcon.tsx
@@ -7,7 +7,7 @@ export type ImageClassificationIconProps = Omit<
 >;
 
 const ImageClassificationIcon: React.FC<ImageClassificationIconProps> = (
-  props
+  props,
 ) => {
   const { width, height, position, style, color } = props;
   return (

--- a/packages/design-system/src/ui/Icons/InstanceSegmentationIcon/InstanceSegmentationIcon.tsx
+++ b/packages/design-system/src/ui/Icons/InstanceSegmentationIcon/InstanceSegmentationIcon.tsx
@@ -7,7 +7,7 @@ export type InstanceSegmentationIconProps = Omit<
 >;
 
 const InstanceSegmentationIcon: React.FC<InstanceSegmentationIconProps> = (
-  props
+  props,
 ) => {
   const { width, height, position, style, color } = props;
   return (

--- a/packages/design-system/src/ui/Icons/KeypointDetectionIcon/KeypointDetectionIcon.stories.tsx
+++ b/packages/design-system/src/ui/Icons/KeypointDetectionIcon/KeypointDetectionIcon.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof KeypointDetectionIcon> = (args) => (
 );
 
 export const Playground: StoryFn<typeof KeypointDetectionIcon> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Icons/ObjectDetectionIcon/ObjectDetectionIcon.stories.tsx
+++ b/packages/design-system/src/ui/Icons/ObjectDetectionIcon/ObjectDetectionIcon.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof ObjectDetectionIcon> = (args) => (
 );
 
 export const Playground: StoryFn<typeof ObjectDetectionIcon> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Icons/SemanticSegmentationIcon/SemanticSegmentationIcon.tsx
+++ b/packages/design-system/src/ui/Icons/SemanticSegmentationIcon/SemanticSegmentationIcon.tsx
@@ -7,7 +7,7 @@ export type SemanticSegmentationIconProps = Omit<
 >;
 
 const SemanticSegmentationIcon: React.FC<SemanticSegmentationIconProps> = (
-  props
+  props,
 ) => {
   const { width, height, position, style, color } = props;
   return (

--- a/packages/design-system/src/ui/Icons/VisualDataOperatorIcon/VisualDataOperatorIcon.stories.tsx
+++ b/packages/design-system/src/ui/Icons/VisualDataOperatorIcon/VisualDataOperatorIcon.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof VisualDataOperatorIcon> = (args) => (
 );
 
 export const Playground: StoryFn<typeof VisualDataOperatorIcon> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Icons/VisualDataOperatorIcon/VisualDataOperatorIcon.tsx
+++ b/packages/design-system/src/ui/Icons/VisualDataOperatorIcon/VisualDataOperatorIcon.tsx
@@ -7,7 +7,7 @@ export type VisualDataOperatorIconProps = Omit<
 >;
 
 const VisualDataOperatorIcon: React.FC<VisualDataOperatorIconProps> = (
-  props
+  props,
 ) => {
   const { width, height, position, style, color } = props;
   return (

--- a/packages/design-system/src/ui/InputDescriptions/BasicInputDescription/BasicInputDescription.stories.tsx
+++ b/packages/design-system/src/ui/InputDescriptions/BasicInputDescription/BasicInputDescription.stories.tsx
@@ -13,5 +13,5 @@ const Template: StoryFn<typeof BasicInputDescription> = () => (
 );
 
 export const Playground: StoryFn<typeof BasicInputDescription> = Template.bind(
-  {}
+  {},
 );

--- a/packages/design-system/src/ui/InputDescriptions/InputDescriptionBase/InputDescriptionBase.stories.tsx
+++ b/packages/design-system/src/ui/InputDescriptions/InputDescriptionBase/InputDescriptionBase.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof InputDescriptionBase> = (args) => (
 );
 
 export const Playground: StoryFn<typeof InputDescriptionBase> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/InputDescriptions/InputDescriptionBase/InputDescriptionBase.tsx
+++ b/packages/design-system/src/ui/InputDescriptions/InputDescriptionBase/InputDescriptionBase.tsx
@@ -71,7 +71,7 @@ export const InputDescriptionBase = (props: InputDescriptionBaseProps) => {
         descriptionLineHeight,
         descriptionTextColor,
         descriptionLinkTextColor,
-        descriptionLinkTextDecoration
+        descriptionLinkTextDecoration,
       )}
     >
       {description}

--- a/packages/design-system/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
+++ b/packages/design-system/src/ui/InputLabels/InputLabelBase/InputLabelBase.tsx
@@ -150,15 +150,15 @@ const InputLabelBase = React.forwardRef<InputLabelBaseRef, InputLabelBaseProps>(
                     errorLabelFontSize,
                     errorLabelFontWeight,
                     errorLabelLineHeight,
-                    errorLabelTextColor
+                    errorLabelTextColor,
                   )
                 : cn(
                     labelFontSize,
                     labelFontWeight,
                     labelTextColor,
                     labelFontFamily,
-                    labelLineHeight
-                  )
+                    labelLineHeight,
+                  ),
             )}
           >{`${label} ${required ? "*" : ""}`}</p>
         ) : null}
@@ -169,7 +169,7 @@ const InputLabelBase = React.forwardRef<InputLabelBaseRef, InputLabelBaseProps>(
             messageLineHeight,
             messageFontSize,
             messageFontWeight,
-            error ? errorLabelTextColor : messageTextColor
+            error ? errorLabelTextColor : messageTextColor,
           )}
           data-testid={
             error ? `${htmlFor}-label-error` : `${htmlFor}-label-message`
@@ -179,7 +179,7 @@ const InputLabelBase = React.forwardRef<InputLabelBaseRef, InputLabelBaseProps>(
         </p>
       </label>
     ) : null;
-  }
+  },
 );
 
 export default React.memo(InputLabelBase);

--- a/packages/design-system/src/ui/Logo/Logo.test.tsx
+++ b/packages/design-system/src/ui/Logo/Logo.test.tsx
@@ -12,7 +12,7 @@ describe("Logo", () => {
     expect(colourLogomark).toHaveStyle("width: 60px");
 
     const colourLogomarkBlackType = screen.getByTestId(
-      "colour-logomark-black-type"
+      "colour-logomark-black-type",
     );
 
     expect(colourLogomarkBlackType).toHaveClass("hidden md:block");
@@ -23,7 +23,7 @@ describe("Logo", () => {
     render(<Logo variant="ColourLogomarkBlackType" width={300} />);
 
     const colourLogomarkBlackType = screen.getByTestId(
-      "colour-logomark-black-type"
+      "colour-logomark-black-type",
     );
     expect(colourLogomarkBlackType).not.toHaveClass();
     expect(colourLogomarkBlackType).toHaveStyle("width: 300px");
@@ -38,7 +38,7 @@ describe("Logo", () => {
     expect(colourLogomark).toHaveStyle("width: 60px");
 
     const colourLogomarkWhiteType = screen.getByTestId(
-      "colour-logomark-white-type"
+      "colour-logomark-white-type",
     );
 
     expect(colourLogomarkWhiteType).toHaveClass("hidden md:block");
@@ -49,7 +49,7 @@ describe("Logo", () => {
     render(<Logo variant="ColourLogomarkWhiteType" width={300} />);
 
     const colourLogomarkWhiteType = screen.getByTestId(
-      "colour-logomark-white-type"
+      "colour-logomark-white-type",
     );
     expect(colourLogomarkWhiteType).not.toHaveClass();
     expect(colourLogomarkWhiteType).toHaveStyle("width: 300px");
@@ -64,7 +64,7 @@ describe("Logo", () => {
     expect(whiteLogomark).toHaveStyle("width: 60px");
 
     const whiteLogomarkWhiteType = screen.getByTestId(
-      "white-logomark-white-type"
+      "white-logomark-white-type",
     );
 
     expect(whiteLogomarkWhiteType).toHaveClass("hidden md:block");
@@ -75,7 +75,7 @@ describe("Logo", () => {
     render(<Logo variant="whiteLogomarkWhiteType" width={300} />);
 
     const whiteLogomarkWhiteType = screen.getByTestId(
-      "white-logomark-white-type"
+      "white-logomark-white-type",
     );
     expect(whiteLogomarkWhiteType).not.toHaveClass();
     expect(whiteLogomarkWhiteType).toHaveStyle("width: 300px");
@@ -90,7 +90,7 @@ describe("Logo", () => {
     expect(blackLogomark).toHaveStyle("width: 60px");
 
     const blackLogomarkWhiteType = screen.getByTestId(
-      "black-logomark-black-type"
+      "black-logomark-black-type",
     );
 
     expect(blackLogomarkWhiteType).toHaveClass("hidden md:block");
@@ -101,7 +101,7 @@ describe("Logo", () => {
     render(<Logo variant="blackLogomarkBlackType" width={300} />);
 
     const blackLogomarkWhiteType = screen.getByTestId(
-      "black-logomark-black-type"
+      "black-logomark-black-type",
     );
     expect(blackLogomarkWhiteType).not.toHaveClass();
     expect(blackLogomarkWhiteType).toHaveStyle("width: 300px");

--- a/packages/design-system/src/ui/Logo/Logo.tsx
+++ b/packages/design-system/src/ui/Logo/Logo.tsx
@@ -28,7 +28,7 @@ export const Logo = (props: LogoProps) => {
 
   const getWhiteLogomarkWhiteType = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -101,7 +101,7 @@ export const Logo = (props: LogoProps) => {
 
   const getBlackLogomarkBlackType = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -186,7 +186,7 @@ export const Logo = (props: LogoProps) => {
 
   const getWhiteLogomark = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -207,7 +207,7 @@ export const Logo = (props: LogoProps) => {
 
   const getBlackLogomark = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -230,7 +230,7 @@ export const Logo = (props: LogoProps) => {
 
   const getBlueLogomark = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -326,7 +326,7 @@ export const Logo = (props: LogoProps) => {
 
   const getColourLogomark = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -422,7 +422,7 @@ export const Logo = (props: LogoProps) => {
 
   const getColourLogomarkBlackType = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg
@@ -567,7 +567,7 @@ export const Logo = (props: LogoProps) => {
 
   const getColourLogomarkWhiteType = (
     width: number,
-    className?: string
+    className?: string,
   ): React.ReactElement => {
     return (
       <svg

--- a/packages/design-system/src/ui/ModalRoot.tsx
+++ b/packages/design-system/src/ui/ModalRoot.tsx
@@ -53,7 +53,7 @@ export const ModalRoot = ({
                   className={cn(
                     "relative transform overflow-hidden text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg",
                     modalBgColor,
-                    modalPadding
+                    modalPadding,
                   )}
                   data-testid={dataTestId}
                 >
@@ -62,7 +62,7 @@ export const ModalRoot = ({
               </div>
             </div>
           </React.Fragment>,
-          el.current
+          el.current,
         )
       : null
     : null;

--- a/packages/design-system/src/ui/Progress/DarkBgSquareProgress/DarkBgSquareProgress.stories.tsx
+++ b/packages/design-system/src/ui/Progress/DarkBgSquareProgress/DarkBgSquareProgress.stories.tsx
@@ -12,7 +12,7 @@ const Template: StoryFn<typeof DarkBgSquareProgress> = (args) => (
   <DarkBgSquareProgress {...args} blockSize={48} />
 );
 export const Playground: StoryFn<typeof DarkBgSquareProgress> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/Progress/WhiteBgSquareProgress/WhiteBgSquareProgress.stories.tsx
+++ b/packages/design-system/src/ui/Progress/WhiteBgSquareProgress/WhiteBgSquareProgress.stories.tsx
@@ -12,7 +12,7 @@ const Template: StoryFn<typeof WhiteBgSquareProgress> = (args) => (
   <WhiteBgSquareProgress {...args} blockSize={48} />
 );
 export const Playground: StoryFn<typeof WhiteBgSquareProgress> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.stories.tsx
@@ -44,7 +44,7 @@ const Template: StoryFn<typeof ProgressMessageBoxBase> = (args) => {
   );
 };
 export const Playground: StoryFn<typeof ProgressMessageBoxBase> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/ProgressMessageBoxBase/ProgressMessageBoxBase.tsx
@@ -203,7 +203,7 @@ const ProgressMessageBoxBase = (props: ProgressMessageBoxBaseProps) => {
       className={cn(
         "flex min-h-[85px] flex-row instill-progress-message-box-shadow",
         width,
-        boxBorderRadius
+        boxBorderRadius,
       )}
     >
       <div
@@ -216,7 +216,7 @@ const ProgressMessageBoxBase = (props: ProgressMessageBoxBaseProps) => {
             ? errorindicatorColumnBgColor
             : state.status === "success"
               ? successIndicatorColumnBgColor
-              : processingIndicatorColumnBgColor
+              : processingIndicatorColumnBgColor,
         )}
       >
         {statusIcon}
@@ -226,7 +226,7 @@ const ProgressMessageBoxBase = (props: ProgressMessageBoxBaseProps) => {
           "flex flex-1 flex-row py-2.5 pl-[15px] pr-2.5",
           messageColumnBgColor,
           messageColumnBottomRightBorderRadius,
-          messageColumnTopRightBorderRadius
+          messageColumnTopRightBorderRadius,
         )}
       >
         <div className="flex flex-1 flex-col gap-y-[5px]">

--- a/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SelectItem.tsx
+++ b/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SelectItem.tsx
@@ -37,7 +37,7 @@ export const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
         </div>
       </Select.Item>
     );
-  }
+  },
 );
 
 SelectItem.displayName = "SelectItem";

--- a/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
+++ b/packages/design-system/src/ui/SingleSelects/SingleSelectBase/SingleSelectBase.tsx
@@ -215,7 +215,7 @@ const SingleSelectBase = (props: SingleSelectBaseProps) => {
                 inputBgColor,
                 {
                   "cursor-not-allowed bg-instillGrey90 bg-opacity-5": disabled,
-                }
+                },
               )}
               aria-label="Food"
               ref={(node) => {
@@ -258,7 +258,7 @@ const SingleSelectBase = (props: SingleSelectBaseProps) => {
                   selectPopoverBorderStyle,
                   selectPopoverBorderWidth,
                   selectPopoverPadding,
-                  "max-h-[320px] overflow-hidden"
+                  "max-h-[320px] overflow-hidden",
                 )}
                 position="popper"
                 sideOffset={8}

--- a/packages/design-system/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
+++ b/packages/design-system/src/ui/TextAreas/TextAreaBase/TextAreaBase.tsx
@@ -171,7 +171,7 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
         errorInputBorderStyle,
         errorInputBorderWidth,
         errorInputTextColor,
-        "instill-input-no-highlight"
+        "instill-input-no-highlight",
       )
     : disabled
       ? cn(
@@ -181,7 +181,7 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
           disabledInputBorderStyle,
           disabledInputBorderWidth,
           disabledInputTextColor,
-          "instill-input-no-highlight"
+          "instill-input-no-highlight",
         )
       : readOnly
         ? cn(
@@ -191,26 +191,26 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
             readOnlyInputBorderStyle,
             readOnlyInputBorderWidth,
             readOnlyInputTextColor,
-            "instill-input-no-highlight"
+            "instill-input-no-highlight",
           )
         : focusHighlight
           ? focus
             ? cn(
                 inputBorderWidth,
                 inputBorderStyle,
-                "outline-none ring-0 ring-white border-instillBlue50 instill-input-focus-shadow cursor-text"
+                "outline-none ring-0 ring-white border-instillBlue50 instill-input-focus-shadow cursor-text",
               )
             : cn(
                 inputBorderColor,
                 inputBorderStyle,
                 inputBorderWidth,
-                "cursor-text"
+                "cursor-text",
               )
           : cn(
               inputBorderColor,
               inputBorderStyle,
               inputBorderWidth,
-              "cursor-text"
+              "cursor-text",
             );
 
   return (
@@ -221,7 +221,7 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
           inputWidth,
           inputBorderRadius,
           bgColor,
-          { "mb-2.5": description }
+          { "mb-2.5": description },
         )}
       >
         <div className={label ? "mb-2.5" : ""}>
@@ -271,15 +271,15 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
               disabled
                 ? cn(
                     disabledCursor,
-                    "text-semantic-node-disconnected-default-stroke"
+                    "text-semantic-node-disconnected-default-stroke",
                   )
                 : readOnly
                   ? cn(
                       readOnlyCursor,
-                      "text-semantic-node-disconnected-default-stroke"
+                      "text-semantic-node-disconnected-default-stroke",
                     )
                   : inputTextColor,
-              cn(getInputStyle, "pt-5")
+              cn(getInputStyle, "pt-5"),
             )}
             disabled={disabled}
             required={required}
@@ -306,7 +306,7 @@ const TextAreaBase = (props: TextAreaBaseProps) => {
                 counterFontFamily,
                 counterLineHeight,
                 counterTextColor,
-                "absolute bottom-2 right-4"
+                "absolute bottom-2 right-4",
               )}
             >{`${value ? value.length : 0}/${counterWordLimit}`}</div>
           ) : null}

--- a/packages/design-system/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
+++ b/packages/design-system/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
@@ -146,7 +146,7 @@ export type ProtectedBasicTextFieldProps =
   ProtectedBasicTextFieldRequiredProps & ProtectedBasicTextFieldOptionalProps;
 
 export const ProtectedBasicTextField = (
-  props: ProtectedBasicTextFieldProps
+  props: ProtectedBasicTextFieldProps,
 ) => {
   const {
     id,

--- a/packages/design-system/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
+++ b/packages/design-system/src/ui/TextFields/TextFieldBase/TextFieldBase.tsx
@@ -112,7 +112,7 @@ const TextFieldBase = (props: TextFieldBaseProps) => {
         errorInputBorderStyle,
         errorInputBorderWidth,
         errorInputTextColor,
-        "instill-input-no-highlight"
+        "instill-input-no-highlight",
       )
     : disabled
       ? cn(
@@ -122,7 +122,7 @@ const TextFieldBase = (props: TextFieldBaseProps) => {
           disabledInputBorderStyle,
           disabledInputBorderWidth,
           disabledInputTextColor,
-          "instill-input-no-highlight"
+          "instill-input-no-highlight",
         )
       : readOnly
         ? cn(
@@ -132,26 +132,26 @@ const TextFieldBase = (props: TextFieldBaseProps) => {
             readOnlyInputBorderStyle,
             readOnlyInputBorderWidth,
             readOnlyInputTextColor,
-            "instill-input-no-highlight"
+            "instill-input-no-highlight",
           )
         : focusHighlight
           ? focus
             ? cn(
                 inputBorderWidth,
                 inputBorderStyle,
-                "outline-none ring-0 ring-white border-instillBlue50 instill-input-focus-shadow cursor-text"
+                "outline-none ring-0 ring-white border-instillBlue50 instill-input-focus-shadow cursor-text",
               )
             : cn(
                 inputBorderColor,
                 inputBorderStyle,
                 inputBorderWidth,
-                "cursor-text"
+                "cursor-text",
               )
           : cn(
               inputBorderColor,
               inputBorderStyle,
               inputBorderWidth,
-              "cursor-text"
+              "cursor-text",
             );
 
   return (
@@ -210,14 +210,14 @@ const TextFieldBase = (props: TextFieldBaseProps) => {
               disabled
                 ? cn(
                     disabledCursor,
-                    "text-semantic-node-disconnected-default-stroke"
+                    "text-semantic-node-disconnected-default-stroke",
                   )
                 : readOnly
                   ? cn(
                       readOnlyCursor,
-                      "text-semantic-node-disconnected-default-stroke"
+                      "text-semantic-node-disconnected-default-stroke",
                     )
-                  : inputTextColor
+                  : inputTextColor,
             )}
             id={id}
             type={showSecret ? "text" : type}

--- a/packages/design-system/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
+++ b/packages/design-system/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.stories.tsx
@@ -50,7 +50,7 @@ const Template: StoryFn<typeof StatefulToggleField> = (args) => {
 };
 
 export const Playground: StoryFn<typeof StatefulToggleField> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
+++ b/packages/design-system/src/ui/ToggleFields/ToggleFieldBase/ToggleFieldBase.tsx
@@ -226,7 +226,7 @@ const ToggleFieldBase = (props: ToggleFieldBaseProps) => {
                     disabledInputBorderWidth,
                     value
                       ? disabledCheckedInputBorderColor
-                      : disabledInputBorderColor
+                      : disabledInputBorderColor,
                   )
                 : readOnly
                   ? cn(
@@ -236,7 +236,7 @@ const ToggleFieldBase = (props: ToggleFieldBaseProps) => {
                       readOnlyInputBorderWidth,
                       value
                         ? readOnlyCheckedInputBorderColor
-                        : readOnlyInputBorderColor
+                        : readOnlyInputBorderColor,
                     )
                   : focusHighlight
                     ? focus
@@ -244,14 +244,14 @@ const ToggleFieldBase = (props: ToggleFieldBaseProps) => {
                           inputBorderWidth,
                           inputBorderStyle,
                           inputFocusBorderColor,
-                          inputFocusShadow
+                          inputFocusShadow,
                         )
                       : cn(
                           inputBorderStyle,
                           value ? checkedInputBorderColor : inputBorderColor,
-                          inputBorderWidth
+                          inputBorderWidth,
                         )
-                    : cn(inputBorderColor, inputBorderStyle, inputBorderWidth)
+                    : cn(inputBorderColor, inputBorderStyle, inputBorderWidth),
             )}
             checked={value}
             type="checkbox"
@@ -285,16 +285,16 @@ const ToggleFieldBase = (props: ToggleFieldBaseProps) => {
               disabled
                 ? cn(
                     value ? disabledCheckedDotColor : disabledDotColor,
-                    "cursor-not-allowed"
+                    "cursor-not-allowed",
                   )
                 : readOnly
                   ? cn(
                       value ? readOnlyCheckedDotColor : readOnlyDotColor,
-                      "cursor-auto"
+                      "cursor-auto",
                     )
                   : cn(checkedDotColor, "cursor-pointer"),
               value ? checkedDotColor : dotColor,
-              inputBorderRadius
+              inputBorderRadius,
             )}
           />
         </label>

--- a/packages/design-system/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.stories.tsx
+++ b/packages/design-system/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn<typeof BasicUploadFileField> = (args) => (
   <BasicUploadFileField {...args} />
 );
 export const Playground: StoryFn<typeof BasicUploadFileField> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.stories.tsx
+++ b/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.stories.tsx
@@ -14,7 +14,7 @@ const Template: StoryFn<typeof UploadFileFieldBase> = (args) => (
 );
 
 export const Playground: StoryFn<typeof UploadFileFieldBase> = Template.bind(
-  {}
+  {},
 );
 
 Playground.args = {

--- a/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
+++ b/packages/design-system/src/ui/UploadFileFields/UploadFileFieldBase/UploadFileFieldBase.tsx
@@ -237,7 +237,7 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                   errorInputBorderColor,
                   errorInputBorderStyle,
                   errorInputBorderWidth,
-                  errorInputBgColor
+                  errorInputBgColor,
                 )
               : disabled
                 ? cn(
@@ -245,7 +245,7 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                     disabledInputBorderColor,
                     disabledInputBorderStyle,
                     disabledInputBorderWidth,
-                    disabledInputBgColor
+                    disabledInputBgColor,
                   )
                 : readOnly
                   ? cn(
@@ -253,7 +253,7 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                       readOnlyInputBorderColor,
                       readOnlyInputBorderStyle,
                       readOnlyInputBorderWidth,
-                      readOnlyInputBgColor
+                      readOnlyInputBgColor,
                     )
                   : focusHighlight
                     ? cn(
@@ -261,15 +261,15 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                         inputBorderColor,
                         inputBorderStyle,
                         inputBgColor,
-                        "instill-input-highlight"
+                        "instill-input-highlight",
                       )
                     : cn(
                         inputBorderColor,
                         inputBorderStyle,
                         inputBorderWidth,
                         inputBgColor,
-                        "instill-input-no-highlight"
-                      )
+                        "instill-input-no-highlight",
+                      ),
           )}
         >
           <div className={"my-auto mr-auto flex pl-5"}>
@@ -302,7 +302,7 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                         : readOnly
                           ? readOnlyInputTextColor
                           : inputTextColor,
-                    "flex"
+                    "flex",
                   )}
                 >
                   {file.split("\\").slice(-1)[0]}
@@ -322,7 +322,7 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
               placeholderFontSize,
               placeholderFontWeight,
               placeholderLineHeight,
-              placeholderTextColor
+              placeholderTextColor,
             )}
             aria-label={`${id}-label`}
             id={id}
@@ -364,8 +364,8 @@ const UploadFileFieldBase = (props: UploadFileFieldBaseProps) => {
                       uploadButtonBgColor,
                       uploadButtonTextColor,
                       uploadButtonHoverBgColor,
-                      uploadButtonHoverTextColor
-                    )
+                      uploadButtonHoverTextColor,
+                    ),
             )}
             onClick={(event) => handleButtonOnClick(event)}
           >

--- a/packages/design-system/src/utils/index.ts
+++ b/packages/design-system/src/utils/index.ts
@@ -6,7 +6,7 @@ export type ElementPosition = {
 };
 
 export const getElementPosition = (
-  element: HTMLElement | Element
+  element: HTMLElement | Element,
 ): ElementPosition => {
   const box = element.getBoundingClientRect();
 
@@ -33,7 +33,7 @@ export const getElementPosition = (
 export const getTailwindClassNumber = (className: string): number => {
   if (!hasNumber(className)) {
     throw new Error(
-      "Tailwind css classNames don't have number, please try to use abitrary classname like w-[10px]"
+      "Tailwind css classNames don't have number, please try to use abitrary classname like w-[10px]",
     );
   }
 
@@ -59,13 +59,13 @@ export const getTailwindClassNumber = (className: string): number => {
     }
 
     throw new Error(
-      `getTailwindClassNumber now only support px and rem, input - ${className}`
+      `getTailwindClassNumber now only support px and rem, input - ${className}`,
     );
   }
 
   if (className.includes("[") || className.includes("]")) {
     throw new Error(
-      `Tailwind css classname is not complete, input - ${className}`
+      `Tailwind css classname is not complete, input - ${className}`,
     );
   }
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -51,5 +51,10 @@
   },
   "peerDependencies": {
     "tailwindcss": "^3.3.0"
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ]
   }
 }

--- a/packages/design-tokens/src/buildCSSVariables.ts
+++ b/packages/design-tokens/src/buildCSSVariables.ts
@@ -62,7 +62,7 @@ function main() {
       }
 
       const mapped = Object.entries(fontWeightMap).filter(
-        ([key]) => key === value.toString().toLocaleLowerCase()
+        ([key]) => key === value.toString().toLocaleLowerCase(),
       );
 
       if (mapped[0]) {
@@ -119,19 +119,19 @@ function generateTheme(themes: { themeName: string; themePath: string }[]) {
       format: {
         cssVariables: ({ dictionary }) => {
           const colours = dictionary.allTokens.filter(
-            (e) => e.type === "color"
+            (e) => e.type === "color",
           );
           const colourCSS = colours
             .map((e) => `--${e.name}: ${e.value};`)
             .join("\n");
 
           const boxShadows = dictionary.allTokens.filter(
-            (e) => e.type === "boxShadow"
+            (e) => e.type === "boxShadow",
           );
           const boxShadowCSS = boxShadows
             .map(
               (e) =>
-                `--${e.name}: ${e.value.x}px ${e.value.y}px ${e.value.blur}px ${e.value.spread}px ${e.value.color};`
+                `--${e.name}: ${e.value.x}px ${e.value.y}px ${e.value.blur}px ${e.value.spread}px ${e.value.color};`,
             )
             .join("\n");
 
@@ -187,13 +187,13 @@ function generateRootTheme() {
           .join("\n");
 
         const boxShadows = dictionary.allTokens.filter(
-          (e) => e.type === "boxShadow"
+          (e) => e.type === "boxShadow",
         );
 
         const boxShadowCSS = boxShadows
           .map(
             (e) =>
-              `--${e.name}: ${e.value.x}px ${e.value.y}px ${e.value.blur}px ${e.value.spread}px ${e.value.color};`
+              `--${e.name}: ${e.value.x}px ${e.value.y}px ${e.value.blur}px ${e.value.spread}px ${e.value.color};`,
           )
           .join("\n");
 

--- a/packages/design-tokens/src/buildSDTokens.ts
+++ b/packages/design-tokens/src/buildSDTokens.ts
@@ -62,7 +62,7 @@ function main() {
       }
 
       const mapped = Object.entries(fontWeightMap).filter(
-        ([key]) => key === value.toString().toLocaleLowerCase()
+        ([key]) => key === value.toString().toLocaleLowerCase(),
       );
 
       if (mapped[0]) {

--- a/packages/design-tokens/src/buildTailwindPreset.ts
+++ b/packages/design-tokens/src/buildTailwindPreset.ts
@@ -5,10 +5,10 @@ import { TypographyValue } from "./type";
 
 async function main() {
   const semanticColours = tokens.filter(
-    (e) => e.type === "color" && e.filePath === "tokens/semantic/colour.json"
+    (e) => e.type === "color" && e.filePath === "tokens/semantic/colour.json",
   );
   const semanticBoxShadow = tokens.filter(
-    (e) => e.type === "boxShadow" && e.filePath === "tokens/semantic/comp.json"
+    (e) => e.type === "boxShadow" && e.filePath === "tokens/semantic/comp.json",
   );
 
   const borderWidth = tokens.filter((e) => e.type === "borderWidth");
@@ -42,7 +42,7 @@ async function main() {
           e.value as string
         )
           .replaceAll(" ", "-")
-          .toLowerCase()})"`
+          .toLowerCase()})"`,
     )
     .join(",\n");
 

--- a/packages/prettier-config-cortex/index.js
+++ b/packages/prettier-config-cortex/index.js
@@ -3,7 +3,7 @@ module.exports = {
   printWidth: 80,
   singleQuote: false,
   tabWidth: 2,
-  trailingComma: "es5",
+  trailingComma: "all",
   useTabs: false,
   overrides: [
     {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -157,5 +157,10 @@
     "budgetPercentIncreaseRed": 20,
     "minimumChangeThreshold": 0,
     "showDetails": true
+  },
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix"
+    ]
   }
 }

--- a/packages/toolkit/src/components/AutoresizeInput.tsx
+++ b/packages/toolkit/src/components/AutoresizeInput.tsx
@@ -45,7 +45,7 @@ export const AutoresizeInputWrapper = ({
         <div
           className={cn(
             "invisible !m-0 box-border h-full border-none",
-            placeholderClassname
+            placeholderClassname,
           )}
           contentEditable={true}
           suppressContentEditableWarning={true}

--- a/packages/toolkit/src/components/ClonePipelineDialog.tsx
+++ b/packages/toolkit/src/components/ClonePipelineDialog.tsx
@@ -159,7 +159,7 @@ export const ClonePipelineDialog = ({
     };
 
     const namespace = namespaces.find(
-      (account) => account.id === data.namespaceId
+      (account) => account.id === data.namespaceId,
     );
 
     if (namespace) {
@@ -302,9 +302,9 @@ export const ClonePipelineDialog = ({
                       <span className="ml-2 break-all product-body-text-3-semibold">
                         {form.watch("id") !== "" && form.watch("id")
                           ? `${env(
-                              "NEXT_PUBLIC_CONSOLE_BASE_URL"
+                              "NEXT_PUBLIC_CONSOLE_BASE_URL",
                             )}/${form.getValues(
-                              "namespaceId"
+                              "namespaceId",
                             )}/pipelines/${form.getValues("id")}`
                           : null}
                       </span>

--- a/packages/toolkit/src/components/CodeBlock.tsx
+++ b/packages/toolkit/src/components/CodeBlock.tsx
@@ -17,7 +17,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
     <div
       className={cn(
         "relative flex h-full w-full flex-1 rounded-sm border bg-semantic-bg-primary",
-        className
+        className,
       )}
     >
       <div className="absolute right-3 top-3">

--- a/packages/toolkit/src/components/CopyToClipboardButton.tsx
+++ b/packages/toolkit/src/components/CopyToClipboardButton.tsx
@@ -19,7 +19,7 @@ export const CopyToClipboardButton = ({
     <Button
       className={cn(
         "flex items-center justify-center gap-x-1 !border !px-2 font-semibold",
-        className
+        className,
       )}
       variant="secondaryGrey"
       size="md"

--- a/packages/toolkit/src/components/DeleteResourceModal.tsx
+++ b/packages/toolkit/src/components/DeleteResourceModal.tsx
@@ -58,7 +58,7 @@ export const DeleteResourceModal = ({
       description =
         "Something went wrong when try to activate the flow of deleting resource, please contact our support.";
       console.error(
-        "You have passed resource not included in Pipeline, Model, Connector, Application and AI"
+        "You have passed resource not included in Pipeline, Model, Connector, Application and AI",
       );
     }
 
@@ -85,7 +85,7 @@ export const DeleteResourceModal = ({
     (event: React.ChangeEvent<HTMLInputElement>) => {
       setConfirmationCode(event.target.value);
     },
-    []
+    [],
   );
 
   const canDeleteResource = React.useMemo(() => {

--- a/packages/toolkit/src/components/IconWithBackground.tsx
+++ b/packages/toolkit/src/components/IconWithBackground.tsx
@@ -16,7 +16,7 @@ function IconWithBackground({
     <div
       className={cn(
         "flex h-8 w-8 items-center justify-center rounded-lg p-2",
-        className
+        className,
       )}
     >
       {iconElement}

--- a/packages/toolkit/src/components/NamespaceAvatarWithFallback.tsx
+++ b/packages/toolkit/src/components/NamespaceAvatarWithFallback.tsx
@@ -48,13 +48,13 @@ export const NamespaceAvatarWithFallbackFallback = ({
     <div
       className={cn(
         "flex shrink-0 grow-0 items-center justify-center rounded-full bg-semantic-bg-line",
-        className
+        className,
       )}
     >
       <p
         className={cn(
           "font-sans text-[11px] font-semibold text-semantic-fg-secondary",
-          textClassName
+          textClassName,
         )}
       >
         {displayName && displayName !== "" && displayName !== " "

--- a/packages/toolkit/src/components/PageBase.tsx
+++ b/packages/toolkit/src/components/PageBase.tsx
@@ -23,7 +23,7 @@ const Content = ({
       <div
         className={cn(
           "h-[calc(100vh-var(--topbar-controller-height)-var(--topbar-nav-height))] w-full min-w-[927px] overflow-y-scroll",
-          contentPadding ? contentPadding : "p-20"
+          contentPadding ? contentPadding : "p-20",
         )}
       >
         {children}

--- a/packages/toolkit/src/components/RealTimeTextEditor.tsx
+++ b/packages/toolkit/src/components/RealTimeTextEditor.tsx
@@ -60,7 +60,7 @@ export const RealTimeTextEditor = ({
         }
       }, 1000);
     },
-    [isReady, toast, onSave]
+    [isReady, toast, onSave],
   );
 
   const editor = useEditor({
@@ -99,7 +99,7 @@ export const RealTimeTextEditor = ({
       <EditorContent
         className={cn(
           "mb-2 w-full rounded-sm border",
-          hasUnsavedChanges ? "rounded-sm border-semantic-bg-line" : ""
+          hasUnsavedChanges ? "rounded-sm border-semantic-bg-line" : "",
         )}
         editor={editor}
       />

--- a/packages/toolkit/src/components/ReferenceHintDataTypeTag.tsx
+++ b/packages/toolkit/src/components/ReferenceHintDataTypeTag.tsx
@@ -15,7 +15,7 @@ export const ReferenceHintDataTypeTag = ({
     <div
       className={cn(
         "flex flex-row gap-x-[3px] rounded bg-[#D1FAED] px-[6px] py-[1.5px]",
-        className
+        className,
       )}
     >
       <p className="my-auto align-middle font-sans text-[9px] font-medium text-semantic-success-default	">
@@ -31,7 +31,7 @@ export const ReferenceHintDataTypeTag = ({
     <div
       className={cn(
         "flex h-5 flex-row items-center rounded bg-semantic-success-bg px-2 py-1",
-        className
+        className,
       )}
     >
       <p className="font-sans text-[11px] font-medium text-semantic-success-default">

--- a/packages/toolkit/src/components/ReferenceHintTag.tsx
+++ b/packages/toolkit/src/components/ReferenceHintTag.tsx
@@ -29,7 +29,7 @@ export const ReferenceHintInstillFormat = ({
         <div
           className={cn(
             "flex flex-row items-center gap-x-[3.62px] rounded-t bg-semantic-bg-secondary px-[7.25px] py-px",
-            className
+            className,
           )}
         >
           <p className="text-semantic-fg-secondary product-label-label-2">
@@ -43,7 +43,7 @@ export const ReferenceHintInstillFormat = ({
         <div
           className={cn(
             "rounded-t border border-semantic-bg-line bg-semantic-bg-base-bg px-[7.25px] py-px font-sans text-[9px] font-medium uppercase leading-[9px] text-semantic-fg-primary",
-            className
+            className,
           )}
         >
           {instillFormat}
@@ -109,7 +109,7 @@ export const ReferenceHintPath = ({
                 "max-w-[240px] truncate px-[7.25px] py-px",
                 "flex flex-row items-center gap-x-1 bg-semantic-accent-bg",
                 "rounded-r rounded-bl",
-                className
+                className,
               )}
             >
               {icon}
@@ -186,7 +186,7 @@ export const ReferenceHintTagIcon = ({
     <Icons.ReferenceIconCheck
       className={cn(
         "h-[9px] w-[18px] stroke-semantic-accent-default",
-        className
+        className,
       )}
     />
   );

--- a/packages/toolkit/src/components/StateLabel.tsx
+++ b/packages/toolkit/src/components/StateLabel.tsx
@@ -72,7 +72,7 @@ export const StateLabel = ({ state, className }: StateLabelProps) => {
       className={cn(
         "flex h-6 flex-row items-center gap-x-2 rounded-full px-2.5 py-1",
         bgColor,
-        className
+        className,
       )}
       data-testid="state-label"
     >

--- a/packages/toolkit/src/components/TableError.tsx
+++ b/packages/toolkit/src/components/TableError.tsx
@@ -12,7 +12,7 @@ export const TableError = (props: TableErrorProps) => {
     <div
       className={cn(
         "border-instillGrey20 flex min-h-[300px] w-full border bg-white",
-        marginBottom
+        marginBottom,
       )}
     >
       <div className="m-auto flex flex-col gap-y-2.5">

--- a/packages/toolkit/src/components/TableLoadingProgress.tsx
+++ b/packages/toolkit/src/components/TableLoadingProgress.tsx
@@ -16,7 +16,7 @@ export const TableLoadingProgress = ({
     <div
       className={cn(
         "border-instillGrey20 flex min-h-[300px] w-full border bg-white",
-        marginBottom
+        marginBottom,
       )}
     >
       <div className="m-auto flex flex-col gap-y-2.5">

--- a/packages/toolkit/src/components/TablePlaceholderBase.tsx
+++ b/packages/toolkit/src/components/TablePlaceholderBase.tsx
@@ -40,7 +40,7 @@ export const TablePlaceholderBase = ({
     <div
       className={cn(
         "border-instillGrey15 flex min-h-[300px] w-full flex-row border bg-white px-[9px] py-[18px]",
-        marginBottom
+        marginBottom,
       )}
     >
       {svgElement ? (

--- a/packages/toolkit/src/components/UploadImageFieldWithCrop.tsx
+++ b/packages/toolkit/src/components/UploadImageFieldWithCrop.tsx
@@ -79,7 +79,7 @@ export const UploadImageFieldWithCrop = ({
                       alt={title}
                       className={cn(
                         "h-[150px] object-contain",
-                        rounded ? "rounded-full" : null
+                        rounded ? "rounded-full" : null,
                       )}
                       width={150}
                       height={150}

--- a/packages/toolkit/src/components/UserProfileCard.tsx
+++ b/packages/toolkit/src/components/UserProfileCard.tsx
@@ -101,7 +101,7 @@ export const UserProfileCard = ({
                     onClick={() => {
                       router.push(`/${membership.organization.id}`);
                       updateNavigationNamespaceAnchor(
-                        () => membership.organization.id
+                        () => membership.organization.id,
                       );
                     }}
                     className="flex !normal-case text-semantic-accent-default product-button-button-2 hover:!underline"

--- a/packages/toolkit/src/components/card-pipeline/Body.tsx
+++ b/packages/toolkit/src/components/card-pipeline/Body.tsx
@@ -26,7 +26,7 @@ export const Body = ({ pipeline }: { pipeline: Pipeline }) => {
           className="my-auto !normal-case text-semantic-accent-default product-button-button-2 hover:!underline"
           onClick={() => {
             router.push(
-              `/${pipeline.ownerName.split("/")[1]}/pipelines/${pipeline.id}`
+              `/${pipeline.ownerName.split("/")[1]}/pipelines/${pipeline.id}`,
             );
           }}
         >

--- a/packages/toolkit/src/components/card-pipeline/Footer.tsx
+++ b/packages/toolkit/src/components/card-pipeline/Footer.tsx
@@ -85,7 +85,7 @@ export const Footer = ({
               router.push(
                 `/${pipeline.ownerName.split("/")[1]}/pipelines/${
                   pipeline.id
-                }/editor`
+                }/editor`,
               );
             }}
           >

--- a/packages/toolkit/src/components/top-bar/AppTopbar.tsx
+++ b/packages/toolkit/src/components/top-bar/AppTopbar.tsx
@@ -50,7 +50,7 @@ export const AppTopbar = ({
       <div
         className={cn(
           "box-content flex h-[var(--topbar-controller-height)] flex-row justify-between bg-semantic-bg-primary px-8 py-px",
-          className
+          className,
         )}
       >
         <div className="flex flex-row">

--- a/packages/toolkit/src/components/top-bar/NamespaceSwitch.tsx
+++ b/packages/toolkit/src/components/top-bar/NamespaceSwitch.tsx
@@ -77,7 +77,7 @@ export const NamespaceSwitch = () => {
           ...namespace,
           remainingCredit:
             namespacesRemainingCredit.data.find(
-              (e) => e.namespaceName === namespace.name
+              (e) => e.namespaceName === namespace.name,
             )?.remainingCredit.total ?? 0,
         };
       });
@@ -98,7 +98,7 @@ export const NamespaceSwitch = () => {
     return namespacesWithRemainingCredit.length === 0
       ? namespaces.find((e) => e.id === navigationNamespaceAnchor) ?? null
       : namespacesWithRemainingCredit.find(
-          (e) => e.id === navigationNamespaceAnchor
+          (e) => e.id === navigationNamespaceAnchor,
         ) ?? null;
   }, [namespacesWithRemainingCredit, namespaces, navigationNamespaceAnchor]);
 
@@ -289,7 +289,9 @@ export const NamespaceSwitch = () => {
         icon={<React.Fragment />}
         className={cn(
           "!w-[136px] !border-none !p-1 hover:!bg-semantic-bg-secondary",
-          switchIsOpen ? "!bg-semantic-bg-secondary" : "!bg-semantic-bg-primary"
+          switchIsOpen
+            ? "!bg-semantic-bg-secondary"
+            : "!bg-semantic-bg-primary",
         )}
       >
         {selectedNamespace ? (

--- a/packages/toolkit/src/components/top-bar/NavLinks.tsx
+++ b/packages/toolkit/src/components/top-bar/NavLinks.tsx
@@ -50,7 +50,7 @@ export const NavLink = ({ title, Icon, pathname }: NavLinkProps) => {
   const router = useRouter();
   const currentPathname = usePathname();
   const { navigationNamespaceAnchor } = useInstillStore(
-    useShallow(navLinkSelector)
+    useShallow(navLinkSelector),
   );
 
   const isOnIt = React.useMemo(() => {
@@ -69,7 +69,7 @@ export const NavLink = ({ title, Icon, pathname }: NavLinkProps) => {
   const namespaceAnchor = React.useMemo(() => {
     if (!navigationNamespaceAnchor) {
       const userNamespace = namespaces.find(
-        (namespace) => namespace.type === "user"
+        (namespace) => namespace.type === "user",
       );
 
       if (userNamespace) {
@@ -98,7 +98,7 @@ export const NavLink = ({ title, Icon, pathname }: NavLinkProps) => {
         "group flex h-10 flex-row gap-x-2 border-b-2 border-[#316FED] py-3 product-button-button-1 hover:text-semantic-accent-default",
         isOnIt
           ? "border-opacity-100 text-semantic-fg-primary"
-          : "border-opacity-0 text-semantic-fg-disabled"
+          : "border-opacity-0 text-semantic-fg-disabled",
       )}
     >
       <Icon className="h-5 w-5 stroke-semantic-fg-disabled group-hover:stroke-semantic-accent-default" />
@@ -114,7 +114,7 @@ const navLinksSelector = (store: InstillStore) => ({
 
 export const NavLinks = () => {
   const { accessToken, enabledQuery } = useInstillStore(
-    useShallow(navLinksSelector)
+    useShallow(navLinksSelector),
   );
   const me = useAuthenticatedUser({
     enabled: enabledQuery,

--- a/packages/toolkit/src/components/top-bar/TopbarLinks.tsx
+++ b/packages/toolkit/src/components/top-bar/TopbarLinks.tsx
@@ -75,7 +75,7 @@ export const TopbarLink = (props: {
         {
           "border-opacity-100 bg-semantic-accent-bg": hightlighted,
         },
-        className
+        className,
       )}
     >
       <div className="flex flex-row items-center space-x-3">

--- a/packages/toolkit/src/components/top-bar/TopbarMiscLinks.tsx
+++ b/packages/toolkit/src/components/top-bar/TopbarMiscLinks.tsx
@@ -14,7 +14,7 @@ export const TopbarMiscLinks = () => {
         href="https://github.com/instill-ai/instill-core"
         className={cn(
           "flex h-8 flex-row gap-x-2",
-          buttonVariants({ variant: "secondaryGrey", size: "md" })
+          buttonVariants({ variant: "secondaryGrey", size: "md" }),
         )}
       >
         <ComplicateIcons.GitHub
@@ -27,7 +27,7 @@ export const TopbarMiscLinks = () => {
         href="https://www.instill.tech/docs"
         className={cn(
           "flex h-8 flex-row gap-x-2",
-          buttonVariants({ variant: "tertiaryGrey", size: "md" })
+          buttonVariants({ variant: "tertiaryGrey", size: "md" }),
         )}
       >
         <Icons.File06 className="h-[14px] w-[14px] stroke-semantic-fg-primary" />
@@ -37,7 +37,7 @@ export const TopbarMiscLinks = () => {
         href="https://discord.com/invite/sevxWsqpGh"
         className={cn(
           "flex h-8 flex-row gap-x-2",
-          buttonVariants({ variant: "tertiaryGrey", size: "md" })
+          buttonVariants({ variant: "tertiaryGrey", size: "md" }),
         )}
       >
         <Icons.MessageSmileSquare className="h-[14px] w-[14px] stroke-semantic-fg-primary" />

--- a/packages/toolkit/src/lib/airbytes/helpers/getConditionFormPath/getConditionFormPath.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/getConditionFormPath/getConditionFormPath.ts
@@ -2,7 +2,7 @@ import { Nullable } from "../../../type";
 import { AirbyteFormConditionItem, AirbyteFormItem } from "../../types";
 
 export const getConditionFormPath = (
-  item: AirbyteFormConditionItem
+  item: AirbyteFormConditionItem,
 ): Nullable<string> => {
   // Try to find a workaround of Typescript limitation
   // https://github.com/microsoft/TypeScript/issues/9998

--- a/packages/toolkit/src/lib/airbytes/helpers/getFieldsPaths/getFieldPaths.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/getFieldsPaths/getFieldPaths.ts
@@ -2,7 +2,7 @@ import { AirbyteFormTree } from "../../types";
 
 export const getFieldPaths = (
   formTree: AirbyteFormTree | AirbyteFormTree[],
-  forceUnique: boolean
+  forceUnique: boolean,
 ): string[] => {
   const fieldPaths = [];
 
@@ -25,7 +25,7 @@ export const getFieldPaths = (
 
 const pickPath = (
   formTree: AirbyteFormTree,
-  paths: string[] = []
+  paths: string[] = [],
 ): string[] => {
   if (formTree._type === "formGroup") {
     const newPaths: string[] = [];

--- a/packages/toolkit/src/lib/airbytes/helpers/pickSelectedConditionMap/pickSelectedConditionMap.test.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/pickSelectedConditionMap/pickSelectedConditionMap.test.ts
@@ -1258,7 +1258,7 @@ test("should find one selected condition map", () => {
 
   const selectedConditionMap = pickSelectedConditionMap(
     formTree,
-    initialValues
+    initialValues,
   );
 
   expect(selectedConditionMap).toStrictEqual({
@@ -2528,7 +2528,7 @@ test("should find multiple selected condition map", () => {
 
   const selectedConditionMap = pickSelectedConditionMap(
     formTree,
-    initialValues
+    initialValues,
   );
 
   expect(selectedConditionMap).toStrictEqual({

--- a/packages/toolkit/src/lib/airbytes/helpers/pickSelectedConditionMap/pickSelectedConditionMap.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/pickSelectedConditionMap/pickSelectedConditionMap.ts
@@ -9,7 +9,7 @@ import {
 export const pickSelectedConditionMap = (
   formTree: AirbyteFormTree,
   initialValue: AirbyteFieldValues,
-  parentMap: SelectedItemMap = {}
+  parentMap: SelectedItemMap = {},
 ): SelectedItemMap => {
   if (formTree._type === "formGroup") {
     let map = {} as SelectedItemMap;
@@ -66,7 +66,7 @@ export const pickSelectedConditionMap = (
     const childMap = pickSelectedConditionMap(
       formTree.properties,
       initialValue,
-      parentMap
+      parentMap,
     );
 
     map = {

--- a/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToAirbyteFormTree/transformAirbyteSchemaToAirbyteFormTree.test.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToAirbyteFormTree/transformAirbyteSchemaToAirbyteFormTree.test.ts
@@ -138,7 +138,7 @@ test("should reformat jsonSchema to formTree representation with parent schema",
     undefined,
     {
       required: ["key"],
-    }
+    },
   );
 
   const expected = {
@@ -230,7 +230,7 @@ test("should reformat jsonSchema to formTree representation when has oneOf", () 
     undefined,
     {
       required: ["key"],
-    }
+    },
   );
 
   const expected = {

--- a/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToAirbyteFormTree/transformAirbyteSchemaToAirbyteFormTree.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToAirbyteFormTree/transformAirbyteSchemaToAirbyteFormTree.ts
@@ -13,7 +13,7 @@ export const transformAirbyteSchemaToAirbyteFormTree = (
   jsonSchema: AirbyteJsonSchemaDefinition,
   key = "",
   path: string = key,
-  parent?: AirbyteJsonSchema
+  parent?: AirbyteJsonSchema,
 ): AirbyteFormTree => {
   const isRequired = isKeyRequired(key, parent);
 
@@ -39,10 +39,10 @@ export const transformAirbyteSchemaToAirbyteFormTree = (
           transformAirbyteSchemaToAirbyteFormTree(
             { ...condition, type: jsonSchema.type },
             key,
-            path
+            path,
           ),
         ];
-      })
+      }),
     );
 
     return {
@@ -69,7 +69,7 @@ export const transformAirbyteSchemaToAirbyteFormTree = (
       properties: transformAirbyteSchemaToAirbyteFormTree(
         jsonSchema.items,
         key,
-        path
+        path,
       ),
       isRequired,
     };
@@ -85,8 +85,8 @@ export const transformAirbyteSchemaToAirbyteFormTree = (
           schema,
           k,
           path ? `${path}.${k}` : k,
-          jsonSchema
-        )
+          jsonSchema,
+        ),
       )
       .sort((a, b) => {
         if (typeof a.order === "undefined") {
@@ -127,7 +127,7 @@ export const transformAirbyteSchemaToAirbyteFormTree = (
 
 const isKeyRequired = (
   key: string,
-  parentSchema?: AirbyteJsonSchemaDefinition
+  parentSchema?: AirbyteJsonSchemaDefinition,
 ): boolean => {
   const isRequired =
     (typeof parentSchema !== "boolean" &&
@@ -152,13 +152,13 @@ const defaultFields: Array<keyof AirbyteJsonSchema> = [
 ];
 
 const pickDefaultFields = (
-  schema: AirbyteJsonSchema
+  schema: AirbyteJsonSchema,
 ): Partial<AirbyteJsonSchema> => {
   const partialSchema: Partial<AirbyteJsonSchema> = {
     ...Object.fromEntries(
       Object.entries(schema).filter(([k]) =>
-        defaultFields.includes(k as keyof AirbyteJsonSchema)
-      )
+        defaultFields.includes(k as keyof AirbyteJsonSchema),
+      ),
     ),
   };
 
@@ -180,7 +180,7 @@ const pickDefaultFields = (
 };
 
 function isDefined<T>(
-  a: T | null | undefined
+  a: T | null | undefined,
 ): a is Exclude<T, null | undefined> {
   return a !== undefined && a !== null;
 }

--- a/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToYup.ts
+++ b/packages/toolkit/src/lib/airbytes/helpers/transformAirbyteSchemaToYup.ts
@@ -8,7 +8,7 @@ export const transformAirbyteSchemaToYup = (
   selectedItemMap: Nullable<SelectedItemMap>,
   parentSchema?: AirbyteJsonSchema,
   propertyKey?: string,
-  propertyPath: string | undefined = propertyKey
+  propertyPath: string | undefined = propertyKey,
 ): yup.AnySchema => {
   let schema:
     | yup.NumberSchema
@@ -39,7 +39,7 @@ export const transformAirbyteSchemaToYup = (
         ? jsonSchema.oneOf.find(
             (condition) =>
               typeof condition !== "boolean" &&
-              condition.title === selectedItemMap[""]?.selectedItem
+              condition.title === selectedItemMap[""]?.selectedItem,
           )
         : jsonSchema.oneOf[0];
     } else {
@@ -48,7 +48,7 @@ export const transformAirbyteSchemaToYup = (
           ? jsonSchema.oneOf.find(
               (condition) =>
                 typeof condition !== "boolean" &&
-                condition.title === selectedItemMap[propertyPath]?.selectedItem
+                condition.title === selectedItemMap[propertyPath]?.selectedItem,
             )
           : jsonSchema.oneOf[0];
     }
@@ -59,7 +59,7 @@ export const transformAirbyteSchemaToYup = (
         selectedItemMap,
         jsonSchema,
         propertyKey,
-        propertyPath
+        propertyPath,
       );
     }
   }
@@ -78,8 +78,8 @@ export const transformAirbyteSchemaToYup = (
               selectedItemMap,
               jsonSchema,
               propertyKey,
-              propertyPath
-            )
+              propertyPath,
+            ),
           );
       }
       break;
@@ -96,10 +96,10 @@ export const transformAirbyteSchemaToYup = (
                 selectedItemMap,
                 jsonSchema,
                 propertyKey,
-                propertyPath ? `${propertyPath}.${propertyKey}` : propertyKey
+                propertyPath ? `${propertyPath}.${propertyKey}` : propertyKey,
               )
             : yup.mixed(),
-        ]
+        ],
       );
 
       if (keyEntries.length) {
@@ -117,7 +117,7 @@ export const transformAirbyteSchemaToYup = (
       if (jsonSchema?.pattern !== undefined) {
         schema = schema.matches(
           new RegExp(jsonSchema.pattern),
-          "form.pattern.error"
+          "form.pattern.error",
         );
       }
       break;

--- a/packages/toolkit/src/lib/airbytes/hooks/useAirbyteFieldValues.ts
+++ b/packages/toolkit/src/lib/airbytes/hooks/useAirbyteFieldValues.ts
@@ -5,7 +5,7 @@ import { AirbyteFieldValues, AirbyteFormTree } from "../types";
 
 export const useAirbyteFieldValues = (
   formTree: Nullable<AirbyteFormTree>,
-  initialValue: Nullable<AirbyteFieldValues>
+  initialValue: Nullable<AirbyteFieldValues>,
 ) => {
   const [fieldValues, setFieldValues] =
     React.useState<Nullable<AirbyteFieldValues>>(initialValue);
@@ -42,11 +42,11 @@ export const pickInitialValues = (
   fieldValues: Nullable<AirbyteFieldValues>,
   setFieldValues: React.Dispatch<
     React.SetStateAction<Nullable<AirbyteFieldValues>>
-  >
+  >,
 ) => {
   if (formTree._type === "formGroup") {
     formTree.properties.map((e) =>
-      pickInitialValues(e, fieldValues, setFieldValues)
+      pickInitialValues(e, fieldValues, setFieldValues),
     );
     return;
   }

--- a/packages/toolkit/src/lib/airbytes/hooks/useAirbyteFormTree.ts
+++ b/packages/toolkit/src/lib/airbytes/hooks/useAirbyteFormTree.ts
@@ -4,7 +4,7 @@ import * as React from "react";
 import { transformAirbyteSchemaToAirbyteFormTree } from "../helpers/transformAirbyteSchemaToAirbyteFormTree";
 
 export const useAirbyteFormTree = (
-  definition: Nullable<ConnectorDefinition>
+  definition: Nullable<ConnectorDefinition>,
 ) => {
   const formTree = React.useMemo(() => {
     if (!definition) {
@@ -12,7 +12,7 @@ export const useAirbyteFormTree = (
     }
 
     const formTree = transformAirbyteSchemaToAirbyteFormTree(
-      definition.spec.resourceSpecification
+      definition.spec.resourceSpecification,
     );
 
     return formTree;

--- a/packages/toolkit/src/lib/airbytes/hooks/useAirbyteSelectedConditionMap.ts
+++ b/packages/toolkit/src/lib/airbytes/hooks/useAirbyteSelectedConditionMap.ts
@@ -9,7 +9,7 @@ export type UseAirbyteSelectedConditionMapResult = UseCustomHookResult<
 
 export const useAirbyteSelectedConditionMap = (
   formTree: Nullable<AirbyteFormTree>,
-  initialValue: Nullable<AirbyteFieldValues>
+  initialValue: Nullable<AirbyteFieldValues>,
 ): UseAirbyteSelectedConditionMapResult => {
   let initialConditionMap: Nullable<SelectedItemMap> = {};
 

--- a/packages/toolkit/src/lib/airbytes/hooks/useBuildAirbyteYup.ts
+++ b/packages/toolkit/src/lib/airbytes/hooks/useBuildAirbyteYup.ts
@@ -7,13 +7,13 @@ import { AirbyteJsonSchema, SelectedItemMap } from "../types";
 export const useBuildAirbyteYup = (
   jsonSchema: Nullable<AirbyteJsonSchema>,
   selectedItemMap: Nullable<SelectedItemMap>,
-  additionalSchema: Nullable<AnySchema>
+  additionalSchema: Nullable<AnySchema>,
 ): Nullable<AnySchema> => {
   const yup = React.useMemo(() => {
     if (!jsonSchema) return null;
     const airbyteSchema = transformAirbyteSchemaToYup(
       jsonSchema,
-      selectedItemMap
+      selectedItemMap,
     );
     return additionalSchema
       ? airbyteSchema.concat(additionalSchema)

--- a/packages/toolkit/src/lib/amplitude/helper.ts
+++ b/packages/toolkit/src/lib/amplitude/helper.ts
@@ -6,7 +6,7 @@ import { AmplitudeEvent, AmplitudeEventProperties } from "./type";
 export const initAmplitude = (
   userId: Nullable<string>,
   enabledPageViewsTracking = true,
-  enabledSessionTracking = true
+  enabledSessionTracking = true,
 ) => {
   if (!env("NEXT_PUBLIC_AMPLITUDE_KEY")) {
     console.error("Amplitude key is not set");
@@ -27,7 +27,7 @@ export const setAmplitudeUserId = (userId: string) => {
 
 export const sendAmplitudeData = (
   eventType: AmplitudeEvent,
-  eventProperties?: AmplitudeEventProperties
+  eventProperties?: AmplitudeEventProperties,
 ) => {
   track(eventType, {
     ...eventProperties,

--- a/packages/toolkit/src/lib/amplitude/useSendAmplitudeData.ts
+++ b/packages/toolkit/src/lib/amplitude/useSendAmplitudeData.ts
@@ -6,7 +6,7 @@ import { AmplitudeEvent, AmplitudeEventProperties } from "./type";
 export const useSendAmplitudeData = (
   event: AmplitudeEvent,
   properties: AmplitudeEventProperties,
-  routerIsReady: boolean
+  routerIsReady: boolean,
 ) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
   React.useEffect(() => {

--- a/packages/toolkit/src/lib/convertSentenceToCamelCase.ts
+++ b/packages/toolkit/src/lib/convertSentenceToCamelCase.ts
@@ -3,6 +3,8 @@ export const convertSentenceToCamelCase = (str: string) =>
   str
     .split(" ")
     .map((e, i) =>
-      i ? e.charAt(0).toUpperCase() + e.slice(1).toLowerCase() : e.toLowerCase()
+      i
+        ? e.charAt(0).toUpperCase() + e.slice(1).toLowerCase()
+        : e.toLowerCase(),
     )
     .join("");

--- a/packages/toolkit/src/lib/dashboard/calculatePercentageDelta.ts
+++ b/packages/toolkit/src/lib/dashboard/calculatePercentageDelta.ts
@@ -1,6 +1,6 @@
 export function calculatePercentageDelta(
   previousCount: number,
-  currentCount: number
+  currentCount: number,
 ): number {
   if (previousCount === 0 && currentCount === 0) {
     return 0; // Both counts are zero, return 0 as percentage change

--- a/packages/toolkit/src/lib/dashboard/formatDateTime.ts
+++ b/packages/toolkit/src/lib/dashboard/formatDateTime.ts
@@ -13,7 +13,7 @@ export function formatDateTime(timeStr: string, format: string): string {
 
     return `${month} ${day}, ${formattedHours}:${String(minutes).padStart(
       2,
-      "0"
+      "0",
     )} ${period}`;
   }
   return `${month} ${day}`;

--- a/packages/toolkit/src/lib/dashboard/generateChartData.ts
+++ b/packages/toolkit/src/lib/dashboard/generateChartData.ts
@@ -5,7 +5,7 @@ import { sortByDate } from "./sortByDate";
 
 export function generateChartData(
   apiResponse: PipelinesChart[],
-  range: string
+  range: string,
 ): { xAxis: string[]; yAxis: number[][] } {
   const pipelineData = apiResponse;
 

--- a/packages/toolkit/src/lib/dashboard/getDateRange.ts
+++ b/packages/toolkit/src/lib/dashboard/getDateRange.ts
@@ -9,7 +9,7 @@ export function getDateRange(range: string): string[] {
       today.getDate() - 1,
       0,
       0,
-      0
+      0,
     );
     const endDate = new Date(
       today.getFullYear(),
@@ -17,7 +17,7 @@ export function getDateRange(range: string): string[] {
       today.getDate(),
       0,
       0,
-      0
+      0,
     );
 
     for (
@@ -31,7 +31,7 @@ export function getDateRange(range: string): string[] {
           day: "numeric",
           hour: "numeric",
           minute: "numeric",
-        })
+        }),
       );
     }
     // push end date
@@ -41,7 +41,7 @@ export function getDateRange(range: string): string[] {
         day: "numeric",
         hour: "numeric",
         minute: "numeric",
-      })
+      }),
     );
   } else if (range === "24h") {
     const startDate = new Date(
@@ -50,7 +50,7 @@ export function getDateRange(range: string): string[] {
       today.getDate(),
       0,
       0,
-      0
+      0,
     );
 
     for (
@@ -64,7 +64,7 @@ export function getDateRange(range: string): string[] {
           day: "numeric",
           hour: "numeric",
           minute: "numeric",
-        })
+        }),
       );
     }
     // push end date
@@ -74,7 +74,7 @@ export function getDateRange(range: string): string[] {
         day: "numeric",
         hour: "numeric",
         minute: "numeric",
-      })
+      }),
     );
   } else if (range.endsWith("d")) {
     const days = parseInt(range.slice(0, -1));
@@ -86,12 +86,12 @@ export function getDateRange(range: string): string[] {
       date.setDate(date.getDate() + 1)
     ) {
       dates.push(
-        date.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+        date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
       );
     }
   } else {
     throw new Error(
-      "Invalid range format. Please use the format <number>d, 24h, or 1d."
+      "Invalid range format. Please use the format <number>d, 24h, or 1d.",
     );
   }
 

--- a/packages/toolkit/src/lib/dashboard/getPipelineTriggersSummary.ts
+++ b/packages/toolkit/src/lib/dashboard/getPipelineTriggersSummary.ts
@@ -3,7 +3,7 @@ import { calculatePercentageDelta } from "./calculatePercentageDelta";
 
 export function getPipelineTriggersSummary(
   pipelines: TriggeredPipeline[],
-  pipelinesPrevious: TriggeredPipeline[]
+  pipelinesPrevious: TriggeredPipeline[],
 ): PipelineTriggersStatusSummary {
   let pipelineCompleteAmount = 0;
   let pipelineCompleteAmountPrevious = 0;
@@ -24,7 +24,7 @@ export function getPipelineTriggersSummary(
     pipelineCompleteAmount,
     pipelineCompleteAmountPrevious,
     pipelineErroredAmount,
-    pipelineErroredAmountPrevious
+    pipelineErroredAmountPrevious,
   );
 }
 
@@ -32,7 +32,7 @@ export function getPipelineTriggersStatusSummary(
   pipelineCompleteAmount: number,
   pipelineCompleteAmountPrevious: number,
   pipelineErroredAmount: number,
-  pipelineErroredAmountPrevious: number
+  pipelineErroredAmountPrevious: number,
 ): PipelineTriggersStatusSummary {
   return {
     completed: {
@@ -41,7 +41,7 @@ export function getPipelineTriggersStatusSummary(
       type: "pipeline",
       delta: calculatePercentageDelta(
         pipelineCompleteAmountPrevious,
-        pipelineCompleteAmount
+        pipelineCompleteAmount,
       ),
     },
     errored: {
@@ -50,7 +50,7 @@ export function getPipelineTriggersStatusSummary(
       type: "pipeline",
       delta: calculatePercentageDelta(
         pipelineErroredAmountPrevious,
-        pipelineErroredAmount
+        pipelineErroredAmount,
       ),
     },
   };

--- a/packages/toolkit/src/lib/dashboard/getPreviousTimeframe.ts
+++ b/packages/toolkit/src/lib/dashboard/getPreviousTimeframe.ts
@@ -11,7 +11,7 @@ export type DashboardAvailableTimeframe =
   | "30d";
 
 export function getPreviousTimeframe(
-  timeframe: DashboardAvailableTimeframe
+  timeframe: DashboardAvailableTimeframe,
 ): string {
   if (timeframe === "24h" || timeframe === "1d") {
     return "2d";

--- a/packages/toolkit/src/lib/dashboard/getTimeInRFC3339Format.ts
+++ b/packages/toolkit/src/lib/dashboard/getTimeInRFC3339Format.ts
@@ -19,7 +19,7 @@ export function getTimeInRFC3339Format(interval: string): string {
 
   if (!match) {
     throw new Error(
-      "Invalid time interval format. Supported formats are: now, todayStart, 1h, 3h, 6h, 24h, 1d, 7d"
+      "Invalid time interval format. Supported formats are: now, todayStart, 1h, 3h, 6h, 24h, 1d, 7d",
     );
   }
 
@@ -32,7 +32,7 @@ export function getTimeInRFC3339Format(interval: string): string {
 
   if (!Object.prototype.hasOwnProperty.call(timeUnits, unit)) {
     throw new Error(
-      "Invalid time unit. Supported units are: h (hour), d (day)"
+      "Invalid time unit. Supported units are: h (hour), d (day)",
     );
   }
 

--- a/packages/toolkit/src/lib/dashboard/getTriggersSummary.ts
+++ b/packages/toolkit/src/lib/dashboard/getTriggersSummary.ts
@@ -6,7 +6,7 @@ import { getPipelineTriggersStatusSummary } from "./getPipelineTriggersSummary";
 
 export function getTriggersSummary(
   triggers: PipelineTriggerRecord[],
-  triggersPrevious: PipelineTriggerRecord[]
+  triggersPrevious: PipelineTriggerRecord[],
 ): PipelineTriggersStatusSummary {
   let pipelineCompleteAmount = 0;
   let pipelineCompleteAmountPrevious = 0;
@@ -29,6 +29,6 @@ export function getTriggersSummary(
     pipelineCompleteAmount,
     pipelineCompleteAmountPrevious,
     pipelineErroredAmount,
-    pipelineErroredAmountPrevious
+    pipelineErroredAmountPrevious,
   );
 }

--- a/packages/toolkit/src/lib/dashboard/orderCountsByTriggerTime.ts
+++ b/packages/toolkit/src/lib/dashboard/orderCountsByTriggerTime.ts
@@ -8,7 +8,7 @@ export function orderCountsByTriggerTime(counts: Count[]): Count[] {
 
   const sortedCounts = formattedCounts.sort(
     (a, b) =>
-      new Date(a.triggerTime).getTime() - new Date(b.triggerTime).getTime()
+      new Date(a.triggerTime).getTime() - new Date(b.triggerTime).getTime(),
   );
 
   return sortedCounts;

--- a/packages/toolkit/src/lib/dashboard/parseTriggerStatusLabel.ts
+++ b/packages/toolkit/src/lib/dashboard/parseTriggerStatusLabel.ts
@@ -4,7 +4,7 @@ export function parseTriggerStatusLabel(status: PipelineTriggerStatus): string {
   const convertedStatus = status
     .split("_")
     .map(
-      (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+      (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
     )[1];
 
   return convertedStatus;

--- a/packages/toolkit/src/lib/dashboard/sortByTriggerTime.ts
+++ b/packages/toolkit/src/lib/dashboard/sortByTriggerTime.ts
@@ -1,10 +1,10 @@
 import { PipelineTriggerRecord } from "../vdp-sdk";
 
 export function sortByTriggerTime(
-  data: PipelineTriggerRecord[]
+  data: PipelineTriggerRecord[],
 ): PipelineTriggerRecord[] {
   return data.sort(
     (a, b) =>
-      new Date(b.triggerTime).getTime() - new Date(a.triggerTime).getTime()
+      new Date(b.triggerTime).getTime() - new Date(a.triggerTime).getTime(),
   );
 }

--- a/packages/toolkit/src/lib/dot/index.test.ts
+++ b/packages/toolkit/src/lib/dot/index.test.ts
@@ -80,7 +80,7 @@ describe("setter", () => {
     dot.setter(obj, "twofoldly.foo.bar", undefined);
     expect(obj).toStrictEqual({ x: "y", twofoldly: { foo: {} } });
     expect(
-      Object.prototype.hasOwnProperty.call(obj.twofoldly.foo, "bar")
+      Object.prototype.hasOwnProperty.call(obj.twofoldly.foo, "bar"),
     ).toBeFalsy();
   });
 

--- a/packages/toolkit/src/lib/dot/index.ts
+++ b/packages/toolkit/src/lib/dot/index.ts
@@ -58,7 +58,7 @@ const setter = (obj: any, path: DotPath, value: any) => {
 const toDot = (obj: any, parentKey?: string, result: any = {}) => {
   if (!isObject(obj)) {
     throw new Error(
-      "Target value is not a object, toDot function only process object."
+      "Target value is not a object, toDot function only process object.",
     );
   }
 

--- a/packages/toolkit/src/lib/fillArrayWithZero.ts
+++ b/packages/toolkit/src/lib/fillArrayWithZero.ts
@@ -1,7 +1,7 @@
 export function fillArrayWithZeros<T>(arr: T[], length: number): T[] {
   const resultArray = Array.from(
     { length },
-    (_, index) => arr[index] || (0 as T)
+    (_, index) => arr[index] || (0 as T),
   );
   return resultArray;
 }

--- a/packages/toolkit/src/lib/generateDateInPast.ts
+++ b/packages/toolkit/src/lib/generateDateInPast.ts
@@ -7,7 +7,7 @@ export type GenerateDateInPastOptions = {
 
 export const generateDateInPast = (
   startDate: string | number,
-  { hours, days, months, years }: GenerateDateInPastOptions
+  { hours, days, months, years }: GenerateDateInPastOptions,
 ) => {
   const date = new Date(startDate);
 

--- a/packages/toolkit/src/lib/github/index.ts
+++ b/packages/toolkit/src/lib/github/index.ts
@@ -17,11 +17,11 @@ type listRepoFileContentResponse = {
 export const listRepoFileContent = async (
   owner: string,
   repo: string,
-  path: string
+  path: string,
 ): Promise<listRepoFileContentResponse> => {
   try {
     const response = await axios.get(
-      `https://api.github.com/repos/${owner}/${repo}/contents/${path}`
+      `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
     );
 
     return response.data;

--- a/packages/toolkit/src/lib/hook/useGuardPipelineBuilderUnsavedChangesNavigation.ts
+++ b/packages/toolkit/src/lib/hook/useGuardPipelineBuilderUnsavedChangesNavigation.ts
@@ -41,6 +41,6 @@ export function useGuardPipelineBuilderUnsavedChangesNavigation() {
       updateWarnUnsavdChangesDialogState,
       router,
       pathname,
-    ]
+    ],
   );
 }

--- a/packages/toolkit/src/lib/hook/useNavigateBackAfterLogin.tsx
+++ b/packages/toolkit/src/lib/hook/useNavigateBackAfterLogin.tsx
@@ -17,9 +17,9 @@ export const useNavigateBackAfterLogin = () => {
       router.push(
         path
           ? `/api/auth/login?returnTo=${encodeURIComponent(`${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}/${path}`)}`
-          : `/api/auth/login?returnTo=${encodeURIComponent(`${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}/${pathname}`)}`
+          : `/api/auth/login?returnTo=${encodeURIComponent(`${env("NEXT_PUBLIC_CONSOLE_BASE_URL")}/${pathname}`)}`,
       );
     },
-    [pathname, router]
+    [pathname, router],
   );
 };

--- a/packages/toolkit/src/lib/hook/useOnScreen.ts
+++ b/packages/toolkit/src/lib/hook/useOnScreen.ts
@@ -11,7 +11,7 @@ export const useOnScreen = (ref: React.RefObject<HTMLElement>) => {
 
   React.useEffect(() => {
     observerRef.current = new IntersectionObserver(([entry]) =>
-      setIsOnScreen(entry.isIntersecting)
+      setIsOnScreen(entry.isIntersecting),
     );
   }, []);
 

--- a/packages/toolkit/src/lib/hook/useRefSize.ts
+++ b/packages/toolkit/src/lib/hook/useRefSize.ts
@@ -7,7 +7,7 @@ export type RefSize = {
 };
 
 export function useRefSize(
-  ref: React.RefObject<HTMLElement>
+  ref: React.RefObject<HTMLElement>,
 ): Nullable<RefSize> {
   const [refSize, setRefSize] = React.useState<Nullable<RefSize>>(null);
   const observerRef = React.useRef<ResizeObserver | null>(null);

--- a/packages/toolkit/src/lib/react-query-service/connector/useConnectorDefinition.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/useConnectorDefinition.ts
@@ -24,7 +24,7 @@ export function useConnectorDefinition({
     queryFn: async () => {
       if (!connectorDefinitionName) {
         return Promise.reject(
-          new Error("connectorDefinitionName not provided")
+          new Error("connectorDefinitionName not provided"),
         );
       }
 

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useCreateApiToken.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useCreateApiToken.ts
@@ -29,7 +29,7 @@ export function useCreateApiToken() {
     },
     onSuccess: ({ token }) => {
       queryClient.setQueryData<ApiToken[]>(["api-tokens"], (old) =>
-        old ? [...old, token] : [token]
+        old ? [...old, token] : [token],
       );
       queryClient.setQueryData<ApiToken>(["api-tokens", token.name], token);
     },

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useDeleteApiToken.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useDeleteApiToken.ts
@@ -21,7 +21,7 @@ export function useDeleteApiToken() {
     },
     onSuccess: (tokenName) => {
       queryClient.setQueryData<ApiToken[]>(["api-tokens"], (old) =>
-        old ? old.filter((e) => e.name !== tokenName) : []
+        old ? old.filter((e) => e.name !== tokenName) : [],
       );
       queryClient.removeQueries({
         queryKey: ["api-tokens", tokenName],

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useMgmtDefinition.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useMgmtDefinition.ts
@@ -14,7 +14,7 @@ export function useMgmtDefinition({
       const { content } = await listRepoFileContent(
         "instill-ai",
         "mgmt-backend",
-        "config/models/user.json"
+        "config/models/user.json",
       );
 
       const decode = window.atob(content);

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useUpdateAuthenticatedUser.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useUpdateAuthenticatedUser.ts
@@ -30,7 +30,7 @@ export function useUpdateAuthenticatedUser() {
     onSuccess: (newUser) => {
       queryClient.setQueryData<AuthenticatedUser>(
         ["authenticated-user"],
-        newUser
+        newUser,
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/misc/useBlogPosts.ts
+++ b/packages/toolkit/src/lib/react-query-service/misc/useBlogPosts.ts
@@ -45,15 +45,15 @@ const formatDate = (dateString: string | undefined) => {
 const fetchBlogPosts = async () => {
   // Fetch the latest release tag
   const tagsResponse = await axios.get(
-    "https://api.github.com/repos/instill-ai/instill.tech/tags"
+    "https://api.github.com/repos/instill-ai/instill.tech/tags",
   );
   const latestTag = tagsResponse.data[0]?.name;
 
   const mdxResponse = await axios.get(
-    `https://api.github.com/repos/instill-ai/instill.tech/contents/blog?ref=${latestTag}`
+    `https://api.github.com/repos/instill-ai/instill.tech/contents/blog?ref=${latestTag}`,
   );
   const mdxFiles = mdxResponse.data.filter((file: any) =>
-    file.name.endsWith(".mdx")
+    file.name.endsWith(".mdx"),
   );
 
   const blogPostsData: BlogPostData[] = await Promise.all(
@@ -87,12 +87,12 @@ const fetchBlogPosts = async () => {
         slug: file.path.replace(/^blog\//g, "").replace(/\.mdx$/g, ""),
         draft,
       };
-    })
+    }),
   );
 
   blogPostsData.sort(
     (a, b) =>
-      new Date(b.publishedOn).getTime() - new Date(a.publishedOn).getTime()
+      new Date(b.publishedOn).getTime() - new Date(a.publishedOn).getTime(),
   );
 
   return blogPostsData.filter((post) => !post.draft);

--- a/packages/toolkit/src/lib/react-query-service/misc/useChangelogs.ts
+++ b/packages/toolkit/src/lib/react-query-service/misc/useChangelogs.ts
@@ -12,7 +12,7 @@ interface Changelog {
 
 const fetchChangelogs = async () => {
   const response = await axios.get(
-    "https://productlane.com/api/v1/changelogs/52f06d0d-2381-411e-a8c5-7b375e3a0114"
+    "https://productlane.com/api/v1/changelogs/52f06d0d-2381-411e-a8c5-7b375e3a0114",
   );
   return response.data;
 };
@@ -26,7 +26,7 @@ export const useChangelogs = () => {
         .filter((changelog: Changelog) => changelog.published)
         .sort(
           (a: Changelog, b: Changelog) =>
-            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
         );
       return filteredAndSortedChangelogs.slice(0, 3);
     },

--- a/packages/toolkit/src/lib/react-query-service/model/onSuccessAfterModelMutation.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/onSuccessAfterModelMutation.ts
@@ -39,7 +39,7 @@ export type OnSuccessAfterUndeployModelProps = {
 };
 
 export async function onSuccessAfterModelMutation(
-  props: OnSuccessAfterModelMutationProps
+  props: OnSuccessAfterModelMutationProps,
 ) {
   const { type, queryClient } = props;
 
@@ -51,11 +51,11 @@ export async function onSuccessAfterModelMutation(
 
     queryClient.setQueryData<Model>(["models", model.name], model);
     queryClient.setQueryData<Model[]>(["models"], (old) =>
-      old ? [...old.filter((e) => e.name !== model.name), model] : [model]
+      old ? [...old.filter((e) => e.name !== model.name), model] : [model],
     );
 
     queryClient.setQueryData<Model[]>(["models", userName], (old) =>
-      old ? [...old.filter((e) => e.name !== model.name), model] : [model]
+      old ? [...old.filter((e) => e.name !== model.name), model] : [model],
     );
 
     // Invalidate readme

--- a/packages/toolkit/src/lib/react-query-service/model/useInfiniteModelVersions.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useInfiniteModelVersions.ts
@@ -55,7 +55,7 @@ export function useInfiniteModelVersions({
     getNextPageParam: (lastPage) => {
       const versionsLastPage = Math.max(
         Math.ceil(lastPage.totalSize / lastPage.pageSize) - 1,
-        0
+        0,
       );
 
       if (lastPage.page >= versionsLastPage) {

--- a/packages/toolkit/src/lib/react-query-service/model/useUserModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useUserModels.ts
@@ -7,7 +7,7 @@ export async function fetchUserModels(
   userName: string,
   accessToken: Nullable<string>,
   filter: Nullable<string>,
-  visibility: Nullable<Visibility>
+  visibility: Nullable<Visibility>,
 ) {
   try {
     const models = await listUserModelsQuery({
@@ -58,7 +58,7 @@ export const useUserModels = ({
         userName,
         accessToken,
         filter,
-        visibility
+        visibility,
       );
       return Promise.resolve(models);
     },

--- a/packages/toolkit/src/lib/react-query-service/organization/use-organization-memberships/server.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/use-organization-memberships/server.ts
@@ -26,7 +26,7 @@ export async function fetchOrganizationMemberships({
 }
 
 export function getUseOrganizationMembershipsQueryKey(
-  organizationID: Nullable<string>
+  organizationID: Nullable<string>,
 ) {
   return ["organizations", organizationID, "memberships"];
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useCreateOrganization.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useCreateOrganization.ts
@@ -30,11 +30,11 @@ export function useCreateOrganization() {
     },
     onSuccess: ({ organization }) => {
       queryClient.setQueryData<Organization[]>(["organizations"], (old) =>
-        old ? [...old, organization] : [organization]
+        old ? [...old, organization] : [organization],
       );
       queryClient.setQueryData<Organization>(
         ["organizations", organization],
-        organization
+        organization,
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/organization/useDeleteOrganization.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useDeleteOrganization.ts
@@ -25,7 +25,7 @@ export function useDeleteOrganization() {
     },
     onSuccess: (organizationID) => {
       queryClient.setQueryData<Organization[]>(["organizations"], (old) =>
-        old ? old.filter((e) => e.id !== organizationID) : []
+        old ? old.filter((e) => e.id !== organizationID) : [],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/organization/useUpdateOrganization.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useUpdateOrganization.ts
@@ -29,11 +29,11 @@ export function useUpdateOrganization() {
     },
     onSuccess: ({ organization }) => {
       queryClient.setQueryData<Organization[]>(["organization"], (old) =>
-        old ? [...old, organization] : [organization]
+        old ? [...old, organization] : [organization],
       );
       queryClient.setQueryData<Organization>(
         ["organization", organization],
-        organization
+        organization,
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipeline-releases/server.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-user-pipeline-releases/server.ts
@@ -31,7 +31,7 @@ export async function fetchUserPipelineReleases({
 }
 
 export function getUseUserPipelineReleasesQueryKey(
-  pipelineName: Nullable<string>
+  pipelineName: Nullable<string>,
 ) {
   return ["pipelineReleases", pipelineName];
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useCloneNamespacePipeline.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useCloneNamespacePipeline.ts
@@ -33,7 +33,7 @@ export function useCloneNamespacePipeline() {
 
       queryClient.setQueryData<Pipeline>(
         ["pipelines", pipeline.name],
-        pipeline
+        pipeline,
       );
 
       queryClient.invalidateQueries({ queryKey: ["pipelines", "infinite"] });
@@ -44,13 +44,13 @@ export function useCloneNamespacePipeline() {
       queryClient.setQueryData<Pipeline[]>(["pipelines", namespace], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines"], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserPipeline.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserPipeline.ts
@@ -34,7 +34,7 @@ export function useCreateUserPipeline() {
     onSuccess: async ({ pipeline, entityName }) => {
       queryClient.setQueryData<Pipeline>(
         ["pipelines", pipeline.name],
-        pipeline
+        pipeline,
       );
 
       queryClient.invalidateQueries({ queryKey: ["pipelines", "infinite"] });
@@ -45,13 +45,13 @@ export function useCreateUserPipeline() {
       queryClient.setQueryData<Pipeline[]>(["pipelines", entityName], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines"], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserPipelineRelease.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserPipelineRelease.ts
@@ -39,7 +39,7 @@ export function useCreateUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineRelease>(
         ["pipelineReleases", pipelineRelease.name],
-        pipelineRelease
+        pipelineRelease,
       );
 
       queryClient.setQueryData<PipelineRelease[]>(
@@ -50,7 +50,7 @@ export function useCreateUserPipelineRelease() {
                 ...old.filter((e) => e.name !== pipelineRelease.name),
                 pipelineRelease,
               ]
-            : [pipelineRelease]
+            : [pipelineRelease],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserSecret.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useCreateUserSecret.ts
@@ -45,7 +45,7 @@ export function useCreateUserSecret() {
 
       const useUserSecretsQueryKey = getUseUserSecretsQueryKey(entityName);
       queryClient.setQueryData<Secret[]>(useUserSecretsQueryKey, (old) =>
-        old ? [secret, ...old] : [secret]
+        old ? [secret, ...old] : [secret],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteUserPipeline.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteUserPipeline.ts
@@ -31,11 +31,11 @@ export function useDeleteUserPipeline() {
       });
 
       queryClient.setQueryData<Pipeline[]>(["pipelines"], (old) =>
-        old ? old.filter((e) => e.name !== pipelineName) : []
+        old ? old.filter((e) => e.name !== pipelineName) : [],
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines", userName], (old) =>
-        old ? old.filter((e) => e.name !== pipelineName) : []
+        old ? old.filter((e) => e.name !== pipelineName) : [],
       );
 
       queryClient.removeQueries({

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteUserPipelineRelease.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteUserPipelineRelease.ts
@@ -35,7 +35,7 @@ export function useDeleteUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineRelease[]>(
         ["pipelineReleases", userName],
-        (old) => (old ? old.filter((e) => e.name !== pipelineReleaseName) : [])
+        (old) => (old ? old.filter((e) => e.name !== pipelineReleaseName) : []),
       );
       queryClient.removeQueries({
         queryKey: ["pipelineReleases", pipelineReleaseName],

--- a/packages/toolkit/src/lib/react-query-service/pipeline/usePipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/usePipelines.ts
@@ -6,7 +6,7 @@ import type { Nullable } from "../../type";
 export async function fetchPipelines(
   accessToken: Nullable<string>,
   filter: Nullable<string>,
-  visibility: Nullable<Visibility>
+  visibility: Nullable<Visibility>,
 ) {
   try {
     const pipelines = await listPipelinesQuery({

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useRenameUserPipeline.tsx
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useRenameUserPipeline.tsx
@@ -40,13 +40,13 @@ export function useRenameUserPipeline() {
 
       queryClient.setQueryData<Pipeline>(
         ["pipelines", pipeline.name],
-        pipeline
+        pipeline,
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines", userName], (old) =>
         old
           ? [...old.filter((e) => e.name !== oldPipelineName), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useRestoreUserPipelineRelease.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useRestoreUserPipelineRelease.ts
@@ -39,7 +39,7 @@ export function useRestoreUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineRelease>(
         ["pipelineReleases", pipelineRelease.name],
-        pipelineRelease
+        pipelineRelease,
       );
 
       queryClient.setQueryData<PipelineRelease[]>(
@@ -50,7 +50,7 @@ export function useRestoreUserPipelineRelease() {
                 ...old.filter((e) => e.name !== pipelineRelease.name),
                 pipelineRelease,
               ]
-            : [pipelineRelease]
+            : [pipelineRelease],
       );
 
       // process watch state
@@ -62,7 +62,7 @@ export function useRestoreUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineReleaseWatchState>(
         ["pipelineReleases", pipelineRelease.name, "watch"],
-        watch
+        watch,
       );
 
       queryClient.setQueryData<PipelineReleasesWatchState>(
@@ -73,7 +73,7 @@ export function useRestoreUserPipelineRelease() {
                 ...removeObjKey(old, pipelineRelease.name),
                 [pipelineRelease.name]: watch,
               }
-            : { [pipelineRelease.name]: watch }
+            : { [pipelineRelease.name]: watch },
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useSetDefaultUserPipelineRelease.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useSetDefaultUserPipelineRelease.ts
@@ -39,7 +39,7 @@ export function useSetDefaultUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineRelease>(
         ["pipelineReleases", pipelineRelease.name],
-        pipelineRelease
+        pipelineRelease,
       );
 
       queryClient.setQueryData<PipelineRelease[]>(
@@ -50,7 +50,7 @@ export function useSetDefaultUserPipelineRelease() {
                 ...old.filter((e) => e.name !== pipelineRelease.name),
                 pipelineRelease,
               ]
-            : [pipelineRelease]
+            : [pipelineRelease],
       );
 
       // process watch state
@@ -62,7 +62,7 @@ export function useSetDefaultUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineReleaseWatchState>(
         ["pipelineReleases", pipelineRelease.name, "watch"],
-        watch
+        watch,
       );
 
       queryClient.setQueryData<PipelineReleasesWatchState>(
@@ -73,7 +73,7 @@ export function useSetDefaultUserPipelineRelease() {
                 ...removeObjKey(old, pipelineRelease.name),
                 [pipelineRelease.name]: watch,
               }
-            : { [pipelineRelease.name]: watch }
+            : { [pipelineRelease.name]: watch },
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useUpdateUserPipeline.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useUpdateUserPipeline.ts
@@ -34,19 +34,19 @@ export function useUpdateUserPipeline() {
 
       queryClient.setQueryData<Pipeline>(
         ["pipelines", pipeline.name],
-        pipeline
+        pipeline,
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines"], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
 
       queryClient.setQueryData<Pipeline[]>(["pipelines", userName], (old) =>
         old
           ? [...old.filter((e) => e.name !== pipeline.name), pipeline]
-          : [pipeline]
+          : [pipeline],
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useUpdateUserPipelineRelease.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useUpdateUserPipelineRelease.ts
@@ -43,7 +43,7 @@ export function useUpdateUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineRelease>(
         ["pipelineReleases", pipelineRelease.name],
-        pipelineRelease
+        pipelineRelease,
       );
 
       queryClient.setQueryData<PipelineRelease[]>(
@@ -54,7 +54,7 @@ export function useUpdateUserPipelineRelease() {
                 ...old.filter((e) => e.name !== pipelineRelease.name),
                 pipelineRelease,
               ]
-            : [pipelineRelease]
+            : [pipelineRelease],
       );
 
       // process watch state
@@ -66,7 +66,7 @@ export function useUpdateUserPipelineRelease() {
 
       queryClient.setQueryData<PipelineReleaseWatchState>(
         ["pipelineReleases", pipelineRelease.name, "watch"],
-        watch
+        watch,
       );
 
       queryClient.setQueryData<PipelineReleasesWatchState>(
@@ -77,7 +77,7 @@ export function useUpdateUserPipelineRelease() {
                 ...removeObjKey(old, pipelineRelease.name),
                 [pipelineRelease.name]: watch,
               }
-            : { [pipelineRelease.name]: watch }
+            : { [pipelineRelease.name]: watch },
       );
     },
   });

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useUserPipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useUserPipelines.ts
@@ -9,7 +9,7 @@ export async function fetchUserPipelines(
   userName: string,
   accessToken: Nullable<string>,
   filter: Nullable<string>,
-  visibility: Nullable<Visibility>
+  visibility: Nullable<Visibility>,
 ) {
   try {
     const pipelines = await listUserPipelinesQuery({
@@ -64,7 +64,7 @@ export const useUserPipelines = ({
         userName,
         accessToken,
         filter,
-        visibility
+        visibility,
       );
       return Promise.resolve(pipelines);
     },

--- a/packages/toolkit/src/lib/store/useConfigureModelFormStore.ts
+++ b/packages/toolkit/src/lib/store/useConfigureModelFormStore.ts
@@ -27,11 +27,11 @@ export type ConfigureModelFormAction = {
   init: () => void;
   setFieldError: (
     fieldName: keyof ConfigureModelFormState["errors"],
-    value: Nullable<string>
+    value: Nullable<string>,
   ) => void;
   setFieldValue: <T extends keyof ConfigureModelFormFields>(
     fieldName: T,
-    value: ConfigureModelFormFields[T]
+    value: ConfigureModelFormFields[T],
   ) => void;
   setFieldsValue: (fields: ConfigureModelFormFields) => void;
   setErrorsValue: (errors: ConfigureModelFormState["errors"]) => void;
@@ -58,27 +58,27 @@ export const useConfigureModelFormStore = create<ConfigureModelFormStore>()(
       set(
         produce((draft: ConfigureModelFormStore) => {
           draft.errors[fieldName] = value;
-        })
+        }),
       ),
     setFieldValue: (fieldName, value) =>
       set(
         produce((draft: ConfigureModelFormStore) => {
           draft.formIsDirty = true;
           draft.fields[fieldName] = value;
-        })
+        }),
       ),
     setFieldsValue: (fields) =>
       set(
         produce((draft: ConfigureModelFormStore) => {
           draft.formIsDirty = true;
           draft.fields = fields;
-        })
+        }),
       ),
     setErrorsValue: (errors) =>
       set(
         produce((draft: ConfigureModelFormStore) => {
           draft.errors = errors;
-        })
+        }),
       ),
-  }))
+  })),
 );

--- a/packages/toolkit/src/lib/store/useConfigureSourceFormStore.ts
+++ b/packages/toolkit/src/lib/store/useConfigureSourceFormStore.ts
@@ -27,11 +27,11 @@ export type ConfigureSourceFormAction = {
   init: () => void;
   setFieldError: (
     fieldName: keyof ConfigureSourceFormState["errors"],
-    value: Nullable<string>
+    value: Nullable<string>,
   ) => void;
   setFieldValue: <T extends keyof ConfigureSourceFormFields>(
     fieldName: T,
-    value: ConfigureSourceFormFields[T]
+    value: ConfigureSourceFormFields[T],
   ) => void;
   setFieldsValue: (fields: ConfigureSourceFormFields) => void;
   setErrorsValue: (errors: ConfigureSourceFormState["errors"]) => void;
@@ -62,27 +62,27 @@ export const useConfigureSourceFormStore = create<ConfigureSourceFormStore>()(
       set(
         produce((draft: ConfigureSourceFormStore) => {
           draft.errors[fieldName] = value;
-        })
+        }),
       ),
     setFieldValue: (fieldName, value) =>
       set(
         produce((draft: ConfigureSourceFormStore) => {
           draft.formIsDirty = true;
           draft.fields[fieldName] = value;
-        })
+        }),
       ),
     setFieldsValue: (fields) =>
       set(
         produce((draft: ConfigureSourceFormStore) => {
           draft.formIsDirty = true;
           draft.fields = fields;
-        })
+        }),
       ),
     setErrorsValue: (errors) =>
       set(
         produce((draft: ConfigureSourceFormStore) => {
           draft.errors = errors;
-        })
+        }),
       ),
-  }))
+  })),
 );

--- a/packages/toolkit/src/lib/store/useCreateResourceFormStore.ts
+++ b/packages/toolkit/src/lib/store/useCreateResourceFormStore.ts
@@ -241,39 +241,39 @@ export const useCreateResourceFormStore = create<CreateResourceFormStore>()(
       set(
         produce((draft: CreateResourceFormStore) => {
           dot.setter(draft.errors, errorPath, value);
-        })
+        }),
       ),
     setFieldValue: (fieldPath, value) =>
       set(
         produce((draft: CreateResourceFormStore) => {
           draft.formIsDirty = true;
           dot.setter(draft.fields, fieldPath, value);
-        })
+        }),
       ),
     setFieldsValue: (fields) =>
       set(
         produce((draft: CreateResourceFormStore) => {
           draft.formIsDirty = true;
           draft.fields = fields;
-        })
+        }),
       ),
     setErrorsValue: (errors) =>
       set(
         produce((draft: CreateResourceFormStore) => {
           draft.errors = errors;
-        })
+        }),
       ),
     increasePipelineFormStep: () =>
       set(
         produce((draft: CreateResourceFormStore) => {
           draft.pipelineFormStep = draft.pipelineFormStep + 1;
-        })
+        }),
       ),
     decreasePipelineFormStep: () =>
       set(
         produce((draft: CreateResourceFormStore) => {
           draft.pipelineFormStep = draft.pipelineFormStep - 1;
-        })
+        }),
       ),
-  }))
+  })),
 );

--- a/packages/toolkit/src/lib/store/useMessageBoxStore.tsx
+++ b/packages/toolkit/src/lib/store/useMessageBoxStore.tsx
@@ -34,5 +34,5 @@ export const useMessageBoxStore = create<MessageBoxStore>()(
         ...preState,
         ...newState,
       })),
-  }))
+  })),
 );

--- a/packages/toolkit/src/lib/store/useModalStore.ts
+++ b/packages/toolkit/src/lib/store/useModalStore.ts
@@ -29,5 +29,5 @@ export const useModalStore = create<ModalStore>()(
       set(() => ({
         modalIsOpen: true,
       })),
-  }))
+  })),
 );

--- a/packages/toolkit/src/lib/test/utils.tsx
+++ b/packages/toolkit/src/lib/test/utils.tsx
@@ -22,10 +22,10 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
 
 export const customRender: (
   ui: React.ReactElement,
-  options?: Omit<RenderOptions, "wrapper">
+  options?: Omit<RenderOptions, "wrapper">,
 ) => ReturnType<typeof render> = (
   ui: React.ReactElement,
-  options?: Omit<RenderOptions, "wrapper">
+  options?: Omit<RenderOptions, "wrapper">,
 ) =>
   render(ui, { wrapper: AllTheProviders, ...options }) as ReturnType<
     typeof render
@@ -48,7 +48,7 @@ export { customRender as render };
  * @returns escaped value like ${{user.name}
  */
 export const getEscapedReferenceValueForReactTestingLibrary = (
-  value: string
+  value: string,
 ) => {
   return "${{" + value.replace("${", "").replace("}", "") + "}";
 };

--- a/packages/toolkit/src/lib/tip-tap/markdown.ts
+++ b/packages/toolkit/src/lib/tip-tap/markdown.ts
@@ -41,7 +41,7 @@ export function renderHardBreak(
   state: MarkdownSerializerState,
   node: Node,
   parent: Node,
-  index: number
+  index: number,
 ) {
   const br = isInTable(parent) ? "<br>" : "\\\n";
   for (let i = index + 1; i < parent.childCount; i += 1) {
@@ -68,7 +68,7 @@ export function isPlainURL(
   link: Mark,
   parent: Node,
   index: number,
-  side: number
+  side: number,
 ) {
   if (link.attrs.title || !/^\w+:/.test(link.attrs.href)) return false;
   const content = parent.child(index + (side < 0 ? -1 : 0));
@@ -107,7 +107,7 @@ const serializerMarks = {
       state: MarkdownSerializerState,
       mark: Mark,
       parent: Node,
-      index: number
+      index: number,
     ) {
       const href = mark.attrs.canonicalSrc || mark.attrs.href;
 
@@ -151,7 +151,7 @@ export function serialize(schema: Schema, content: any) {
   const proseMirrorDocument = schema.nodeFromJSON(content);
   const serializer = new ProseMirrorMarkdownSerializer(
     serializerNodes,
-    serializerMarks
+    serializerMarks,
   );
 
   return serializer.serialize(proseMirrorDocument, {

--- a/packages/toolkit/src/lib/use-callback-ref/useCallbackRef.tsx
+++ b/packages/toolkit/src/lib/use-callback-ref/useCallbackRef.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 function useCallbackRef<T extends (...args: any[]) => any>(
-  callback: T | undefined
+  callback: T | undefined,
 ): T {
   const callbackRef = React.useRef(callback);
 
@@ -20,7 +20,7 @@ function useCallbackRef<T extends (...args: any[]) => any>(
   // https://github.com/facebook/react/issues/19240
   return React.useMemo(
     () => ((...args) => callbackRef.current?.(...args)) as T,
-    []
+    [],
   );
 }
 

--- a/packages/toolkit/src/lib/use-controllable-state/useControllableState.tsx
+++ b/packages/toolkit/src/lib/use-controllable-state/useControllableState.tsx
@@ -41,7 +41,7 @@ function useControllableState<T>({
           setUncontrolledProp(nextValue);
         }
       },
-      [isControlled, prop, setUncontrolledProp, handleChange]
+      [isControlled, prop, setUncontrolledProp, handleChange],
     );
 
   return [value, setValue] as const;

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/CopyButton.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/CopyButton.tsx
@@ -15,7 +15,7 @@ export const CopyButton = ({
     <button
       className={cn(
         "flex flex-row items-center gap-x-1 rounded px-1 py-0.5 hover:bg-semantic-bg-base-bg",
-        className
+        className,
       )}
       type="button"
       onClick={async () => {

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/FieldRoot.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/FieldRoot.tsx
@@ -20,7 +20,7 @@ export const FieldRoot = ({
       key={fieldKey}
       className={cn(
         "flex w-full flex-col gap-y-2 rounded-[6px] bg-semantic-bg-primary p-2",
-        className
+        className,
       )}
       data-testid={`output-${fieldKey}`}
     >

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/MDTextViewer.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/MDTextViewer.tsx
@@ -67,7 +67,7 @@ export const MDTextViewer = ({ text }: { text: Nullable<string> }) => {
           <div
             className={cn(
               "markdown-body w-full overflow-x-scroll rounded-b-sm px-1.5 py-1",
-              enableFormattedText ? "" : "hidden"
+              enableFormattedText ? "" : "hidden",
             )}
           >
             <Markdown>{text ?? ""}</Markdown>
@@ -75,7 +75,7 @@ export const MDTextViewer = ({ text }: { text: Nullable<string> }) => {
           <pre
             className={cn(
               "flex w-full flex-1 items-center whitespace-pre-line break-all px-1.5 py-1 text-semantic-fg-primary product-body-text-4-regular",
-              enableFormattedText ? "hidden" : ""
+              enableFormattedText ? "hidden" : "",
             )}
           >
             {text}

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/BooleanField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/BooleanField.tsx
@@ -49,14 +49,14 @@ export const BooleanField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={shortDescription ?? null}
             />
             <Form.Message
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-medium" : ""
+                size === "sm" ? "!product-body-text-4-medium" : "",
               )}
             />
           </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/CollapsibleFormGroup.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/CollapsibleFormGroup.tsx
@@ -31,7 +31,7 @@ export const CollapsibleFormGroup = ({
       setOpen(false);
       if (updateForceCloseCollapsibleFormGroups) {
         updateForceCloseCollapsibleFormGroups(
-          forceCloseCollapsibleFormGroups.filter((e) => e !== path)
+          forceCloseCollapsibleFormGroups.filter((e) => e !== path),
         );
       }
     }
@@ -49,7 +49,7 @@ export const CollapsibleFormGroup = ({
       setOpen(true);
       if (updateForceOpenCollapsibleFormGroups) {
         updateForceOpenCollapsibleFormGroups(
-          forceOpenCollapsibleFormGroups.filter((e) => e !== path)
+          forceOpenCollapsibleFormGroups.filter((e) => e !== path),
         );
       }
     }

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/CredentialTextField.tsx
@@ -44,7 +44,7 @@ export const CredentialTextField = ({
                   {...field}
                   className={cn(
                     "nodrag nowheel",
-                    size === "sm" ? "!product-body-text-4-regular" : ""
+                    size === "sm" ? "!product-body-text-4-regular" : "",
                   )}
                   type="text"
                   value={
@@ -78,14 +78,14 @@ export const CredentialTextField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={shortDescription ?? null}
             />
             <Form.Message
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-medium" : ""
+                size === "sm" ? "!product-body-text-4-medium" : "",
               )}
             />
           </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/ImageField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/ImageField.tsx
@@ -55,7 +55,7 @@ export const ImageField = ({
                 <img
                   key={`${value.slice(
                     value.indexOf(",") + 1,
-                    value.indexOf(",") + 13
+                    value.indexOf(",") + 13,
                   )}`}
                   src={value}
                   alt={path}
@@ -103,7 +103,7 @@ export const ImageField = ({
               <FileListItem
                 name={value.slice(
                   value.indexOf(",") + 1,
-                  value.indexOf(",") + 13
+                  value.indexOf(",") + 13,
                 )}
                 onDelete={() => {
                   setImageFile(null);

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/ImagesField.tsx
@@ -157,7 +157,7 @@ export const ImagesField = ({
                     if (value.prompt_image_base64) {
                       const binaryKey = value.prompt_image_base64.slice(
                         value.prompt_image_base64.indexOf(",") + 1,
-                        value.prompt_image_base64.indexOf(",") + 13
+                        value.prompt_image_base64.indexOf(",") + 13,
                       );
 
                       return (
@@ -166,7 +166,7 @@ export const ImagesField = ({
                           name={binaryKey}
                           onDelete={async () => {
                             const newFiles = imageFiles.filter(
-                              (_, index) => index !== i
+                              (_, index) => index !== i,
                             );
 
                             if (instillModelPromptImageBase64ObjectFormat) {
@@ -210,7 +210,7 @@ export const ImagesField = ({
                       name={e.name}
                       onDelete={async () => {
                         const newFiles = imageFiles.filter(
-                          (_, index) => index !== i
+                          (_, index) => index !== i,
                         );
 
                         if (instillModelPromptImageBase64ObjectFormat) {

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/OneOfConditionField.tsx
@@ -109,7 +109,7 @@ export const OneOfConditionField = ({
                     <Select.Trigger
                       className={cn(
                         "w-full",
-                        size === "sm" ? "!product-body-text-4-regular" : ""
+                        size === "sm" ? "!product-body-text-4-regular" : "",
                       )}
                     >
                       <Select.Value />
@@ -125,7 +125,7 @@ export const OneOfConditionField = ({
                             "my-auto text-semantic-fg-primary group-hover:text-semantic-bg-primary data-[highlighted]:text-semantic-bg-primary",
                             size === "sm"
                               ? "!product-body-text-4-regular"
-                              : "product-body-text-4-regular"
+                              : "product-body-text-4-regular",
                           )}
                           label={option.title ?? option.key}
                         />
@@ -136,14 +136,14 @@ export const OneOfConditionField = ({
                 <Form.Description
                   className={cn(
                     "nodrag nopan cursor-text select-text",
-                    size === "sm" ? "!product-body-text-4-regular" : ""
+                    size === "sm" ? "!product-body-text-4-regular" : "",
                   )}
                   text={shortDescription ?? null}
                 />
                 <Form.Message
                   className={cn(
                     "nodrag nopan cursor-text select-text",
-                    size === "sm" ? "!product-body-text-4-medium" : ""
+                    size === "sm" ? "!product-body-text-4-medium" : "",
                   )}
                 />
               </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/SingleSelectField.tsx
@@ -80,7 +80,7 @@ export const SingleSelectField = ({
 
         const currentCredentialFieldValue = dot.getter(
           values,
-          currentCredentialFieldPath
+          currentCredentialFieldPath,
         );
 
         // Deal with case that support instill credit, if the secret field
@@ -92,7 +92,7 @@ export const SingleSelectField = ({
           ) {
             form.setValue(
               currentCredentialFieldPath,
-              "${secret." + `${InstillCredit.key}` + "}"
+              "${secret." + `${InstillCredit.key}` + "}",
             );
 
             if (updateForceCloseCollapsibleFormGroups) {
@@ -204,7 +204,7 @@ export const SingleSelectField = ({
                 <Select.Trigger
                   className={cn(
                     "w-full",
-                    size === "sm" ? "!product-body-text-4-regular" : ""
+                    size === "sm" ? "!product-body-text-4-regular" : "",
                   )}
                 >
                   <Select.Value />
@@ -222,7 +222,7 @@ export const SingleSelectField = ({
                           "group my-auto !flex !flex-row justify-between text-semantic-fg-primary group-hover:text-semantic-bg-primary data-[highlighted]:text-semantic-bg-primary",
                           size === "sm"
                             ? "!product-body-text-4-regular"
-                            : "product-body-text-3-regular"
+                            : "product-body-text-3-regular",
                         )}
                       >
                         <Select.ItemText>
@@ -268,14 +268,14 @@ export const SingleSelectField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={shortDescription ?? null}
             />
             <Form.Message
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-medium" : ""
+                size === "sm" ? "!product-body-text-4-medium" : "",
               )}
             />
           </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextAreaField.tsx
@@ -39,7 +39,7 @@ export const TextAreaField = ({
                 {...field}
                 className={cn(
                   "nodrag nowheel",
-                  size === "sm" ? "!product-body-text-4-regular" : ""
+                  size === "sm" ? "!product-body-text-4-regular" : "",
                 )}
                 // At some moment the value maybe a object
                 // For example, { foo: { bar: "baz" } }}}. For foo.bar field
@@ -63,14 +63,14 @@ export const TextAreaField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={shortDescription ?? null}
             />
             <Form.Message
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-medium" : ""
+                size === "sm" ? "!product-body-text-4-medium" : "",
               )}
             />
           </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/regular/TextField.tsx
@@ -43,7 +43,7 @@ export const TextField = ({
                   aria-label={title ?? undefined}
                   className={cn(
                     "nodrag nowheel",
-                    size === "sm" ? "!product-body-text-4-regular" : ""
+                    size === "sm" ? "!product-body-text-4-regular" : "",
                   )}
                   type="text"
                   value={
@@ -66,14 +66,14 @@ export const TextField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={shortDescription ?? null}
             />
             <Form.Message
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-medium" : ""
+                size === "sm" ? "!product-body-text-4-medium" : "",
               )}
             />
           </Form.Item>

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/SmartHintList.tsx
@@ -84,7 +84,7 @@ export const SmartHintList = ({
                     {
                       "bg-semantic-accent-bg text-semantic-accent-hover":
                         highlightedHintIndex === index,
-                    }
+                    },
                   )}
                   onClick={() => {
                     onClickSmartHint({

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextArea.tsx
@@ -140,7 +140,7 @@ export const TextArea = ({
                     {...field}
                     className={cn(
                       "nodrag nowheel placeholder:text-semantic-fg-disabled",
-                      size === "sm" ? "!product-body-text-4-regular" : ""
+                      size === "sm" ? "!product-body-text-4-regular" : "",
                     )}
                     ref={inputRef}
                     value={
@@ -196,7 +196,7 @@ export const TextArea = ({
                   e.preventDefault();
                 }}
                 className={cn(
-                  "relative !w-[var(--radix-popover-trigger-width)] !rounded !p-0"
+                  "relative !w-[var(--radix-popover-trigger-width)] !rounded !p-0",
                 )}
                 align="end"
               >
@@ -234,7 +234,7 @@ export const TextArea = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={
                 supportInstillCredit && instillCredential

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/TextField.tsx
@@ -155,7 +155,7 @@ export const TextField = ({
                       }
                       className={cn(
                         "nodrag nowheel placeholder:text-semantic-fg-disabled",
-                        size === "sm" ? "!product-body-text-4-regular" : ""
+                        size === "sm" ? "!product-body-text-4-regular" : "",
                       )}
                       placeholder={placeholder}
                       autoComplete="off"
@@ -208,7 +208,7 @@ export const TextField = ({
                   e.preventDefault();
                 }}
                 className={cn(
-                  "relative !w-[var(--radix-popover-trigger-width)] !rounded !p-0"
+                  "relative !w-[var(--radix-popover-trigger-width)] !rounded !p-0",
                 )}
                 align="end"
               >
@@ -246,7 +246,7 @@ export const TextField = ({
             <Form.Description
               className={cn(
                 "nodrag nopan cursor-text select-text",
-                size === "sm" ? "!product-body-text-4-regular" : ""
+                size === "sm" ? "!product-body-text-4-regular" : "",
               )}
               text={
                 supportInstillCredit && instillCredential

--- a/packages/toolkit/src/lib/use-instill-form/components/smart-hint/useFilteredHints.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/smart-hint/useFilteredHints.tsx
@@ -38,7 +38,7 @@ export function useFilteredHints({
 
     let allHints = pickSmartHintsFromAcceptFormats(
       smartHints,
-      instillAcceptFormats
+      instillAcceptFormats,
     );
 
     if (instillSecret && secrets) {

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
@@ -95,7 +95,7 @@ export const AudiosField = ({
                   "nowheel h-[216px] rounded-sm p-2",
                   mode === "build"
                     ? "bg-semantic-bg-secondary"
-                    : "border border-semantic-bg-line"
+                    : "border border-semantic-bg-line",
                 )}
               >
                 <div className="flex h-full flex-col gap-y-2">
@@ -106,7 +106,7 @@ export const AudiosField = ({
                       src={URL.createObjectURL(e)}
                       onDelete={async () => {
                         const newFiles = audioFiles.filter(
-                          (_, index) => index !== i
+                          (_, index) => index !== i,
                         );
 
                         const newBinaries: string[] = [];

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
@@ -94,7 +94,7 @@ export const FilesField = ({
                   "nowheel h-[216px] rounded-sm p-2",
                   mode === "build"
                     ? "bg-semantic-bg-secondary"
-                    : "border border-semantic-bg-line"
+                    : "border border-semantic-bg-line",
                 )}
               >
                 <div className="flex h-full flex-col gap-y-2">
@@ -104,7 +104,7 @@ export const FilesField = ({
                       name={e.name}
                       onDelete={async () => {
                         const newFiles = uploadedFiles.filter(
-                          (_, index) => index !== i
+                          (_, index) => index !== i,
                         );
 
                         const newBinaries: string[] = [];

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImageField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImageField.tsx
@@ -55,7 +55,7 @@ export const ImageField = ({
                   alt={`${path}-${imageFile.name}`}
                   className={cn(
                     "w-full object-contain",
-                    mode === "build" ? "h-[150px]" : "h-[360px]"
+                    mode === "build" ? "h-[150px]" : "h-[360px]",
                   )}
                 />
               ) : (
@@ -65,7 +65,7 @@ export const ImageField = ({
                     "flex w-full items-center justify-center",
                     mode === "build"
                       ? "h-[150px] bg-semantic-bg-secondary"
-                      : "h-[260px] rounded-sm border border-semantic-bg-line bg-transparent"
+                      : "h-[260px] rounded-sm border border-semantic-bg-line bg-transparent",
                   )}
                 ></div>
               )}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
@@ -52,7 +52,7 @@ export const ImagesField = ({
                 "grid w-full grid-flow-row grid-cols-4",
                 mode === "build"
                   ? ""
-                  : "rounded-sm border border-semantic-bg-line"
+                  : "rounded-sm border border-semantic-bg-line",
               )}
             >
               {imageFiles.length > 0
@@ -67,7 +67,7 @@ export const ImagesField = ({
                           className={cn(
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain"
+                              : "h-[140px] object-contain",
                           )}
                         />
                       ) : (
@@ -77,7 +77,7 @@ export const ImagesField = ({
                             "w-full bg-semantic-bg-secondary",
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain"
+                              : "h-[140px] object-contain",
                           )}
                         />
                       );
@@ -89,7 +89,7 @@ export const ImagesField = ({
                         "w-full",
                         mode === "build"
                           ? "h-[55px] bg-semantic-bg-secondary object-cover"
-                          : "h-[140px] object-contain"
+                          : "h-[140px] object-contain",
                       )}
                     />
                   ))}
@@ -140,7 +140,7 @@ export const ImagesField = ({
                   "nowheel h-[216px] rounded-sm p-2",
                   mode === "build"
                     ? "bg-semantic-bg-secondary"
-                    : "border border-semantic-bg-line"
+                    : "border border-semantic-bg-line",
                 )}
               >
                 <div className="flex h-full flex-col gap-y-2">
@@ -150,7 +150,7 @@ export const ImagesField = ({
                       name={e.name}
                       onDelete={async () => {
                         const newFiles = imageFiles.filter(
-                          (_, index) => index !== i
+                          (_, index) => index !== i,
                         );
 
                         const newBinaries: string[] = [];

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumbersField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/NumbersField.tsx
@@ -46,7 +46,8 @@ export const NumbersField = ({
         if (fieldError) {
           if (Array.isArray(fieldError)) {
             targetError = String(
-              fieldError.filter((e) => e !== undefined || e !== null)[0].message
+              fieldError.filter((e) => e !== undefined || e !== null)[0]
+                .message,
             );
           } else {
             targetError = String(fieldError.message);

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextsField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/TextsField.tsx
@@ -44,7 +44,8 @@ export const TextsField = ({
         if (fieldError) {
           if (Array.isArray(fieldError)) {
             targetError = String(
-              fieldError.filter((e) => e !== undefined || e !== null)[0].message
+              fieldError.filter((e) => e !== undefined || e !== null)[0]
+                .message,
             );
           } else {
             targetError = String(fieldError.message);

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/UploadFileInput.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/UploadFileInput.tsx
@@ -23,7 +23,7 @@ export const UploadFileInput = React.forwardRef<
         "flex rounded-full px-2 py-0.5 font-sans text-xs font-medium text-semantic-accent-default hover:bg-semantic-accent-bg",
         disabled
           ? "cursor-not-allowed bg-semantic-bg-secondary"
-          : "cursor-pointer underline"
+          : "cursor-pointer underline",
       )}
     >
       {title}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideoField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideoField.tsx
@@ -61,7 +61,7 @@ export const VideoField = ({
                     "flex w-full items-center justify-center",
                     mode === "build"
                       ? "h-[150px] bg-semantic-bg-secondary"
-                      : "h-[260px] rounded-sm border border-semantic-bg-line bg-transparent"
+                      : "h-[260px] rounded-sm border border-semantic-bg-line bg-transparent",
                   )}
                 ></div>
               )}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
@@ -53,7 +53,7 @@ export const VideosField = ({
                 "grid w-full grid-flow-row grid-cols-4",
                 mode === "build"
                   ? ""
-                  : "rounded-sm border border-semantic-bg-line"
+                  : "rounded-sm border border-semantic-bg-line",
               )}
             >
               {videosFiles.length > 0
@@ -77,7 +77,7 @@ export const VideosField = ({
                             "w-full bg-semantic-bg-secondary",
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain"
+                              : "h-[140px] object-contain",
                           )}
                         />
                       );
@@ -89,7 +89,7 @@ export const VideosField = ({
                         "w-full",
                         mode === "build"
                           ? "h-[55px] bg-semantic-bg-secondary object-cover"
-                          : "h-[140px] object-contain"
+                          : "h-[140px] object-contain",
                       )}
                     />
                   ))}
@@ -140,7 +140,7 @@ export const VideosField = ({
                   "nowheel h-[216px] rounded-sm p-2",
                   mode === "build"
                     ? "bg-semantic-bg-secondary"
-                    : "border border-semantic-bg-line"
+                    : "border border-semantic-bg-line",
                 )}
               >
                 <div className="flex h-full flex-col gap-y-2">
@@ -150,7 +150,7 @@ export const VideosField = ({
                       name={e.name}
                       onDelete={async () => {
                         const newFiles = videosFiles.filter(
-                          (_, index) => index !== i
+                          (_, index) => index !== i,
                         );
 
                         const newBinaries: string[] = [];

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -14,7 +14,7 @@ export type PickComponentOutputFieldsFromInstillFormTreeProps = {
 };
 
 export function pickComponentOutputFieldsFromInstillFormTree(
-  props: PickComponentOutputFieldsFromInstillFormTreeProps
+  props: PickComponentOutputFieldsFromInstillFormTreeProps,
 ) {
   // 1. Preprocess
 

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickConstInfoFromOneOfCondition.ts
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickConstInfoFromOneOfCondition.ts
@@ -1,7 +1,7 @@
 import { InstillJSONSchema } from "../types";
 
 export function pickConstInfoFromOneOfCondition(
-  properties: Record<string, InstillJSONSchema>
+  properties: Record<string, InstillJSONSchema>,
 ) {
   let constKey: null | string = null;
   let constValue: null | string = null;

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickRegularFieldsFromInstillFormTree.tsx
@@ -41,7 +41,7 @@ export function pickRegularFieldsFromInstillFormTree(
   setSelectedConditionMap: React.Dispatch<
     React.SetStateAction<SelectedConditionMap | null>
   >,
-  options?: PickRegularFieldsFromInstillFormTreeOptions
+  options?: PickRegularFieldsFromInstillFormTreeOptions,
 ): React.ReactNode {
   const disabledAll = options?.disabledAll ?? false;
   const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
@@ -104,7 +104,7 @@ export function pickRegularFieldsFromInstillFormTree(
               form,
               selectedConditionMap,
               setSelectedConditionMap,
-              options
+              options,
             );
           })}
         </React.Fragment>
@@ -136,7 +136,7 @@ export function pickRegularFieldsFromInstillFormTree(
                 // We only enable collapsible form group for the first level
                 ...options,
                 enabledCollapsibleFormGroup: false,
-              }
+              },
             );
           })}
         </RegularFields.CollapsibleFormGroup>
@@ -150,7 +150,7 @@ export function pickRegularFieldsFromInstillFormTree(
             "mb-2 text-semantic-fg-primary",
             size === "sm"
               ? "product-body-text-4-medium"
-              : "product-body-text-3-medium"
+              : "product-body-text-3-medium",
           )}
         >
           {title}
@@ -162,7 +162,7 @@ export function pickRegularFieldsFromInstillFormTree(
               form,
               selectedConditionMap,
               setSelectedConditionMap,
-              options
+              options,
             );
           })}
         </div>
@@ -183,12 +183,12 @@ export function pickRegularFieldsFromInstillFormTree(
               form,
               selectedConditionMap,
               setSelectedConditionMap,
-              options
+              options,
             ),
             title: constInfo?.title ?? null,
           },
         ];
-      })
+      }),
     );
 
     // We will use the const path as the OneOfConditionField's path
@@ -204,7 +204,7 @@ export function pickRegularFieldsFromInstillFormTree(
 
     if (selectedCondition && tree.conditions[selectedCondition]) {
       selectedConstField = tree.conditions[selectedCondition].properties.find(
-        (e) => "const" in e
+        (e) => "const" in e,
       );
     }
 
@@ -243,7 +243,7 @@ export function pickRegularFieldsFromInstillFormTree(
           form,
           selectedConditionMap,
           setSelectedConditionMap,
-          options
+          options,
         )}
       </React.Fragment>
     );
@@ -257,7 +257,7 @@ export function pickRegularFieldsFromInstillFormTree(
           form,
           selectedConditionMap,
           setSelectedConditionMap,
-          options
+          options,
         )}
       </React.Fragment>
     );

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickSelectedConditionMap.ts
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickSelectedConditionMap.ts
@@ -55,7 +55,7 @@ export function pickSelectedConditionMap({
     if (defaultCondition?.path) {
       const initialConditionValue = dot.getter(
         initialValue,
-        defaultCondition.path
+        defaultCondition.path,
       );
 
       if (initialConditionValue) {

--- a/packages/toolkit/src/lib/use-instill-form/transform/recursivelyResetFormData.test.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/recursivelyResetFormData.test.ts
@@ -291,7 +291,7 @@ test("should reset basic form data", () => {
   recursivelyResetFormData(
     tree.conditions["TASK_TEXT_GENERATION"],
     selectedConditionMap,
-    data
+    data,
   );
 
   expect(data).toStrictEqual({
@@ -772,6 +772,6 @@ test.skip("should reset nested oneOf form data", () => {
   recursivelyResetFormData(
     tree.conditions["TASK_TEXT_GENERATION"],
     selectedConditionMap,
-    data
+    data,
   );
 });

--- a/packages/toolkit/src/lib/use-instill-form/transform/recursivelyResetFormData.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/recursivelyResetFormData.ts
@@ -6,7 +6,7 @@ import { transformInstillFormTreeToDefaultValue } from "./transformInstillFormTr
 export function recursivelyResetFormData(
   tree: InstillFormTree,
   selectedConditionMap: SelectedConditionMap,
-  formData: GeneralRecord
+  formData: GeneralRecord,
 ) {
   switch (tree._type) {
     case "formGroup": {
@@ -29,7 +29,7 @@ export function recursivelyResetFormData(
           recursivelyResetFormData(
             tree.conditions[selectedCondition],
             selectedConditionMap,
-            formData
+            formData,
           );
         }
       }

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.test.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.test.ts
@@ -1546,7 +1546,7 @@ test("should transform to selected conditions", () => {
       selectedConditionMap: {
         task: "TASK_SPEECH_RECOGNITION",
       },
-    })
+    }),
   ).toStrictEqual({
     input: { audio: null },
     task: "TASK_SPEECH_RECOGNITION",
@@ -1557,7 +1557,7 @@ test("should transform to selected conditions", () => {
       selectedConditionMap: {
         task: "TASK_SPEECH_RECOGNITION",
       },
-    })
+    }),
   ).toStrictEqual({
     input: { audio: null },
     task: "TASK_SPEECH_RECOGNITION",

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.ts
@@ -13,7 +13,7 @@ export type TransformInstillFormTreeToDefaultValueOptions = {
 
 export function transformInstillFormTreeToDefaultValue(
   tree: InstillFormTree,
-  options?: TransformInstillFormTreeToDefaultValueOptions
+  options?: TransformInstillFormTreeToDefaultValueOptions,
 ): GeneralRecord {
   const initialData = options?.initialData ?? {};
   const isRoot = options?.isRoot ?? false;
@@ -34,13 +34,13 @@ export function transformInstillFormTreeToDefaultValue(
             initialData,
             selectedConditionMap,
             isRoot,
-          }
+          },
         );
 
         dot.setter(
           initialData,
           constPath,
-          selectedConditionMap[constPath] as string
+          selectedConditionMap[constPath] as string,
         );
       } else {
         transformInstillFormTreeToDefaultValue(
@@ -49,7 +49,7 @@ export function transformInstillFormTreeToDefaultValue(
             initialData,
             selectedConditionMap,
             isRoot,
-          }
+          },
         );
 
         dot.setter(initialData, constPath, defaultCondition.const as string);

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToInitialSelectedCondition.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToInitialSelectedCondition.ts
@@ -12,7 +12,7 @@ export type TransformInstillFormTreeToInitialSelectedConditionOptions = {
 
 export function transformInstillFormTreeToInitialSelectedCondition(
   tree: InstillFormTree,
-  options?: TransformInstillFormTreeToInitialSelectedConditionOptions
+  options?: TransformInstillFormTreeToInitialSelectedConditionOptions,
 ) {
   let selectedConditionMap: SelectedConditionMap = {};
 
@@ -22,7 +22,7 @@ export function transformInstillFormTreeToInitialSelectedCondition(
         ...selectedConditionMap,
         ...transformInstillFormTreeToInitialSelectedCondition(
           property,
-          options
+          options,
         ),
       };
     }
@@ -33,7 +33,7 @@ export function transformInstillFormTreeToInitialSelectedCondition(
       ...selectedConditionMap,
       ...transformInstillFormTreeToInitialSelectedCondition(
         tree.properties,
-        options
+        options,
       ),
     };
   }
@@ -47,7 +47,7 @@ export function transformInstillFormTreeToInitialSelectedCondition(
       if (options?.initialData) {
         const selectedCondition = dot.getter(
           options.initialData,
-          constField.path
+          constField.path,
         );
 
         if (selectedCondition) {
@@ -57,7 +57,7 @@ export function transformInstillFormTreeToInitialSelectedCondition(
             ...selectedConditionMap,
             ...transformInstillFormTreeToInitialSelectedCondition(
               tree.conditions[selectedCondition as string],
-              options
+              options,
             ),
           };
 
@@ -71,7 +71,7 @@ export function transformInstillFormTreeToInitialSelectedCondition(
         ...selectedConditionMap,
         ...transformInstillFormTreeToInitialSelectedCondition(
           tree.conditions[constField.const as string],
-          options
+          options,
         ),
       };
     }

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToReferenceHints.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToReferenceHints.ts
@@ -3,7 +3,7 @@ import { ComponentOutoutReferenceHint, InstillFormTree } from "../types";
 export function transformInstillFormTreeToReferenceHints(
   tree: InstillFormTree,
   isObjectArrayChild?: boolean,
-  objectArrayParentPath?: string
+  objectArrayParentPath?: string,
 ): ComponentOutoutReferenceHint[] {
   // 1. Preprocess
   let referenceHints: ComponentOutoutReferenceHint[] = [];
@@ -19,7 +19,7 @@ export function transformInstillFormTreeToReferenceHints(
       const hints = transformInstillFormTreeToReferenceHints(
         property,
         isObjectArrayChild,
-        objectArrayParentPath
+        objectArrayParentPath,
       );
       referenceHints = [...referenceHints, ...hints];
     }
@@ -38,7 +38,7 @@ export function transformInstillFormTreeToReferenceHints(
       const hints = transformInstillFormTreeToReferenceHints(
         tree.properties,
         true,
-        tree.path
+        tree.path,
       );
       referenceHints = [...referenceHints, ...hints];
     }

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormatToHumanReadableFormat.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormatToHumanReadableFormat.tsx
@@ -2,7 +2,7 @@ import { InstillHumanReadableFormat } from "../types";
 
 export function transformInstillFormatToHumanReadableFormat(
   format: string,
-  arrayInArray?: boolean
+  arrayInArray?: boolean,
 ): InstillHumanReadableFormat {
   if (format.includes("array:")) {
     if (arrayInArray) {

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToFormTree.ts
@@ -18,7 +18,7 @@ export type TransformInstillJSONSchemaToFormTreeOptions = {
 
 export function transformInstillJSONSchemaToFormTree(
   targetSchema: InstillJSONSchemaDefinition,
-  options?: TransformInstillJSONSchemaToFormTreeOptions
+  options?: TransformInstillJSONSchemaToFormTreeOptions,
 ): InstillFormTree {
   let isRequired = false;
   const key = options?.key;
@@ -70,7 +70,7 @@ export function transformInstillJSONSchemaToFormTree(
   // 1.1 Get the type and instillAcceptFormats from anyOf field
   if (targetSchema.anyOf && targetSchema.anyOf.length > 0) {
     const instillUpstreamValue = targetSchema.anyOf.find(
-      (e) => e.instillUpstreamType === "value"
+      (e) => e.instillUpstreamType === "value",
     );
 
     if (instillUpstreamValue) {
@@ -123,7 +123,7 @@ export function transformInstillJSONSchemaToFormTree(
       }
 
       const { constKey, constValue } = pickConstInfoFromOneOfCondition(
-        condition.properties ?? {}
+        condition.properties ?? {},
       );
 
       // Some time oneOf field will also have properties fields to support
@@ -152,7 +152,7 @@ export function transformInstillJSONSchemaToFormTree(
                 key,
                 path,
                 checkIsHidden,
-              }
+              },
             ) as InstillFormGroupItem,
           ]);
         }
@@ -173,7 +173,7 @@ export function transformInstillJSONSchemaToFormTree(
             key,
             path,
             checkIsHidden,
-          }
+          },
         ) as InstillFormGroupItem,
       ]);
     }
@@ -182,7 +182,7 @@ export function transformInstillJSONSchemaToFormTree(
 
     const constField = targetSchema.oneOf[0].properties
       ? Object.entries(targetSchema.oneOf[0].properties).find(
-          ([, property]) => "const" in property
+          ([, property]) => "const" in property,
         )?.[1]
       : undefined;
 
@@ -220,7 +220,7 @@ export function transformInstillJSONSchemaToFormTree(
           key,
           path,
           checkIsHidden,
-        }
+        },
       );
 
       return {
@@ -263,7 +263,7 @@ export function transformInstillJSONSchemaToFormTree(
         key,
         path,
         checkIsHidden,
-      }
+      },
     );
 
     return {
@@ -304,7 +304,7 @@ export function transformInstillJSONSchemaToFormTree(
           key,
           path: path ? `${path}.${key}` : key,
           checkIsHidden,
-        })
+        }),
       )
       .sort((a, b) => {
         if (typeof a.instillUIOrder === "undefined") {
@@ -373,7 +373,7 @@ const baseFields: Array<keyof InstillJSONSchema> = [
 
 function pickBaseFields(
   schema: InstillJSONSchema,
-  ignoreFields?: string[]
+  ignoreFields?: string[],
 ): Partial<InstillJSONSchema> {
   const partialSchema: Partial<InstillJSONSchema> = {
     ...Object.fromEntries(
@@ -383,7 +383,7 @@ function pickBaseFields(
         }
 
         return baseFields.includes(k as keyof InstillJSONSchema);
-      })
+      }),
     ),
   };
 
@@ -405,7 +405,7 @@ function pickBaseFields(
 }
 
 function isDefined<T>(
-  a: T | null | undefined
+  a: T | null | undefined,
 ): a is Exclude<T, null | undefined> {
   return a !== undefined && a !== null;
 }

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillJSONSchemaToZod.ts
@@ -62,7 +62,7 @@ export function transformInstillJSONSchemaToZod({
     const selectedSchema = selectedConditionMap
       ? oneOfConditions.find((condition) => {
           const { constKey, constValue } = pickConstInfoFromOneOfCondition(
-            condition.properties ?? {}
+            condition.properties ?? {},
           );
 
           const accessPath = propertyPath
@@ -166,7 +166,7 @@ export function transformInstillJSONSchemaToZod({
             targetSchema: targetSchema.items as InstillJSONSchema,
             selectedConditionMap,
             checkIsHidden,
-          })
+          }),
         );
       }
     } else {
@@ -215,7 +215,7 @@ export function transformInstillJSONSchemaToZod({
     // accept the object input from start operator.
     if (
       targetSchema.instillAcceptFormats?.some((format) =>
-        format.includes("semi-structured")
+        format.includes("semi-structured"),
       )
     ) {
       instillZodSchema = z.string();
@@ -230,7 +230,7 @@ export function transformInstillJSONSchemaToZod({
     let objectSchema = z.object({});
 
     for (const [entryKey, entryJsonSchema] of Object.entries(
-      objectProperties
+      objectProperties,
     )) {
       if (typeof entryJsonSchema !== "boolean") {
         objectSchema = objectSchema.extend({
@@ -266,13 +266,13 @@ export function transformInstillJSONSchemaToZod({
 
   if (targetSchema.anyOf && targetSchema.anyOf.length > 0) {
     const instillUpstreamValue = targetSchema.anyOf.find(
-      (e) => e.instillUpstreamType === "value"
+      (e) => e.instillUpstreamType === "value",
     );
 
     const acceptPrimitive = instillUpstreamValue ? true : false;
 
     const acceptReference = targetSchema.anyOf.some(
-      (e) => e.instillUpstreamType === "reference"
+      (e) => e.instillUpstreamType === "reference",
     );
 
     if (instillUpstreamValue) {
@@ -475,7 +475,7 @@ export function transformInstillJSONSchemaToZod({
             .array(
               z.object({
                 prompt_image_base64: z.string(),
-              })
+              }),
             )
             .nullable()
             .optional();

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformPipelineTriggerRequestFieldsToSuperRefineRules.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformPipelineTriggerRequestFieldsToSuperRefineRules.ts
@@ -2,7 +2,7 @@ import { Nullable, SuperRefineRule } from "../../type";
 import { PipelineVariableFieldMap } from "../../vdp-sdk";
 
 export function transformPipelineTriggerRequestFieldsToSuperRefineRules(
-  fields: Nullable<PipelineVariableFieldMap>
+  fields: Nullable<PipelineVariableFieldMap>,
 ) {
   const rules: SuperRefineRule[] = [];
 

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformPipelineTriggerRequestFieldsToZod.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformPipelineTriggerRequestFieldsToZod.ts
@@ -5,7 +5,7 @@ import { Nullable } from "../../type";
 import { PipelineVariableFieldMap } from "../../vdp-sdk";
 
 export function transformPipelineTriggerRequestFieldsToZod(
-  fields: Nullable<PipelineVariableFieldMap>
+  fields: Nullable<PipelineVariableFieldMap>,
 ) {
   let zodSchema: z.ZodObject<any, any, any> = z.object({});
 
@@ -19,7 +19,7 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "array:string":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.string().nullable().optional()).nullable().optional()
+          z.array(z.string().nullable().optional()).nullable().optional(),
         );
         break;
       case "boolean":
@@ -28,13 +28,16 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "number":
         zodSchema = zodSchema.setKey(
           key,
-          z.coerce.number().nullable().optional()
+          z.coerce.number().nullable().optional(),
         );
         break;
       case "array:number":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.coerce.number().nullable().optional()).nullable().optional()
+          z
+            .array(z.coerce.number().nullable().optional())
+            .nullable()
+            .optional(),
         );
         break;
       case "audio/*":
@@ -43,7 +46,7 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "array:audio/*":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.string().nullable().optional()).nullable().optional()
+          z.array(z.string().nullable().optional()).nullable().optional(),
         );
         break;
       case "image/*":
@@ -52,7 +55,7 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "array:image/*":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.string().nullable().optional()).nullable().optional()
+          z.array(z.string().nullable().optional()).nullable().optional(),
         );
         break;
       case "video/*":
@@ -61,7 +64,7 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "array:video/*":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.string().nullable().optional()).nullable().optional()
+          z.array(z.string().nullable().optional()).nullable().optional(),
         );
         break;
       case "*/*":
@@ -70,7 +73,7 @@ export function transformPipelineTriggerRequestFieldsToZod(
       case "array:*/*":
         zodSchema = zodSchema.setKey(
           key,
-          z.array(z.string().nullable().optional()).nullable().optional()
+          z.array(z.string().nullable().optional()).nullable().optional(),
         );
         break;
       case "semi-structured/json":

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.test.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.test.tsx
@@ -214,22 +214,22 @@ test("should generate simple one layer form", async () => {
   // Check the engine options are rendered, this need to move below the other fields
   expect(engineField).toHaveAttribute("aria-expanded", "true");
   expect(
-    screen.getByRole("option", { name: "stable-diffusion-xl-1024-v1-0" })
+    screen.getByRole("option", { name: "stable-diffusion-xl-1024-v1-0" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "stable-diffusion-xl-1024-v0-9" })
+    screen.getByRole("option", { name: "stable-diffusion-xl-1024-v0-9" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "stable-diffusion-v1-6" })
+    screen.getByRole("option", { name: "stable-diffusion-v1-6" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "esrgan-v1-x2plus" })
+    screen.getByRole("option", { name: "esrgan-v1-x2plus" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "stable-diffusion-512-v2-1" })
+    screen.getByRole("option", { name: "stable-diffusion-512-v2-1" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "stable-diffusion-xl-beta-v2-2-2" })
+    screen.getByRole("option", { name: "stable-diffusion-xl-beta-v2-2-2" }),
   ).toBeInTheDocument();
 
   // Select the last option
@@ -352,10 +352,10 @@ test("should generate oneOf form", async () => {
   // Check the task options are rendered
   expect(taskField).toHaveAttribute("aria-expanded", "true");
   expect(
-    screen.getByRole("option", { name: "TASK_TEXT_TO_IMAGE" })
+    screen.getByRole("option", { name: "TASK_TEXT_TO_IMAGE" }),
   ).toBeInTheDocument();
   expect(
-    screen.getByRole("option", { name: "TASK_IMAGE_TO_IMAGE" })
+    screen.getByRole("option", { name: "TASK_IMAGE_TO_IMAGE" }),
   ).toBeInTheDocument();
 
   // Select the last option
@@ -374,7 +374,7 @@ test("should generate oneOf form", async () => {
   // Fill in the desire values
   await user.type(
     weightsField,
-    getEscapedReferenceValueForReactTestingLibrary(weights)
+    getEscapedReferenceValueForReactTestingLibrary(weights),
   );
   expect(weightsField).toHaveValue();
 
@@ -1239,7 +1239,7 @@ test("should generate stability ai form", async () => {
   });
   expect(samplerField).toBeInTheDocument();
   expect(
-    within(samplerField).getByText("K_DPM_2_ANCESTRAL")
+    within(samplerField).getByText("K_DPM_2_ANCESTRAL"),
   ).toBeInTheDocument();
 
   const samplesField = screen.getByRole("textbox", {
@@ -1276,7 +1276,7 @@ test("should generate stability ai form", async () => {
   await user.click(screen.getByRole("option", { name: "TASK_IMAGE_TO_IMAGE" }));
   expect(taskField).toHaveAttribute("aria-expanded", "false");
   expect(
-    within(taskField).getByText("TASK_IMAGE_TO_IMAGE")
+    within(taskField).getByText("TASK_IMAGE_TO_IMAGE"),
   ).toBeInTheDocument();
 
   // Check the chosen task fields are correctly rendered
@@ -1289,7 +1289,7 @@ test("should generate stability ai form", async () => {
   expect(cfgScaleField).toHaveValue("7");
   expect(samplerField).toBeInTheDocument();
   expect(
-    within(samplerField).getByText("K_DPM_2_ANCESTRAL")
+    within(samplerField).getByText("K_DPM_2_ANCESTRAL"),
   ).toBeInTheDocument();
   expect(samplesField).toBeInTheDocument();
   expect(samplesField).toHaveValue("1");
@@ -1333,7 +1333,7 @@ test("should generate stability ai form", async () => {
 
   await user.type(
     promptsField,
-    getEscapedReferenceValueForReactTestingLibrary(prompts)
+    getEscapedReferenceValueForReactTestingLibrary(prompts),
   );
   expect(promptsField).toHaveValue(prompts);
   await userEvent.click(engineField, {
@@ -1344,12 +1344,12 @@ test("should generate stability ai form", async () => {
   expect(within(engineField).getByText(engine)).toBeInTheDocument();
   await user.type(
     weightsField,
-    getEscapedReferenceValueForReactTestingLibrary(weights)
+    getEscapedReferenceValueForReactTestingLibrary(weights),
   );
   expect(weightsField).toHaveValue(weights);
   await user.type(
     initImageField,
-    getEscapedReferenceValueForReactTestingLibrary(initImage)
+    getEscapedReferenceValueForReactTestingLibrary(initImage),
   );
   expect(initImageField).toHaveValue(initImage);
   await userEvent.click(initImageModeField, {
@@ -1358,7 +1358,7 @@ test("should generate stability ai form", async () => {
   await user.click(screen.getByRole("option", { name: initImageMode }));
   expect(initImageModeField).toHaveAttribute("aria-expanded", "false");
   expect(
-    within(initImageModeField).getByText(initImageMode)
+    within(initImageModeField).getByText(initImageMode),
   ).toBeInTheDocument();
   await user.clear(seedField);
   await user.type(seedField, seed);

--- a/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillForm.tsx
@@ -40,7 +40,7 @@ export type UseInstillFormOptions = {
 export function useInstillForm(
   schema: InstillJSONSchema | null,
   data: GeneralRecord | null,
-  options?: UseInstillFormOptions
+  options?: UseInstillFormOptions,
 ) {
   const disabledAll = options?.disabledAll ?? false;
   const chooseTitleFrom = options?.chooseTitleFrom ?? "title";
@@ -66,7 +66,7 @@ export function useInstillForm(
 
   const [formTree, setFormTree] = React.useState<InstillFormTree | null>(null);
   const [ValidatorSchema, setValidatorSchema] = React.useState<z.ZodTypeAny>(
-    z.any()
+    z.any(),
   );
   const [initialValues, setInitialValues] =
     React.useState<Nullable<GeneralRecord>>(null);
@@ -165,7 +165,7 @@ export function useInstillForm(
         forceOpenCollapsibleFormGroups,
         updateForceOpenCollapsibleFormGroups,
         updateIsUsingInstillCredit,
-      }
+      },
     );
 
     return fields;

--- a/packages/toolkit/src/lib/use-instill-form/useInstillSelectedConditionMap.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/useInstillSelectedConditionMap.tsx
@@ -10,7 +10,7 @@ export type UseInstillSelectedConditionMapResult = UseCustomHookResult<
 
 export function useInstillSelectedConditionMap(
   tree: Nullable<InstillFormTree>,
-  initialValue: Nullable<GeneralRecord>
+  initialValue: Nullable<GeneralRecord>,
 ): UseInstillSelectedConditionMapResult {
   let initialConditionMap: Nullable<SelectedConditionMap> = {};
 

--- a/packages/toolkit/src/lib/use-instill-store/generalSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/generalSlice.ts
@@ -35,7 +35,7 @@ export const createGeneralSlice: StateCreator<
     }),
   navigationNamespaceAnchor: null,
   updateNavigationNamespaceAnchor: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) =>
     set((state) => {
       return {

--- a/packages/toolkit/src/lib/use-instill-store/pipelineBuilderSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/pipelineBuilderSlice.ts
@@ -111,7 +111,7 @@ export const createPipelineBuilderSlice: StateCreator<
     set({
       edges: addEdge(
         { ...connection, animated: false, type: "customEdge" },
-        get().edges
+        get().edges,
       ),
     });
   },
@@ -137,7 +137,7 @@ export const createPipelineBuilderSlice: StateCreator<
       };
     }),
   updateSelectedConnectorNodeId: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) =>
     set((state) => {
       return {
@@ -146,13 +146,13 @@ export const createPipelineBuilderSlice: StateCreator<
       };
     }),
   updateCurrentAdvancedConfigurationNodeID: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) =>
     set((state) => {
       return {
         ...state,
         currentAdvancedConfigurationNodeID: fn(
-          state.currentAdvancedConfigurationNodeID
+          state.currentAdvancedConfigurationNodeID,
         ),
       };
     }),
@@ -179,8 +179,8 @@ export const createPipelineBuilderSlice: StateCreator<
     }),
   updateTestModeTriggerResponse: (
     fn: (
-      prev: Nullable<TriggerUserPipelineResponse>
-    ) => Nullable<TriggerUserPipelineResponse>
+      prev: Nullable<TriggerUserPipelineResponse>,
+    ) => Nullable<TriggerUserPipelineResponse>,
   ) =>
     set((state) => {
       return {
@@ -190,7 +190,7 @@ export const createPipelineBuilderSlice: StateCreator<
     }),
 
   updatePipelineOpenAPIOutputSchema: (
-    fn: (prev: Nullable<InstillJSONSchema>) => Nullable<InstillJSONSchema>
+    fn: (prev: Nullable<InstillJSONSchema>) => Nullable<InstillJSONSchema>,
   ) =>
     set((state) => {
       return {
@@ -255,13 +255,13 @@ export const createPipelineBuilderSlice: StateCreator<
       };
     }),
   updateTempSavedNodesForEditingIteratorFlow: (
-    fn: (prev: Node<NodeData>[]) => Node<NodeData>[]
+    fn: (prev: Node<NodeData>[]) => Node<NodeData>[],
   ) =>
     set((state) => {
       return {
         ...state,
         tempSavedNodesForEditingIteratorFlow: fn(
-          state.tempSavedNodesForEditingIteratorFlow
+          state.tempSavedNodesForEditingIteratorFlow,
         ),
       };
     }),
@@ -273,7 +273,7 @@ export const createPipelineBuilderSlice: StateCreator<
       };
     }),
   updateWarnUnsavdChangesDialogState: (
-    fn: (prev: WarnUnsavedChangesDialogState) => WarnUnsavedChangesDialogState
+    fn: (prev: WarnUnsavedChangesDialogState) => WarnUnsavedChangesDialogState,
   ) =>
     set((state) => {
       return {

--- a/packages/toolkit/src/lib/use-instill-store/recentlyUsedSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/recentlyUsedSlice.ts
@@ -9,13 +9,13 @@ export const createRecentlyUsedSlice: StateCreator<
 > = (set) => ({
   recentlyUsedStartComponentFieldTypes: [],
   updateRecentlyUsedStartComponentFieldTypes: (
-    fn: (prev: string[]) => string[]
+    fn: (prev: string[]) => string[],
   ) =>
     set((state) => {
       return {
         ...state,
         recentlyUsedStartComponentFieldTypes: fn(
-          state.recentlyUsedStartComponentFieldTypes
+          state.recentlyUsedStartComponentFieldTypes,
         ),
       };
     }),

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -44,7 +44,7 @@ export type PipelineBuilderAction = {
   initIteratorRelatedState: () => void;
   updatePipelineId: (fn: (prev: Nullable<string>) => Nullable<string>) => void;
   updatePipelineName: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
   updateNodes: (fn: (prev: Node<NodeData>[]) => Node<NodeData>[]) => void;
   updateEdges: (fn: (prev: Edge[]) => Edge[]) => void;
@@ -56,25 +56,25 @@ export type PipelineBuilderAction = {
   updatePipelineRecipeIsDirty: (fn: (prev: boolean) => boolean) => void;
   updatePipelineIsNew: (fn: (prev: boolean) => boolean) => void;
   updateSelectedConnectorNodeId: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
   updateCurrentAdvancedConfigurationNodeID: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
   updateConnectorFormIsDirty: (fn: (prev: boolean) => boolean) => void;
   updateSelectResourceDialogIsOpen: (fn: (prev: boolean) => boolean) => void;
   updateCollapseAllNodes: (fn: (prev: boolean) => boolean) => void;
   updateTestModeTriggerResponse: (
     fn: (
-      prev: Nullable<TriggerUserPipelineResponse>
-    ) => Nullable<TriggerUserPipelineResponse>
+      prev: Nullable<TriggerUserPipelineResponse>,
+    ) => Nullable<TriggerUserPipelineResponse>,
   ) => void;
   updatePipelineOpenAPIOutputSchema: (
-    fn: (prev: Nullable<InstillJSONSchema>) => Nullable<InstillJSONSchema>
+    fn: (prev: Nullable<InstillJSONSchema>) => Nullable<InstillJSONSchema>,
   ) => void;
 
   updateCurrentVersion: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
   updateInitializedByTemplateOrClone: (fn: (prev: boolean) => boolean) => void;
   updateIsOwner: (fn: (prev: boolean) => boolean) => void;
@@ -84,13 +84,13 @@ export type PipelineBuilderAction = {
   updatePipelineIsReadOnly: (fn: (prev: boolean) => boolean) => void;
   updateIsEditingIterator: (fn: (prev: boolean) => boolean) => void;
   updateTempSavedNodesForEditingIteratorFlow: (
-    fn: (prev: Node<NodeData>[]) => Node<NodeData>[]
+    fn: (prev: Node<NodeData>[]) => Node<NodeData>[],
   ) => void;
   updateEditingIteratorID: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
   updateWarnUnsavdChangesDialogState: (
-    fn: (prev: WarnUnsavedChangesDialogState) => WarnUnsavedChangesDialogState
+    fn: (prev: WarnUnsavedChangesDialogState) => WarnUnsavedChangesDialogState,
   ) => void;
 };
 
@@ -115,14 +115,14 @@ export type GeneralSlice = {
 
   navigationNamespaceAnchor: Nullable<string>;
   updateNavigationNamespaceAnchor: (
-    fn: (prev: Nullable<string>) => Nullable<string>
+    fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
 };
 
 export type RecentlyUsedSlice = {
   recentlyUsedStartComponentFieldTypes: string[];
   updateRecentlyUsedStartComponentFieldTypes: (
-    fn: (prev: string[]) => string[]
+    fn: (prev: string[]) => string[],
   ) => void;
 };
 

--- a/packages/toolkit/src/lib/use-instill-store/useInstillStore.ts
+++ b/packages/toolkit/src/lib/use-instill-store/useInstillStore.ts
@@ -13,6 +13,6 @@ export const useInstillStore = create<InstillStore>()(
       ...createPipelineBuilderSlice(...a),
       ...createGeneralSlice(...a),
       ...createRecentlyUsedSlice(...a),
-    }))
-  )
+    })),
+  ),
 );

--- a/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/fields/GroupByFormatField.tsx
+++ b/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/fields/GroupByFormatField.tsx
@@ -17,7 +17,7 @@ export const GroupByFormatField = ({
   const humanReadableInstillFormat = React.useMemo(() => {
     return transformInstillFormatToHumanReadableFormat(
       instillFormat,
-      arrayInArray
+      arrayInArray,
     );
   }, [instillFormat, arrayInArray]);
 

--- a/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickFieldsFromOutputReferenceHints.tsx
+++ b/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickFieldsFromOutputReferenceHints.tsx
@@ -36,7 +36,7 @@ export function pickFieldsFromOutputReferenceHints(hints: SmartHint[]) {
 
   const hintsGroupByFormat = groupBy(
     [...nonObjectArrayHints, ...normalizeObjectArrayHints],
-    (hint) => hint.instillFormat
+    (hint) => hint.instillFormat,
   );
 
   Object.entries(hintsGroupByFormat).forEach(([instillFormat, hints]) => {
@@ -45,13 +45,13 @@ export function pickFieldsFromOutputReferenceHints(hints: SmartHint[]) {
         key={instillFormat}
         instillFormat={instillFormat}
         hints={hints}
-      />
+      />,
     );
   });
 
   const arrayArrayHintsGroupByFormat = groupBy(
     arrayArrayHints,
-    (hint) => hint.instillFormat
+    (hint) => hint.instillFormat,
   );
 
   Object.entries(arrayArrayHintsGroupByFormat).forEach(
@@ -62,9 +62,9 @@ export function pickFieldsFromOutputReferenceHints(hints: SmartHint[]) {
           instillFormat={instillFormat}
           hints={hints}
           arrayInArray={true}
-        />
+        />,
       );
-    }
+    },
   );
 
   return fields;

--- a/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickOutputReferenceHintsFromComponent.tsx
+++ b/packages/toolkit/src/lib/use-smart-hint/output-reference-hint/pickOutputReferenceHintsFromComponent.tsx
@@ -41,7 +41,7 @@ export function pickOutputReferenceHintsFromComponent({
           });
 
           const targetHint = componentHints.find(
-            (hint) => hint.path === value.replace("${", "").replace("}", "")
+            (hint) => hint.path === value.replace("${", "").replace("}", ""),
           );
 
           if (targetHint) {
@@ -70,7 +70,7 @@ export function pickOutputReferenceHintsFromComponent({
 
         iteratorHints = transformFormTreeToSmartHints(
           outputFormTree,
-          componentID
+          componentID,
         );
       }
     }

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.test.ts
@@ -125,7 +125,7 @@ test("should pick hints from non objectArray hints", () => {
 
   const pickHints = pickSmartHintsFromAcceptFormats(
     hints,
-    instillAcceptFormats
+    instillAcceptFormats,
   );
 
   expect(pickHints).toStrictEqual([

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromAcceptFormats.ts
@@ -2,7 +2,7 @@ import { SmartHint } from "./types";
 
 export function pickSmartHintsFromAcceptFormats(
   hints: SmartHint[],
-  instillAcceptFormats: string[]
+  instillAcceptFormats: string[],
 ): SmartHint[] {
   const pickHints: SmartHint[] = [];
 
@@ -20,7 +20,7 @@ export function pickSmartHintsFromAcceptFormats(
     if (hint.type === "array" && hint.properties) {
       const childPickHints = pickSmartHintsFromAcceptFormats(
         hint.properties,
-        instillAcceptFormats
+        instillAcceptFormats,
       );
 
       if (childPickHints.length > 0) {
@@ -124,7 +124,7 @@ export function pickSmartHintsFromAcceptFormats(
       if (
         type === "semi-structured" &&
         instillAcceptFormats.some((format) =>
-          format.includes("semi-structured")
+          format.includes("semi-structured"),
         )
       ) {
         pickHints.push(hint);

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromNodes.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromNodes.ts
@@ -40,7 +40,7 @@ export function pickSmartHintsFromNodes({
   for (const node of targetNodes) {
     if (isVariableNode(node)) {
       const hints = transformPipelineTriggerRequestFieldsToSmartHints(
-        node.data.fields
+        node.data.fields,
       );
 
       smartHints = [...smartHints, ...hints];
@@ -113,11 +113,12 @@ export function pickSmartHintsFromNodes({
                 transformInstillJSONSchemaToFormTree(outputSchema);
               const hints = transformFormTreeToSmartHints(
                 outputFormTree,
-                componentKey
+                componentKey,
               );
 
               const targetHint = hints.find(
-                (hint) => hint.path === value.replace("${", "").replace("}", "")
+                (hint) =>
+                  hint.path === value.replace("${", "").replace("}", ""),
               );
 
               if (targetHint) {
@@ -156,14 +157,14 @@ export function pickSmartHintsFromNodes({
   // Add the iterator element into the hints
   if (isEditingIterator && includeEditorElement && editingIteratorID) {
     const targetIteratorNode = tempSavedNodesForEditingIteratorFlow?.find(
-      (node) => node.id === editingIteratorID && isIteratorNode(node)
+      (node) => node.id === editingIteratorID && isIteratorNode(node),
     ) as Node<IteratorNodeData> | undefined;
 
     if (targetIteratorNode) {
       const targetHints = smartHints.find(
         (hint) =>
           hint.path ===
-          targetIteratorNode.data.input.replace("${", "").replace("}", "")
+          targetIteratorNode.data.input.replace("${", "").replace("}", ""),
       );
 
       if (targetHints) {

--- a/packages/toolkit/src/lib/use-smart-hint/transformFormTreeToSmartHints.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/transformFormTreeToSmartHints.ts
@@ -3,14 +3,14 @@ import { SmartHint } from "./types";
 
 export function transformFormTreeToSmartHints(
   tree: InstillFormTree,
-  componentNodeID: string
+  componentNodeID: string,
 ): SmartHint[] {
   let hints: SmartHint[] = [];
   if (tree._type === "formGroup") {
     tree.properties.map((property) => {
       const childHints = transformFormTreeToSmartHints(
         property,
-        componentNodeID
+        componentNodeID,
       );
       hints = [...hints, ...childHints];
     });
@@ -21,7 +21,7 @@ export function transformFormTreeToSmartHints(
   if (tree._type === "objectArray") {
     const objectHints = transformFormTreeToSmartHints(
       tree.properties,
-      componentNodeID
+      componentNodeID,
     );
 
     if (tree.path) {

--- a/packages/toolkit/src/lib/use-smart-hint/transformPipelineTriggerRequestFieldsToSmartHints.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/transformPipelineTriggerRequestFieldsToSmartHints.ts
@@ -2,7 +2,7 @@ import { PipelineVariableFieldMap } from "../vdp-sdk";
 import { SmartHint } from "./types";
 
 export function transformPipelineTriggerRequestFieldsToSmartHints(
-  fields: PipelineVariableFieldMap
+  fields: PipelineVariableFieldMap,
 ): SmartHint[] {
   const hints: SmartHint[] = [];
   for (const [key, value] of Object.entries(fields)) {

--- a/packages/toolkit/src/lib/vdp-sdk/connector/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/connector/queries.ts
@@ -42,7 +42,7 @@ export async function listConnectorDefinitionsQuery({
           accessToken,
           nextPageToken: data.nextPageToken,
           filter,
-        }))
+        })),
       );
     }
 
@@ -67,7 +67,7 @@ export async function getConnectorDefinitionQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetConnectorDefinitionResponse>(
-      `/${connectorDefinitionName}?view=VIEW_FULL`
+      `/${connectorDefinitionName}?view=VIEW_FULL`,
     );
 
     return Promise.resolve(data.connectorDefinition);

--- a/packages/toolkit/src/lib/vdp-sdk/helper/checkIsDefinition.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/helper/checkIsDefinition.ts
@@ -2,19 +2,19 @@ import { ConnectorDefinition } from "../connector";
 import { IteratorDefinition, OperatorDefinition } from "../pipeline";
 
 export function isConnectorDefinition(
-  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition
+  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition,
 ): definition is ConnectorDefinition {
   return "type" in definition;
 }
 
 export function isIteratorDefinition(
-  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition
+  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition,
 ): definition is IteratorDefinition {
   return definition.id === "iterator";
 }
 
 export function isOperatorDefinition(
-  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition
+  definition: IteratorDefinition | ConnectorDefinition | OperatorDefinition,
 ): definition is OperatorDefinition {
   return definition.name.startsWith("operator-definitions");
 }

--- a/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/helper/createInstillAxiosClient.ts
@@ -4,7 +4,7 @@ import { Nullable } from "../../type";
 
 export function createInstillAxiosClient(
   accessToken: Nullable<string>,
-  isModelEndpoint?: boolean
+  isModelEndpoint?: boolean,
 ) {
   const headers = accessToken
     ? {
@@ -23,7 +23,7 @@ export function createInstillAxiosClient(
     !env("NEXT_PUBLIC_API_GATEWAY_URL")
   ) {
     throw new Error(
-      "NEXT_SERVER_API_GATEWAY_URL or NEXT_PUBLIC_API_GATEWAY_URL is not defined"
+      "NEXT_SERVER_API_GATEWAY_URL or NEXT_PUBLIC_API_GATEWAY_URL is not defined",
     );
   }
 

--- a/packages/toolkit/src/lib/vdp-sdk/helper/getQueryString.test.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/helper/getQueryString.test.ts
@@ -15,7 +15,7 @@ test("baseURL contains no query string", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?pageSize=10&pageToken=nextPageToken&filter=filter=a"
+    "https://www.google.com?pageSize=10&pageToken=nextPageToken&filter=filter=a",
   );
 });
 
@@ -33,7 +33,7 @@ test("baseURL contains a query string", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?q=hello&pageSize=10&pageToken=nextPageToken&filter=filter=a"
+    "https://www.google.com?q=hello&pageSize=10&pageToken=nextPageToken&filter=filter=a",
   );
 });
 
@@ -51,7 +51,7 @@ test("pageSize is null", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?pageToken=nextPageToken&filter=filter=a"
+    "https://www.google.com?pageToken=nextPageToken&filter=filter=a",
   );
 });
 
@@ -69,7 +69,7 @@ test("nextPageToken is null", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?pageSize=10&filter=filter=a"
+    "https://www.google.com?pageSize=10&filter=filter=a",
   );
 });
 
@@ -87,7 +87,7 @@ test("filter is null", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?pageSize=10&pageToken=nextPageToken"
+    "https://www.google.com?pageSize=10&pageToken=nextPageToken",
   );
 });
 
@@ -185,7 +185,7 @@ test("baseURL contains a query string, pageSize and filter are null", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?q=hello&pageToken=nextPageToken"
+    "https://www.google.com?q=hello&pageToken=nextPageToken",
   );
 });
 
@@ -219,6 +219,6 @@ test("baseURL contains a query string, all other fields included", () => {
   });
 
   expect(queryString).toBe(
-    "https://www.google.com?q=hello&pageSize=10&pageToken=nextPageToken&filter=filter=a"
+    "https://www.google.com?q=hello&pageSize=10&pageToken=nextPageToken&filter=filter=a",
   );
 });

--- a/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/metric/pipeline/queries.ts
@@ -56,7 +56,7 @@ export async function listPipelineTriggerRecordsQuery({
           accessToken,
           nextPageToken: data.nextPageToken,
           filter,
-        }))
+        })),
       );
     }
 
@@ -100,7 +100,7 @@ export async function listTriggeredPipelineQuery({
           accessToken,
           nextPageToken: data.nextPageToken,
           filter,
-        }))
+        })),
       );
     }
 

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/actions.ts
@@ -35,7 +35,7 @@ export async function authLoginAction({
 
     const { data } = await client.post<AuthLoginActionResponse>(
       "/auth/login",
-      payload
+      payload,
     );
 
     return Promise.resolve(data.accessToken);
@@ -74,7 +74,7 @@ export async function checkNamespace({
       "/check-namespace",
       {
         id,
-      }
+      },
     );
     return Promise.resolve(data.type);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/mutations.ts
@@ -45,7 +45,7 @@ export async function createApiTokenMutation({
 
     const { data } = await client.post<CreateApiTokenResponse>(
       "/tokens",
-      payload
+      payload,
     );
 
     return Promise.resolve(data.token);

--- a/packages/toolkit/src/lib/vdp-sdk/mgmt/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/mgmt/queries.ts
@@ -36,7 +36,7 @@ export async function getAuthenticatedUserSubscriptionsQuery({
 
     const { data } =
       await client.get<GetAuthenticatedUserSubscriptionsResponse>(
-        "/user/subscription"
+        "/user/subscription",
       );
 
     return Promise.resolve(data.subscription);
@@ -131,7 +131,7 @@ export async function listApiTokensQuery({
           pageSize,
           accessToken,
           nextPageToken: data.nextPageToken,
-        }))
+        })),
       );
     }
 
@@ -170,7 +170,7 @@ export async function listUsersQuery({
           pageSize,
           accessToken,
           nextPageToken: data.nextPageToken,
-        }))
+        })),
       );
     }
 
@@ -197,7 +197,7 @@ export async function getRemainingCreditQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetRemainingCreditResponse>(
-      `/${ownerName}/credit`
+      `/${ownerName}/credit`,
     );
 
     return Promise.resolve(data);

--- a/packages/toolkit/src/lib/vdp-sdk/model/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/actions.ts
@@ -18,7 +18,7 @@ export async function deployUserModelAction({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.post<DeployUserModelResponse>(
-      `/${modelName}/deploy`
+      `/${modelName}/deploy`,
     );
     return Promise.resolve(data.modelId);
   } catch (err) {
@@ -41,7 +41,7 @@ export async function undeployUserModeleAction({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.post<UndeployUserModelResponse>(
-      `/${modelName}/undeploy`
+      `/${modelName}/undeploy`,
     );
     return Promise.resolve(data.modelId);
   } catch (err) {
@@ -82,7 +82,7 @@ export async function triggerUserModelAction({
         headers: {
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data);
   } catch (err) {
@@ -110,7 +110,7 @@ export async function triggerUserModelActionAsync({
         headers: {
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/model/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/mutations.ts
@@ -97,7 +97,7 @@ export async function createUserModelMutation({
 
     const { data } = await client.post<CreateUserModelResponse>(
       `/${entityName}/models`,
-      payload
+      payload,
     );
 
     return Promise.resolve(data.model);
@@ -124,7 +124,7 @@ export async function updateModelMutation({
 
     const { data } = await client.patch<UpdateUserModelResponse>(
       `/${name}`,
-      payload
+      payload,
     );
     return Promise.resolve(data.model);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/model/queries.ts
@@ -30,7 +30,7 @@ export async function getModelDefinitionQuery({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetModelDefinitionResponse>(
-      `/${modelDefinitionName}`
+      `/${modelDefinitionName}`,
     );
 
     return Promise.resolve(data.modelDefinition);
@@ -77,7 +77,7 @@ export async function listModelDefinitionsQuery({
           pageSize,
           accessToken,
           nextPageToken: data.nextPageToken,
-        }))
+        })),
       );
     }
 
@@ -106,7 +106,7 @@ export async function getUserModelQuery({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetUserModelResponse>(
-      `/${modelName}?view=VIEW_FULL`
+      `/${modelName}?view=VIEW_FULL`,
     );
     return Promise.resolve(data.model);
   } catch (err) {
@@ -158,17 +158,17 @@ export type ListModelVersionsResponse = {
 export async function listModelsQuery(
   props: listModelsQueryProps & {
     enablePagination: true;
-  }
+  },
 ): Promise<ListModelsResponse>;
 export async function listModelsQuery(
   props: listModelsQueryProps & {
     enablePagination: false;
-  }
+  },
 ): Promise<Model[]>;
 export async function listModelsQuery(
   props: listModelsQueryProps & {
     enablePagination: undefined;
-  }
+  },
 ): Promise<Model[]>;
 export async function listModelsQuery({
   pageSize,
@@ -214,7 +214,7 @@ export async function listModelsQuery({
           filter,
           visibility,
           orderBy,
-        }))
+        })),
       );
     }
 
@@ -227,17 +227,17 @@ export async function listModelsQuery({
 export async function listUserModelsQuery(
   props: listUserModelsQueryProps & {
     enablePagination: true;
-  }
+  },
 ): Promise<ListModelsResponse>;
 export async function listUserModelsQuery(
   props: listUserModelsQueryProps & {
     enablePagination: false;
-  }
+  },
 ): Promise<Model[]>;
 export async function listUserModelsQuery(
   props: listUserModelsQueryProps & {
     enablePagination: undefined;
-  }
+  },
 ): Promise<Model[]>;
 export async function listUserModelsQuery({
   userName,
@@ -283,7 +283,7 @@ export async function listUserModelsQuery({
           enablePagination: false,
           filter,
           visibility,
-        }))
+        })),
       );
     }
 
@@ -308,7 +308,7 @@ export async function getUserModelReadmeQuery({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetUserModelReadmeQueryResponse>(
-      `/${modelName}/readme`
+      `/${modelName}/readme`,
     );
     return Promise.resolve(data.readme);
   } catch (err) {
@@ -347,17 +347,17 @@ export async function listModelRegionsQuery({
 export async function listModelVersionsQuery(
   props: listUserModelVersionsQueryProps & {
     enablePagination: true;
-  }
+  },
 ): Promise<ListModelVersionsResponse>;
 export async function listModelVersionsQuery(
   props: listUserModelVersionsQueryProps & {
     enablePagination: false;
-  }
+  },
 ): Promise<ModelVersion[]>;
 export async function listModelVersionsQuery(
   props: listUserModelVersionsQueryProps & {
     enablePagination: undefined;
-  }
+  },
 ): Promise<ModelVersion[]>;
 export async function listModelVersionsQuery({
   accessToken,
@@ -394,7 +394,7 @@ export async function listModelVersionsQuery({
           page: data.page + 1,
           pageSize,
           enablePagination: false,
-        }))
+        })),
       );
     }
 
@@ -440,7 +440,7 @@ export async function getModelOperationResult({
   try {
     const client = createInstillAxiosClient(accessToken, true);
     const { data } = await client.get<ModelTriggerResult>(
-      `/${modelName}/operation${fullView ? "?view=VIEW_FULL" : ""}`
+      `/${modelName}/operation${fullView ? "?view=VIEW_FULL" : ""}`,
     );
     return Promise.resolve(data);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
@@ -17,7 +17,7 @@ export async function getOperationQuery({
     const client = createInstillAxiosClient(accessToken, true);
 
     const { data } = await client.get<GetModelOperationResponse>(
-      `/${operationName}`
+      `/${operationName}`,
     );
     return Promise.resolve(data.operation);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/organization/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/organization/mutations.ts
@@ -30,7 +30,7 @@ export async function createOrganizationMutation({
 
     const { data } = await client.post<CreateOrganizationResponse>(
       "/organizations",
-      payload
+      payload,
     );
 
     return Promise.resolve(data.organization);
@@ -63,7 +63,7 @@ export async function updateOrganizationMutation({
       {
         ...payload,
         id: undefined,
-      }
+      },
     );
 
     return Promise.resolve(data.organization);
@@ -98,7 +98,7 @@ export async function updateOrganizationMembershipMutation({
         ...payload,
         organizationID: undefined,
         userID: undefined,
-      }
+      },
     );
 
     return Promise.resolve(data.membership);
@@ -136,7 +136,7 @@ export async function deleteOrganizationMembershipMutation({
     const client = createInstillAxiosClient(accessToken);
 
     await client.delete(
-      `/organizations/${organizationID}/memberships/${userID}`
+      `/organizations/${organizationID}/memberships/${userID}`,
     );
   } catch (err) {
     return Promise.reject(err);
@@ -187,7 +187,7 @@ export async function updateUserMembershipMutation({
         ...payload,
         organizationID: undefined,
         userID: undefined,
-      }
+      },
     );
 
     return Promise.resolve(data.membership);

--- a/packages/toolkit/src/lib/vdp-sdk/organization/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/organization/queries.ts
@@ -46,7 +46,7 @@ export async function listOrganizationsQuery({
           accessToken,
           nextPageToken: data.nextPageToken,
           filter,
-        }))
+        })),
       );
     }
 
@@ -71,7 +71,7 @@ export async function getOrganizationQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationResponse>(
-      `/organizations/${organizationID}`
+      `/organizations/${organizationID}`,
     );
 
     return Promise.resolve(data.organization);
@@ -95,7 +95,7 @@ export async function getOrganizationSubscriptionQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationSubscriptionResponse>(
-      `/organizations/${organizationID}/subscription`
+      `/organizations/${organizationID}/subscription`,
     );
 
     return Promise.resolve(data.subscription);
@@ -119,7 +119,7 @@ export async function getOrganizationMembershipsQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationMembershipsResponse>(
-      `/organizations/${organizationID}/memberships`
+      `/organizations/${organizationID}/memberships`,
     );
 
     return Promise.resolve(data.memberships);
@@ -145,7 +145,7 @@ export async function getOrganizationMembershipQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOrganizationMembershipResponse>(
-      `/organizations/${organizationID}/memberships/${userID}`
+      `/organizations/${organizationID}/memberships/${userID}`,
     );
 
     return Promise.resolve(data.membership);
@@ -169,7 +169,7 @@ export async function getUserMembershipsQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserMembershipsResponse>(
-      `users/${userID}/memberships`
+      `users/${userID}/memberships`,
     );
 
     return Promise.resolve(data.memberships);
@@ -195,7 +195,7 @@ export async function getUserMembershipQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserMembershipsResponse>(
-      `users/${userID}/memberships/${organizationID}`
+      `users/${userID}/memberships/${organizationID}`,
     );
 
     return Promise.resolve(data.memberships);

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/actions.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/actions.ts
@@ -41,7 +41,7 @@ export async function triggerUserPipelineAction({
             "instill-return-traces, instill-share-code",
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data);
   } catch (err) {
@@ -80,7 +80,7 @@ export async function triggerAsyncUserPipelineAction({
           "Access-Control-Allow-Headers": "instill-return-traces",
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data.operation);
   } catch (err) {
@@ -107,7 +107,7 @@ export async function setDefaultUserPipelineReleaseMutation({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<SetDefaultUserPipelineReleaseResponse>(
-      `/${pipelineReleaseName}/setDefault`
+      `/${pipelineReleaseName}/setDefault`,
     );
     return Promise.resolve(data.release);
   } catch (err) {
@@ -130,7 +130,7 @@ export async function restoreUserPipelineReleaseMutation({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.post<RestoreUserPipelineReleaseResponse>(
-      `/${pipelineReleaseName}/restore`
+      `/${pipelineReleaseName}/restore`,
     );
     return Promise.resolve(data.release);
   } catch (err) {
@@ -170,7 +170,7 @@ export async function triggerUserPipelineReleaseAction({
           "Access-Control-Allow-Headers": "instill-return-traces",
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data);
   } catch (err) {
@@ -209,7 +209,7 @@ export async function triggerAsyncUserPipelineReleaseAction({
           "Access-Control-Allow-Headers": "instill-return-traces",
           "Content-Type": "application/json",
         },
-      }
+      },
     );
     return Promise.resolve(data.operation);
   } catch (err) {

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/mutations.ts
@@ -35,7 +35,7 @@ export async function createUserPipelineMutation({
 
     const { data } = await client.post<CreatePipelineResponse>(
       `/${entityName}/pipelines`,
-      payload
+      payload,
     );
     return Promise.resolve(data.pipeline);
   } catch (err) {
@@ -68,7 +68,7 @@ export async function updateUserPipelineMutation({
 
     const { data } = await client.patch<UpdateUserPipelineResponse>(
       `/${payload.name}`,
-      payload
+      payload,
     );
     return Promise.resolve(data.pipeline);
   } catch (err) {
@@ -113,7 +113,7 @@ export async function renameUserPipelineMutation({
 
     const { data } = await client.post<RenameUserPipelineResponse>(
       `/${payload.name}/rename`,
-      payload
+      payload,
     );
 
     return Promise.resolve(data.pipeline);
@@ -150,7 +150,7 @@ export async function createUserPipelineReleaseMutation({
 
     const { data } = await client.post<CreateUserPipelineReleaseResponse>(
       `${pipelineName}/releases`,
-      payload
+      payload,
     );
 
     return Promise.resolve(data.release);
@@ -182,7 +182,7 @@ export async function updateUserPipelineReleaseMutation({
 
     const { data } = await client.patch<UpdateUserPipelineReleaseResponse>(
       `/${pipelineReleaseName}`,
-      payload
+      payload,
     );
     return Promise.resolve(data.release);
   } catch (err) {
@@ -230,7 +230,7 @@ export async function createUserSecretMutation({
 
     const { data } = await client.post<CreateUserSecretResponse>(
       `/${entityName}/secrets`,
-      payload
+      payload,
     );
 
     return Promise.resolve(data.secret);
@@ -276,7 +276,7 @@ export async function cloneNamespacePipelineMutation({
 
     const { data } = await client.post<CloneNamespacePipelineResponse>(
       `/${payload.pipelineName}/clone`,
-      payload
+      payload,
     );
 
     return Promise.resolve(data.pipeline);

--- a/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/pipeline/queries.ts
@@ -28,22 +28,22 @@ export type listPipelinesQueryParams = {
 export async function listPipelinesQuery(
   props: listPipelinesQueryParams & {
     enablePagination: true;
-  }
+  },
 ): Promise<ListPipelinesResponse>;
 export async function listPipelinesQuery(
   props: listPipelinesQueryParams & {
     enablePagination: false;
-  }
+  },
 ): Promise<Pipeline[]>;
 export async function listPipelinesQuery(
   props: listPipelinesQueryParams & {
     enablePagination: undefined;
-  }
+  },
 ): Promise<Pipeline[]>;
 export async function listPipelinesQuery(
   props: listPipelinesQueryParams & {
     enablePagination?: boolean;
-  }
+  },
 ) {
   const {
     pageSize,
@@ -88,7 +88,7 @@ export async function listPipelinesQuery(
           visibility,
           orderBy,
           disabledViewFull,
-        }))
+        })),
       );
     }
 
@@ -117,22 +117,22 @@ export type listUserPipelinesQueryProps = {
 export async function listUserPipelinesQuery(
   props: listUserPipelinesQueryProps & {
     enablePagination: true;
-  }
+  },
 ): Promise<ListUserPipelinesResponse>;
 export async function listUserPipelinesQuery(
   props: listUserPipelinesQueryProps & {
     enablePagination: false;
-  }
+  },
 ): Promise<Pipeline[]>;
 export async function listUserPipelinesQuery(
   props: listUserPipelinesQueryProps & {
     enablePagination: undefined;
-  }
+  },
 ): Promise<Pipeline[]>;
 export async function listUserPipelinesQuery(
   props: listUserPipelinesQueryProps & {
     enablePagination?: boolean;
-  }
+  },
 ) {
   const {
     pageSize,
@@ -176,7 +176,7 @@ export async function listUserPipelinesQuery(
           enablePagination: false,
           filter,
           visibility,
-        }))
+        })),
       );
     }
 
@@ -212,7 +212,7 @@ export async function getUserPipelineQuery({
             : undefined,
           "Content-Type": "application/json",
         },
-      }
+      },
     );
 
     return Promise.resolve(data.pipeline);
@@ -265,7 +265,7 @@ export async function ListUserPipelineReleasesQuery({
             : undefined,
           "Content-Type": "application/json",
         },
-      }
+      },
     );
 
     releases.push(...data.releases);
@@ -278,7 +278,7 @@ export async function ListUserPipelineReleasesQuery({
           nextPageToken: data.nextPageToken,
           accessToken,
           shareCode,
-        }))
+        })),
       );
     }
 
@@ -303,7 +303,7 @@ export async function getUserPipelineReleaseQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetUserPipelineReleaseResponse>(
-      `/${pipelineReleaseName}?view=VIEW_FULL`
+      `/${pipelineReleaseName}?view=VIEW_FULL`,
     );
 
     return Promise.resolve(data.release);
@@ -326,7 +326,7 @@ export async function watchUserPipelineReleaseQuery({
   try {
     const client = createInstillAxiosClient(accessToken);
     const { data } = await client.get<WatchUserPipelineReleaseResponse>(
-      `/${pipelineReleaseName}/watch`
+      `/${pipelineReleaseName}/watch`,
     );
     return Promise.resolve(data.state);
   } catch (err) {
@@ -378,7 +378,7 @@ export async function listOperatorDefinitionsQuery({
           accessToken,
           nextPageToken: data.nextPageToken,
           filter,
-        }))
+        })),
       );
     }
 
@@ -403,7 +403,7 @@ export async function getOperatorDefinitionQuery({
     const client = createInstillAxiosClient(accessToken);
 
     const { data } = await client.get<GetOperatorDefinitionResponse>(
-      `/${operatorDefinitionName}?view=VIEW_FULL`
+      `/${operatorDefinitionName}?view=VIEW_FULL`,
     );
 
     return Promise.resolve(data.operator_definition);
@@ -476,7 +476,7 @@ export async function listUserSecretsQuery({
           pageSize,
           accessToken,
           nextPageToken: data.nextPageToken,
-        }))
+        })),
       );
     }
 

--- a/packages/toolkit/src/server/utility/getHumanReadableStringFromTime/getHumanReadableStringFromTime.test.ts
+++ b/packages/toolkit/src/server/utility/getHumanReadableStringFromTime/getHumanReadableStringFromTime.test.ts
@@ -5,7 +5,7 @@ describe("test getTimeAgo", () => {
   test("should return 1 second ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T00:00:01"
+      "1995-12-01T00:00:01",
     );
     expect(result).toBe("a second ago");
   });
@@ -13,7 +13,7 @@ describe("test getTimeAgo", () => {
   test("should return x seconds ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T00:00:10"
+      "1995-12-01T00:00:10",
     );
     expect(result).toBe("10 seconds ago");
   });
@@ -21,12 +21,12 @@ describe("test getTimeAgo", () => {
   test("should return 1 minute ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T00:01:00"
+      "1995-12-01T00:01:00",
     );
     expect(result).toBe("a minute ago");
     const result2 = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T00:01:01"
+      "1995-12-01T00:01:01",
     );
     expect(result2).toBe("a minute ago");
   });
@@ -34,7 +34,7 @@ describe("test getTimeAgo", () => {
   test("should return x minutes ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T00:02:00"
+      "1995-12-01T00:02:00",
     );
     expect(result).toBe("2 minutes ago");
   });
@@ -42,12 +42,12 @@ describe("test getTimeAgo", () => {
   test("should return an hour ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T01:00:00"
+      "1995-12-01T01:00:00",
     );
     expect(result).toBe("an hour ago");
     const result2 = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T01:01:00"
+      "1995-12-01T01:01:00",
     );
     expect(result2).toBe("an hour ago");
   });
@@ -55,7 +55,7 @@ describe("test getTimeAgo", () => {
   test("should return x hours ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-01T10:00:00"
+      "1995-12-01T10:00:00",
     );
     expect(result).toBe("10 hours ago");
   });
@@ -63,12 +63,12 @@ describe("test getTimeAgo", () => {
   test("should return yesterday", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-02T00:00:00"
+      "1995-12-02T00:00:00",
     );
     expect(result).toBe("yesterday");
     const result2 = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-02T00:02:00"
+      "1995-12-02T00:02:00",
     );
     expect(result2).toBe("yesterday");
   });
@@ -76,7 +76,7 @@ describe("test getTimeAgo", () => {
   test("should return x days ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1995-12-10T00:00:00"
+      "1995-12-10T00:00:00",
     );
     expect(result).toBe("9 days ago");
   });
@@ -84,12 +84,12 @@ describe("test getTimeAgo", () => {
   test("should return 1 month ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1996-01-01T00:00:00"
+      "1996-01-01T00:00:00",
     );
     expect(result).toBe("last month");
     const result2 = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1996-01-10T00:00:00"
+      "1996-01-10T00:00:00",
     );
     expect(result2).toBe("last month");
   });
@@ -97,7 +97,7 @@ describe("test getTimeAgo", () => {
   test("should return x months ago", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1996-03-01T00:00:00"
+      "1996-03-01T00:00:00",
     );
     expect(result).toBe("3 months ago");
   });
@@ -105,7 +105,7 @@ describe("test getTimeAgo", () => {
   test("should return Date string", () => {
     const result = getHumanReadableStringFromTime(
       "1995-12-01T00:00:00",
-      "1997-03-01T00:00:00"
+      "1997-03-01T00:00:00",
     );
     expect(result).toBe("Fri Dec 01 1995");
   });

--- a/packages/toolkit/src/server/utility/getHumanReadableStringFromTime/getHumanReadableStringFromTime.ts
+++ b/packages/toolkit/src/server/utility/getHumanReadableStringFromTime/getHumanReadableStringFromTime.ts
@@ -3,7 +3,7 @@
  */
 export function getHumanReadableStringFromTime(
   prevTime: string,
-  nextTime: string | number
+  nextTime: string | number,
 ) {
   const prev = Date.parse(prevTime) / 1000;
 

--- a/packages/toolkit/src/server/utility/groupBy.ts
+++ b/packages/toolkit/src/server/utility/groupBy.ts
@@ -6,7 +6,7 @@
 
 export function groupBy<T, K extends keyof any>(
   list: T[],
-  getKey: (item: T) => K
+  getKey: (item: T) => K,
 ) {
   return list.reduce(
     (previous, currentItem) => {
@@ -15,6 +15,6 @@ export function groupBy<T, K extends keyof any>(
       previous[group].push(currentItem);
       return previous;
     },
-    {} as Record<K, T[]>
+    {} as Record<K, T[]>,
   );
 }

--- a/packages/toolkit/src/server/utility/handle.ts
+++ b/packages/toolkit/src/server/utility/handle.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 export async function handle<T>(
   promise: Promise<T>,
-  defaultError: any = "rejected"
+  defaultError: any = "rejected",
 ): Promise<readonly [undefined, T] | readonly [any, undefined]> {
   return promise
     .then((data) => {

--- a/packages/toolkit/src/view/airbyte/AirbyteDestinationFields.tsx
+++ b/packages/toolkit/src/view/airbyte/AirbyteDestinationFields.tsx
@@ -46,7 +46,7 @@ export const AirbyteDestinationFields = ({
     selectedConditionMap,
     setSelectedConditionMap,
     formIsDirty,
-    setFormIsDirty
+    setFormIsDirty,
   );
 
   return <React.Fragment>{fields}</React.Fragment>;

--- a/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
+++ b/packages/toolkit/src/view/airbyte/OneOfConditionSection.tsx
@@ -147,7 +147,7 @@ export const OneOfConditionSection = ({
     ) {
       const selectedCondition =
         conditionOptions.find(
-          (e) => e.label === selectedConditionMap[formTree.path].selectedItem
+          (e) => e.label === selectedConditionMap[formTree.path].selectedItem,
         ) || null;
       setSelectedConditionOption(selectedCondition);
     }
@@ -162,7 +162,7 @@ export const OneOfConditionSection = ({
         setSelectedConditionOption(option);
 
         const targetConstField = selectedCondition.properties.find(
-          (e) => "const" in e
+          (e) => "const" in e,
         ) as AirbyteFormItem;
 
         if (targetConstField) {
@@ -171,7 +171,7 @@ export const OneOfConditionSection = ({
             dot.setter(
               configuration,
               targetConstField.path,
-              targetConstField.const
+              targetConstField.const,
             );
             return {
               ...prev,
@@ -221,7 +221,7 @@ export const OneOfConditionSection = ({
       formTree.conditions,
       setFormIsDirty,
       conditionOptions,
-    ]
+    ],
   );
 
   return (

--- a/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
+++ b/packages/toolkit/src/view/airbyte/useBuildAirbyteFields.tsx
@@ -30,7 +30,7 @@ export const useBuildAirbyteFields = (
     React.SetStateAction<Nullable<SelectedItemMap>>
   >,
   formIsDirty: boolean,
-  setFormIsDirty: React.Dispatch<React.SetStateAction<boolean>>
+  setFormIsDirty: React.Dispatch<React.SetStateAction<boolean>>,
 ) => {
   const fields = React.useMemo(() => {
     if (!formTree) return null;
@@ -43,7 +43,7 @@ export const useBuildAirbyteFields = (
       selectedConditionMap,
       setSelectedConditionMap,
       formIsDirty,
-      setFormIsDirty
+      setFormIsDirty,
     );
   }, [
     formTree,
@@ -71,7 +71,7 @@ export const pickComponent = (
     React.SetStateAction<Nullable<SelectedItemMap>>
   >,
   formIsDirty: boolean,
-  setFormIsDirty: React.Dispatch<React.SetStateAction<boolean>>
+  setFormIsDirty: React.Dispatch<React.SetStateAction<boolean>>,
 ): React.ReactNode => {
   if (formTree._type === "formGroup") {
     return (
@@ -86,8 +86,8 @@ export const pickComponent = (
             selectedConditionMap,
             setSelectedConditionMap,
             formIsDirty,
-            setFormIsDirty
-          )
+            setFormIsDirty,
+          ),
         )}
       </React.Fragment>
     );
@@ -110,11 +110,11 @@ export const pickComponent = (
                 selectedConditionMap,
                 setSelectedConditionMap,
                 formIsDirty,
-                setFormIsDirty
+                setFormIsDirty,
               ),
             },
           ];
-        })
+        }),
       );
 
     return (
@@ -142,7 +142,7 @@ export const pickComponent = (
       selectedConditionMap,
       setSelectedConditionMap,
       formIsDirty,
-      setFormIsDirty
+      setFormIsDirty,
     );
   }
 
@@ -371,7 +371,7 @@ export const pickComponent = (
           dot.setter(
             configuration,
             formTree.path,
-            inputType === "number" ? parseInt(value) : value
+            inputType === "number" ? parseInt(value) : value,
           );
           return {
             ...prev,
@@ -391,7 +391,7 @@ export const pickComponent = (
 };
 
 const getPlaceholder = (
-  formTree: AirbyteFormGroupItem | AirbyteFormItem
+  formTree: AirbyteFormGroupItem | AirbyteFormItem,
 ): string | null => {
   let placeholder: string | null;
 

--- a/packages/toolkit/src/view/dashboard/DashboardPipelineDetailsPageMainView.tsx
+++ b/packages/toolkit/src/view/dashboard/DashboardPipelineDetailsPageMainView.tsx
@@ -22,7 +22,7 @@ import { useParams } from "next/navigation";
 export type DashboardPipelineDetailsPageMainViewProps = GeneralAppPageProp;
 
 export const DashboardPipelineDetailsPageMainView = (
-  props: DashboardPipelineDetailsPageMainViewProps
+  props: DashboardPipelineDetailsPageMainViewProps,
 ) => {
   const { accessToken, enableQuery, router } = props;
   const { id } = useParams();
@@ -55,15 +55,15 @@ export const DashboardPipelineDetailsPageMainView = (
       const start = getTimeInRFC3339Format(
         selectedTimeOption.value === "24h"
           ? "todayStart"
-          : selectedTimeOption.value
+          : selectedTimeOption.value,
       );
       const stop = getTimeInRFC3339Format(
-        selectedTimeOption?.value === "1d" ? "todayStart" : "now"
+        selectedTimeOption?.value === "1d" ? "todayStart" : "now",
       );
       const previousTime = getTimeInRFC3339Format(
         getPreviousTimeframe(
-          selectedTimeOption.value as DashboardAvailableTimeframe
-        )
+          selectedTimeOption.value as DashboardAvailableTimeframe,
+        ),
       );
       queryParams += ` AND start='${start}' AND stop='${stop}'`;
       queryParamsPrevious += ` AND start='${previousTime}' AND stop='${start}'`;
@@ -113,7 +113,7 @@ export const DashboardPipelineDetailsPageMainView = (
 
     return getTriggersSummary(
       pipelineTriggerRecords.data,
-      previousPipelineTriggerRecords.data
+      previousPipelineTriggerRecords.data,
     );
   }, [
     pipelineTriggerRecords.isSuccess,

--- a/packages/toolkit/src/view/dashboard/DashboardPipelineListPageMainView.tsx
+++ b/packages/toolkit/src/view/dashboard/DashboardPipelineListPageMainView.tsx
@@ -24,7 +24,7 @@ import { DashboardPipelinesTable } from "./DashboardPipelinesTable";
 export type DashboardPipelineListPageMainViewProps = GeneralAppPageProp;
 
 export const DashboardPipelineListPageMainView = (
-  props: DashboardPipelineListPageMainViewProps
+  props: DashboardPipelineListPageMainViewProps,
 ) => {
   const { accessToken, enableQuery, router } = props;
 
@@ -52,15 +52,15 @@ export const DashboardPipelineListPageMainView = (
       const start = getTimeInRFC3339Format(
         selectedTimeOption.value === "24h"
           ? "todayStart"
-          : selectedTimeOption.value
+          : selectedTimeOption.value,
       );
       const stop = getTimeInRFC3339Format(
-        selectedTimeOption?.value === "1d" ? "todayStart" : "now"
+        selectedTimeOption?.value === "1d" ? "todayStart" : "now",
       );
       const previousTime = getTimeInRFC3339Format(
         getPreviousTimeframe(
-          selectedTimeOption.value as DashboardAvailableTimeframe
-        )
+          selectedTimeOption.value as DashboardAvailableTimeframe,
+        ),
       );
 
       queryParams += ` AND start='${start}' AND stop='${stop}'`;
@@ -140,14 +140,14 @@ export const DashboardPipelineListPageMainView = (
     }
 
     const triggeredPipelineIdList = triggeredPipelineList.map(
-      (e) => e.pipelineId
+      (e) => e.pipelineId,
     );
 
     return getPipelineTriggersSummary(
       triggeredPipelineList,
       previoustriggeredPipelines.data.filter((trigger) =>
-        triggeredPipelineIdList.includes(trigger.pipelineId)
-      )
+        triggeredPipelineIdList.includes(trigger.pipelineId),
+      ),
     );
   }, [
     previoustriggeredPipelines.isSuccess,

--- a/packages/toolkit/src/view/dashboard/DashboardPipelinesTable.tsx
+++ b/packages/toolkit/src/view/dashboard/DashboardPipelinesTable.tsx
@@ -16,7 +16,7 @@ export type DashboardPipelinesTableProps = {
 };
 
 export const DashboardPipelinesTable = (
-  props: DashboardPipelinesTableProps
+  props: DashboardPipelinesTableProps,
 ) => {
   const { entity, days } = useParams();
   const { pipelineTriggerCounts, isError, isLoading } = props;
@@ -36,7 +36,7 @@ export const DashboardPipelinesTable = (
             /> */}
             <Link
               href={`/${entity}/dashboard/pipeline/${row.getValue(
-                "pipelineId"
+                "pipelineId",
               )}${days ? "?days=" + days : ""}`}
             >
               {row.getValue("pipelineId")}

--- a/packages/toolkit/src/view/dashboard/FilterByDay.tsx
+++ b/packages/toolkit/src/view/dashboard/FilterByDay.tsx
@@ -27,7 +27,7 @@ export const FilterByDay = ({
   React.useEffect(() => {
     if (days) {
       const timeLineOption = dashboardOptions.timeLine.find(
-        (timeLineOption) => timeLineOption.value === days
+        (timeLineOption) => timeLineOption.value === days,
       );
       if (timeLineOption) {
         setSelectedTimeOption(timeLineOption);
@@ -47,7 +47,7 @@ export const FilterByDay = ({
               "my-auto flex !h-10 cursor-pointer items-center justify-center self-stretch !px-4 !py-1 outline outline-1 outline-semantic-bg-line first:rounded-l-sm last:rounded-r-sm hover:bg-semantic-bg-secondary",
               timeLineOption.value === selectedTimeOption?.value
                 ? "bg-semantic-bg-line"
-                : "bg-white"
+                : "bg-white",
             )}
             onClick={() => {
               setSelectedTimeOption(timeLineOption);
@@ -55,7 +55,7 @@ export const FilterByDay = ({
                 `${
                   new URL(pathname, env("NEXT_PUBLIC_CONSOLE_BASE_URL"))
                     .pathname
-                }?days=${timeLineOption.value}`
+                }?days=${timeLineOption.value}`,
               );
             }}
           >

--- a/packages/toolkit/src/view/dashboard/PipelineTriggerCountsLineChart.tsx
+++ b/packages/toolkit/src/view/dashboard/PipelineTriggerCountsLineChart.tsx
@@ -41,7 +41,7 @@ export const PipelineTriggerCountsLineChart = ({
   const chartRef = useRef<HTMLDivElement>(null);
   const { xAxis, yAxis } = generateChartData(
     pipelines,
-    selectedTimeOption.value
+    selectedTimeOption.value,
   );
 
   const xAxisData = xAxis;

--- a/packages/toolkit/src/view/dashboard/PipelineTriggersSummary.tsx
+++ b/packages/toolkit/src/view/dashboard/PipelineTriggersSummary.tsx
@@ -79,7 +79,7 @@ export type PipelineTriggersSummaryProps = {
 };
 
 export const PipelineTriggersSummary = (
-  props: PipelineTriggersSummaryProps
+  props: PipelineTriggersSummaryProps,
 ) => {
   const { children } = props;
 

--- a/packages/toolkit/src/view/dashboard/PipelineTriggersTable.tsx
+++ b/packages/toolkit/src/view/dashboard/PipelineTriggersTable.tsx
@@ -71,7 +71,7 @@ export const PipelineTriggersTable = (props: PipelineTriggersTableProps) => {
         return (
           <div className="truncate text-center text-semantic-fg-secondary product-body-text-3-regular">
             {convertToSecondsAndMilliseconds(
-              row.getValue("computeTimeDuration")
+              row.getValue("computeTimeDuration"),
             )}
           </div>
         );

--- a/packages/toolkit/src/view/dashboard/TriggersTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/dashboard/TriggersTablePlaceholder.tsx
@@ -12,7 +12,7 @@ export type TriggersTablePlaceholderProps = Pick<
 >;
 
 export const TriggersTablePlaceholder = (
-  props: TriggersTablePlaceholderProps
+  props: TriggersTablePlaceholderProps,
 ) => {
   const { marginBottom, enableCreateButton } = props;
   const width = "w-[136px]";

--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -120,7 +120,7 @@ export const CreateModelForm = () => {
       if (!form.getValues("hardware")) {
         form.setValue(
           "hardware",
-          hardwareOptions[regionOptions[0].value][0].value
+          hardwareOptions[regionOptions[0].value][0].value,
         );
       }
     }
@@ -147,7 +147,7 @@ export const CreateModelForm = () => {
         .filter((item) =>
           currentEnv === "CE"
             ? item.regionName === "REGION_LOCAL"
-            : item.regionName !== "REGION_LOCAL"
+            : item.regionName !== "REGION_LOCAL",
         )
         .map((item) => ({
           value: item.regionName,
@@ -192,7 +192,7 @@ export const CreateModelForm = () => {
     };
 
     const targetNamespace = userNamespaces.find(
-      (namespace) => namespace.id === data.namespaceId
+      (namespace) => namespace.id === data.namespaceId,
     );
 
     if (targetNamespace) {
@@ -389,7 +389,7 @@ export const CreateModelForm = () => {
               />
               <RadioGroup.Root
                 onValueChange={(
-                  value: Exclude<Visibility, "VISIBILITY_UNSPECIFIED">
+                  value: Exclude<Visibility, "VISIBILITY_UNSPECIFIED">,
                 ) => {
                   form.setValue("visibility", value);
                 }}
@@ -458,7 +458,7 @@ export const CreateModelForm = () => {
                             if (Object.keys(hardwareOptions).length) {
                               form.setValue(
                                 "hardware",
-                                hardwareOptions[value][0].value
+                                hardwareOptions[value][0].value,
                               );
                             }
                             {

--- a/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
+++ b/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
@@ -16,7 +16,7 @@ import { ModelsListPagination } from "./ModelsListPagination";
 export type ModelHubListPageMainViewProps = GeneralAppPageProp;
 
 export const ModelHubListPageMainView = (
-  props: ModelHubListPageMainViewProps
+  props: ModelHubListPageMainViewProps,
 ) => {
   const { router, enableQuery, accessToken } = props;
   const searchParams = useSearchParams();
@@ -31,14 +31,14 @@ export const ModelHubListPageMainView = (
       debounce((value: string) => {
         setSearchCode(value);
       }, 300),
-    []
+    [],
   );
 
   const [selectedVisibilityOption, setSelectedVisibilityOption] =
     React.useState<Visibility>(
       visibility === "VISIBILITY_PUBLIC"
         ? "VISIBILITY_PUBLIC"
-        : "VISIBILITY_UNSPECIFIED"
+        : "VISIBILITY_UNSPECIFIED",
     );
 
   useEffect(() => {

--- a/packages/toolkit/src/view/model/ModelHubSettingPageMainView.tsx
+++ b/packages/toolkit/src/view/model/ModelHubSettingPageMainView.tsx
@@ -15,7 +15,7 @@ import { ModelTabNames } from "../../server";
 export type ModelHubSettingPageMainViewProps = GeneralAppPageProp;
 
 export const ModelHubSettingPageMainView = (
-  props: ModelHubSettingPageMainViewProps
+  props: ModelHubSettingPageMainViewProps,
 ) => {
   const router = useRouter();
   const routeInfo = useRouteInfo();
@@ -25,7 +25,7 @@ export const ModelHubSettingPageMainView = (
 
   const setSelectedTab = (tabName: ModelTabNames) => {
     router.replace(
-      `/${routeInfo.data.namespaceId}/models/${model.data?.id}/${tabName}`
+      `/${routeInfo.data.namespaceId}/models/${model.data?.id}/${tabName}`,
     );
   };
 

--- a/packages/toolkit/src/view/model/ModelsList.tsx
+++ b/packages/toolkit/src/view/model/ModelsList.tsx
@@ -65,7 +65,7 @@ export const ModelsList = (props: ModelsListProps) => {
     <div
       className={cn(
         "mb-4 flex flex-col gap-y-4",
-        isEmpty ? "items-center justify-center" : null
+        isEmpty ? "items-center justify-center" : null,
       )}
     >
       {isLoading ? (

--- a/packages/toolkit/src/view/model/ModelsTable.tsx
+++ b/packages/toolkit/src/view/model/ModelsTable.tsx
@@ -45,7 +45,7 @@ export const ModelsTable = (props: ModelsTableProps) => {
       header: () => <div className="min-w-[500px] text-left">ID</div>,
       cell: ({ row }) => {
         const { getIcon, label } = getModelInstanceTaskToolkit(
-          row.original.task
+          row.original.task,
         );
 
         const modelNameFragments = row.original.name.split("/");
@@ -59,7 +59,7 @@ export const ModelsTable = (props: ModelsTableProps) => {
               secondaryLink={null}
               secondaryText={label}
               iconElement={getIcon(
-                `w-4 h-4 ${["TASK_TEXT_GENERATION_CHAT", "TASK_IMAGE_TO_IMAGE", "TASK_VISUAL_QUESTION_ANSWERING"].includes(row.original.task || "") ? "stroke-semantic-fg-primary [&>*]:!stroke-semantic-fg-primary" : "[&>*]:!fill-semantic-fg-primary"}`
+                `w-4 h-4 ${["TASK_TEXT_GENERATION_CHAT", "TASK_IMAGE_TO_IMAGE", "TASK_VISUAL_QUESTION_ANSWERING"].includes(row.original.task || "") ? "stroke-semantic-fg-primary [&>*]:!stroke-semantic-fg-primary" : "[&>*]:!fill-semantic-fg-primary"}`,
               )}
             />
           </div>

--- a/packages/toolkit/src/view/model/view-model/ModelHead.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelHead.tsx
@@ -160,7 +160,7 @@ export const ModelSettingsHead = ({
               size="sm"
             >
               {task.getIcon(
-                `w-3 h-3 ${["TASK_TEXT_GENERATION_CHAT", "TASK_IMAGE_TO_IMAGE", "TASK_VISUAL_QUESTION_ANSWERING"].includes(model?.task || "") ? "stroke-semantic-secondary-on-bg [&>*]:!stroke-semantic-secondary-on-bg" : "[&>*]:!fill-semantic-secondary-on-bg"}`
+                `w-3 h-3 ${["TASK_TEXT_GENERATION_CHAT", "TASK_IMAGE_TO_IMAGE", "TASK_VISUAL_QUESTION_ANSWERING"].includes(model?.task || "") ? "stroke-semantic-secondary-on-bg [&>*]:!stroke-semantic-secondary-on-bg" : "[&>*]:!fill-semantic-secondary-on-bg"}`,
               )}
               {task.label}
             </Tag>

--- a/packages/toolkit/src/view/model/view-model/ModelOverview.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelOverview.tsx
@@ -53,7 +53,7 @@ const convertTaskNameToPayloadPropName = (taskName?: ModelTask) =>
         // This removes "TASK_" and replaces "_" with a space. The first
         // argument has and OR operator for matching both substrings. The second
         // argument is a function with a condition.
-        taskName.replace(/TASK_|_/g, (d) => (d === "TASK_" ? "" : " "))
+        taskName.replace(/TASK_|_/g, (d) => (d === "TASK_" ? "" : " ")),
       )
     : null;
 
@@ -79,7 +79,7 @@ export const ModelOverview = ({ model, modelState }: ModelOverviewProps) => {
     useState<ModelOutputActiveView>("preview");
   const taskPropName = useMemo(
     () => convertTaskNameToPayloadPropName(model?.task),
-    [model]
+    [model],
   );
   const [modelRunResult, setModelRunResult] = useState<Record<
     string,
@@ -109,7 +109,7 @@ export const ModelOverview = ({ model, modelState }: ModelOverviewProps) => {
     inputFromExistingResult,
     {
       disabledAll: !isModelTriggerable,
-    }
+    },
   );
 
   const existingModelTriggerResult = useLastModelTriggerResult({
@@ -184,16 +184,16 @@ export const ModelOverview = ({ model, modelState }: ModelOverviewProps) => {
       !modelRunResult
     ) {
       const taskPropName = convertTaskNameToPayloadPropName(
-        model.task
+        model.task,
       ) as string;
 
       setInputFromExistingResult(
         convertValuesToString(
-          existingTriggerState.response.request.taskInputs[0][taskPropName]
-        )
+          existingTriggerState.response.request.taskInputs[0][taskPropName],
+        ),
       );
       setModelRunResult(
-        existingTriggerState.response.response.taskOutputs[0][taskPropName]
+        existingTriggerState.response.response.taskOutputs[0][taskPropName],
       );
     }
   }, [
@@ -211,7 +211,7 @@ export const ModelOverview = ({ model, modelState }: ModelOverviewProps) => {
   const triggerModel = useTriggerUserModelAsync();
 
   async function onRunModel(
-    formData: Record<string, unknown> /* z.infer<typeof Schema> */
+    formData: Record<string, unknown> /* z.infer<typeof Schema> */,
   ) {
     if (!model || !model.name || !taskPropName) return;
 
@@ -230,7 +230,7 @@ export const ModelOverview = ({ model, modelState }: ModelOverviewProps) => {
     setIsModelRunInProgress(true);
 
     const input = recursiveHelpers.removeUndefinedAndNullFromArray(
-      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(parsedData)
+      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(parsedData),
     );
 
     const parsedStructuredData: GeneralRecord = input;

--- a/packages/toolkit/src/view/model/view-model/ModelSettingsEditForm.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelSettingsEditForm.tsx
@@ -93,7 +93,7 @@ export const ModelSettingsEditForm = ({
             title: getModelHardwareToolkit(hardwareName) || "Unknown",
           },
         ],
-        []
+        [],
       );
   }, [modelRegions, model]);
 
@@ -293,7 +293,7 @@ export const ModelSettingsEditForm = ({
             />
             <RadioGroup.Root
               onValueChange={(
-                value: Exclude<Visibility, "VISIBILITY_UNSPECIFIED">
+                value: Exclude<Visibility, "VISIBILITY_UNSPECIFIED">,
               ) => {
                 form.setValue("visibility", value);
               }}

--- a/packages/toolkit/src/view/model/view-model/ModelVersions.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelVersions.tsx
@@ -69,7 +69,7 @@ export const ModelVersions = ({ model }: ModelVersionsProps) => {
           <div className="font-normal text-semantic-bg-secondary-alt-primary">
             {getHumanReadableStringFromTime(
               row.getValue("updateTime"),
-              Date.now()
+              Date.now(),
             )}
           </div>
         );
@@ -92,7 +92,7 @@ export const ModelVersions = ({ model }: ModelVersionsProps) => {
   const pageCount = useMemo(() => {
     if (versions.data?.pages[0]) {
       return Math.ceil(
-        versions.data.pages[0].totalSize / versions.data.pages[0].pageSize
+        versions.data.pages[0].totalSize / versions.data.pages[0].pageSize,
       );
     }
 
@@ -102,7 +102,7 @@ export const ModelVersions = ({ model }: ModelVersionsProps) => {
   const versionList = useMemo(() => {
     return versions.data?.pages.reduce(
       (acc: ModelVersion[], page) => [...acc, ...page.versions],
-      []
+      [],
     );
   }, [versions.data]);
 

--- a/packages/toolkit/src/view/model/view-model/SectionHeader.tsx
+++ b/packages/toolkit/src/view/model/view-model/SectionHeader.tsx
@@ -12,7 +12,7 @@ export const ModelSectionHeader = ({
     <h2
       className={cn(
         "min-w-full rounded bg-semantic-bg-base-bg px-3 py-2.5 text-lg font-medium leading-snug text-black",
-        className
+        className,
       )}
     >
       {children}

--- a/packages/toolkit/src/view/pipeline-builder/Flow.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/Flow.tsx
@@ -83,7 +83,7 @@ export const Flow = React.forwardRef<HTMLDivElement, FlowProps>(
         </div>
       </div>
     );
-  }
+  },
 );
 
 Flow.displayName = "Flow";

--- a/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
@@ -85,7 +85,7 @@ export const PipelineBuilderMainView = () => {
     if (!pipeline.isSuccess) return;
 
     updatePipelineOpenAPIOutputSchema(
-      () => pipeline.data.dataSpecification?.output ?? null
+      () => pipeline.data.dataSpecification?.output ?? null,
     );
   }, [pipeline.isSuccess, pipeline.data, updatePipelineOpenAPIOutputSchema]);
 
@@ -141,7 +141,9 @@ export const PipelineBuilderMainView = () => {
                 "fixed left-full w-[450px] transform overflow-y-scroll rounded-sm border border-semantic-bg-line bg-semantic-bg-primary p-6 shadow-sm duration-500",
                 "h-[calc(100vh-var(--topbar-controller-height)-var(--pipeline-builder-bottom-bar-height)-var(--pipeline-builder-minimap-height)-var(--pipeline-builder-top-right-controler-height)-calc(4*var(--pipeline-builder-controller-padding)))]",
                 "top-[calc(var(--topbar-controller-height)+var(--pipeline-builder-top-right-controler-height)+calc(2*var(--pipeline-builder-controller-padding)))]",
-                currentAdvancedConfigurationNodeID ? "-translate-x-[450px]" : ""
+                currentAdvancedConfigurationNodeID
+                  ? "-translate-x-[450px]"
+                  : "",
               )}
             >
               <RightPanel />

--- a/packages/toolkit/src/view/pipeline-builder/components/BackToLatestVersionTopBar.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/BackToLatestVersionTopBar.tsx
@@ -79,7 +79,7 @@ export const BackToLatestVersionTopBar = () => {
                 pipeline.data.recipe,
                 {
                   metadata: pipeline.data.metadata,
-                }
+                },
               );
               const edges = composeEdgesFromNodes(nodes);
 

--- a/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
@@ -116,14 +116,14 @@ export const BottomBar = () => {
                             pipeline.data.recipe,
                             {
                               metadata: pipeline.data.metadata,
-                            }
+                            },
                           );
                           const edges = composeEdgesFromNodes(nodes);
                           newNodes = nodes;
                           newEdges = edges;
                         } else {
                           const nodes = createNodesFromPipelineRecipe(
-                            pipeline.data.recipe
+                            pipeline.data.recipe,
                           );
                           const edges = composeEdgesFromNodes(nodes);
                           newNodes = nodes;
@@ -164,7 +164,7 @@ export const BottomBar = () => {
                               release.recipe,
                               {
                                 metadata: release.metadata,
-                              }
+                              },
                             );
                             const edges = composeEdgesFromNodes(nodes);
 
@@ -172,7 +172,7 @@ export const BottomBar = () => {
                             newEdges = edges;
                           } else {
                             const nodes = createNodesFromPipelineRecipe(
-                              release.recipe
+                              release.recipe,
                             );
                             const edges = composeEdgesFromNodes(nodes);
                             newNodes = nodes;
@@ -232,7 +232,7 @@ const VersionButton = ({
       key={id}
       className={cn(
         "w-full",
-        currentVersion === id ? "hover:!bg-semantic-accent-default" : ""
+        currentVersion === id ? "hover:!bg-semantic-accent-default" : "",
       )}
       variant={currentVersion === id ? "primary" : "tertiaryColour"}
       onClick={onClick}
@@ -243,7 +243,7 @@ const VersionButton = ({
             "w-full text-left product-body-text-3-medium",
             currentVersion === id
               ? "text-semantic-fg-on-default"
-              : "text-semantic-fg-secondary"
+              : "text-semantic-fg-secondary",
           )}
         >
           {id}
@@ -254,7 +254,7 @@ const VersionButton = ({
               "w-full text-left product-body-text-4-medium",
               currentVersion === id
                 ? "text-semantic-fg-on-default"
-                : "text-semantic-fg-disabled"
+                : "text-semantic-fg-disabled",
             )}
           >
             {getHumanReadableStringFromTime(createTime, Date.now())}

--- a/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputs.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ComponentOutputs.tsx
@@ -25,7 +25,7 @@ export const ComponentOutputs = ({
   response?: Nullable<TriggerUserPipelineResponse>;
 }) => {
   const testModeTriggerResponse = useInstillStore(
-    (store) => store.testModeTriggerResponse
+    (store) => store.testModeTriggerResponse,
   );
 
   const data = React.useMemo(() => {

--- a/packages/toolkit/src/view/pipeline-builder/components/CustomEdge.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/CustomEdge.tsx
@@ -52,7 +52,7 @@ export const CustomEdge = ({
         "fill-none",
         isSelected
           ? "stroke-semantic-accent-default stroke-[3px]"
-          : "stroke-[#CBD2E1] stroke-[2px]"
+          : "stroke-[#CBD2E1] stroke-[2px]",
       )}
       d={edgePath}
       markerEnd={markerEnd}

--- a/packages/toolkit/src/view/pipeline-builder/components/CustomHandle.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/CustomHandle.tsx
@@ -18,7 +18,7 @@ export const CustomHandle = (props: CustomHandleProps) => {
   const { className, id, ...passThrough } = props;
 
   const { edges, selectedConnectorNodeId } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
 
   const isSelected = React.useMemo(() => {
@@ -45,7 +45,7 @@ export const CustomHandle = (props: CustomHandleProps) => {
         "absolute top-1/2",
         passThrough.type === "target"
           ? "left-0 -translate-x-full"
-          : "right-0 translate-x-full"
+          : "right-0 translate-x-full",
       )}
     >
       <Handle
@@ -53,7 +53,7 @@ export const CustomHandle = (props: CustomHandleProps) => {
         className={cn(
           "!static !flex !h-4 !w-4 !border-[3px] !bg-semantic-bg-primary",
           isSelected ? "!border-semantic-accent-default" : "!border-[#94A0B8]",
-          className
+          className,
         )}
         isConnectable={false}
       />

--- a/packages/toolkit/src/view/pipeline-builder/components/OpenAdvancedConfigurationButton.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/OpenAdvancedConfigurationButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 export const OpenAdvancedConfigurationButton = (
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   return (
     <button

--- a/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/ReadOnlyPipelineBuilder.tsx
@@ -115,7 +115,7 @@ export const ReadOnlyPipelineBuilder = ({
     <div
       className={cn(
         "group flex w-full rounded-sm border-2 border-semantic-bg-line",
-        className
+        className,
       )}
     >
       <ReactFlow

--- a/packages/toolkit/src/view/pipeline-builder/components/SelectConnectorDialogItem.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/SelectConnectorDialogItem.tsx
@@ -5,7 +5,7 @@ import { Icons } from "@instill-ai/design-system";
 export const SelectConnectorDialogItem = (
   props: {
     children: React.ReactNode;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { children, onClick, ...passThrough } = props;
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/Head.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/Head.tsx
@@ -20,7 +20,7 @@ export const Head = ({
   id: Nullable<string>;
 }) => {
   const { updateDialogPublishPipelineIsOpen } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/PublishPipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/publish-pipeline-dialog/PublishPipelineDialog.tsx
@@ -74,7 +74,7 @@ export const PublishPipelineDialog = ({
   const updateUserPipeline = useUpdateUserPipeline();
 
   async function handlePublish(
-    formData: z.infer<typeof PublishPipelineFormSchema>
+    formData: z.infer<typeof PublishPipelineFormSchema>,
   ) {
     if (isPublishing || !pipeline.isSuccess || !pipelineName) return;
 

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/Section.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/Section.tsx
@@ -23,7 +23,7 @@ export const SectionRoot = ({
 export const SectionItem = (
   props: {
     children: React.ReactNode;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { children, onClick, ...passThrough } = props;
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/SelectComponentDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/select-component-dialog/SelectComponentDialog.tsx
@@ -18,7 +18,7 @@ import { ApplicationSection } from "./ApplicationSection";
 import { OpoeratorSection } from "./OpoeratorSection";
 
 export type OnSelectComponent = (
-  definition: ConnectorDefinition | OperatorDefinition | IteratorDefinition
+  definition: ConnectorDefinition | OperatorDefinition | IteratorDefinition,
 ) => void;
 
 export const SelectComponentDialog = ({
@@ -52,7 +52,7 @@ export const SelectComponentDialog = ({
                 "h-4 w-4",
                 disabled
                   ? "stroke-semantic-fg-secondary"
-                  : "stroke-semantic-bg-primary"
+                  : "stroke-semantic-bg-primary",
               )}
             />
           </Button>

--- a/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/dialogs/share-pipeline-dialog/TabShare.tsx
@@ -40,7 +40,7 @@ export const TabShare = ({
 }) => {
   const { amplitudeIsInit } = useAmplitudeCtx();
   const { accessToken, enableQuery, pipelineIsNew } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
   const [isUpdatingShareCodePermission, setIsUpdatingShareCodePermission] =
     React.useState(false);
@@ -77,7 +77,7 @@ export const TabShare = ({
 
     if (pipelineIsPublic) {
       const link = `${env(
-        "NEXT_PUBLIC_CONSOLE_BASE_URL"
+        "NEXT_PUBLIC_CONSOLE_BASE_URL",
       )}/${namespaceId}/pipelines/${id}`;
 
       navigator.clipboard.writeText(link);
@@ -121,7 +121,7 @@ export const TabShare = ({
         }
 
         link = `${env(
-          "NEXT_PUBLIC_CONSOLE_BASE_URL"
+          "NEXT_PUBLIC_CONSOLE_BASE_URL",
         )}/${namespaceId}/pipelines/${id}?view=${pipeline.sharing.shareCode?.code}`;
         setIsUpdatingShareCodePermission(false);
       } catch (error) {
@@ -144,7 +144,7 @@ export const TabShare = ({
       }
     } else {
       link = `${env(
-        "NEXT_PUBLIC_CONSOLE_BASE_URL"
+        "NEXT_PUBLIC_CONSOLE_BASE_URL",
       )}/${namespaceId}/pipelines/${id}?view=${
         pipeline.data.sharing.shareCode?.code
       }`;

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
@@ -79,7 +79,7 @@ export const IteratorEditor = ({
                       ...node.data,
                       component: composePipelineComponentMapFromNodes(
                         nodes,
-                        true
+                        true,
                       ),
                       metadata: composePipelineMetadataMapFromNodes(nodes),
                       outputElements: node.data.outputElements,
@@ -88,7 +88,7 @@ export const IteratorEditor = ({
                 }
 
                 return node;
-              }
+              },
             );
 
             const newEdges = composeEdgesFromNodes(newNodes);

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IterateElementHint.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IterateElementHint.tsx
@@ -17,7 +17,7 @@ export const IterateElmentHint = ({
       return null;
     }
     return transformInstillFormatToHumanReadableFormat(
-      selectedInputOption.instillFormat
+      selectedInputOption.instillFormat,
     );
   }, [selectedInputOption]);
 

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
@@ -49,7 +49,7 @@ export const IteratorInput = ({ className }: { className?: string }) => {
       .filter(
         (hint) =>
           hint.instillFormat.includes("array:") ||
-          hint.instillFormat.includes("semi-structured")
+          hint.instillFormat.includes("semi-structured"),
       )
       .map((hint) => ({
         path: hint.path,
@@ -61,13 +61,13 @@ export const IteratorInput = ({ className }: { className?: string }) => {
   React.useEffect(() => {
     if (editingIteratorID && tempSavedNodesForEditingIteratorFlow) {
       const targetIteratorNode = tempSavedNodesForEditingIteratorFlow.find(
-        (node) => node.id === editingIteratorID && isIteratorNode(node)
+        (node) => node.id === editingIteratorID && isIteratorNode(node),
       ) as Node<IteratorNodeData> | undefined;
 
       const inputOption = availableInputOptions.find(
         (option) =>
           option.path ===
-          targetIteratorNode?.data.input.replace("${", "").replace("}", "")
+          targetIteratorNode?.data.input.replace("${", "").replace("}", ""),
       );
 
       if (inputOption) {
@@ -92,7 +92,7 @@ export const IteratorInput = ({ className }: { className?: string }) => {
           value={selectedInputOption?.path}
           onValueChange={(value) => {
             const option = availableInputOptions.find(
-              (option) => option.path === value
+              (option) => option.path === value,
             );
 
             if (option) {
@@ -111,7 +111,7 @@ export const IteratorInput = ({ className }: { className?: string }) => {
                   }
 
                   return node;
-                })
+                }),
               );
             }
           }}

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/AddOutputButton.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/AddOutputButton.tsx
@@ -33,7 +33,7 @@ export const AddOutputButton = ({
 
           if (targetIteratorNode?.data.outputElements) {
             const currentIndexArray = Object.keys(
-              targetIteratorNode?.data.outputElements
+              targetIteratorNode?.data.outputElements,
             )
               .map((key) => key.replace("result_", ""))
               .map(Number)
@@ -58,7 +58,7 @@ export const AddOutputButton = ({
               }
 
               return node;
-            })
+            }),
           );
         }}
         variant="secondaryGrey"

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/DeleteOutputButton.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/DeleteOutputButton.tsx
@@ -40,7 +40,7 @@ export const DeleteOutputButton = ({ outputKey }: { outputKey: string }) => {
             }
 
             return node;
-          })
+          }),
         );
 
         updatePipelineRecipeIsDirty(() => true);

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
@@ -21,7 +21,7 @@ export const IteratorOutput = () => {
 
   const targetIteratorNode = React.useMemo(() => {
     return tempSavedNodesForEditingIteratorFlow.find(
-      (node) => node.id === editingIteratorID && isIteratorNode(node)
+      (node) => node.id === editingIteratorID && isIteratorNode(node),
     ) as Node<IteratorNodeData> | undefined;
   }, [editingIteratorID, tempSavedNodesForEditingIteratorFlow]);
 
@@ -41,7 +41,7 @@ export const IteratorOutput = () => {
                   outputKey={key}
                   disabledDeleteButton={key === "result_0"}
                 />
-              )
+              ),
             )
           : null}
       </div>

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputKeyField.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputKeyField.tsx
@@ -52,7 +52,7 @@ export const OutputKeyField = ({
           }
 
           return node;
-        })
+        }),
       );
     }, 1000);
   }, [

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueInput.tsx
@@ -26,7 +26,7 @@ export const OutputValueInput = ({ outputKey }: { outputKey: string }) => {
 
   const outputValue = React.useMemo(() => {
     const iteratorNode = tempSavedNodesForEditingIteratorFlow.find(
-      (node) => node.id === editingIteratorID && isIteratorNode(node)
+      (node) => node.id === editingIteratorID && isIteratorNode(node),
     ) as Node<IteratorNodeData> | undefined;
 
     if (iteratorNode) {
@@ -56,7 +56,7 @@ export const OutputValueInput = ({ outputKey }: { outputKey: string }) => {
               }
 
               return node;
-            })
+            }),
           );
           updatePipelineRecipeIsDirty(() => true);
         }}

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
@@ -51,7 +51,7 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
 
   React.useEffect(() => {
     const targetNodes = tempSavedNodesForEditingIteratorFlow.find(
-      (node) => node.id === editingIteratorID && isIteratorNode(node)
+      (node) => node.id === editingIteratorID && isIteratorNode(node),
     ) as Node<IteratorNodeData> | undefined;
 
     if (targetNodes) {
@@ -84,7 +84,7 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
       value={selectedOutputOption?.path}
       onValueChange={(value) => {
         const option = availableOutputOptions.find(
-          (option) => option.path === value
+          (option) => option.path === value,
         );
 
         if (option) {
@@ -106,7 +106,7 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
               }
 
               return node;
-            })
+            }),
           );
         }
       }}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/EmptyNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/EmptyNode.tsx
@@ -10,7 +10,7 @@ import { useInstillStore } from "../../../../lib";
 
 export const EmptyNode = ({ id }: NodeProps<NodeData>) => {
   const updateSelectResourceDialogIsOpen = useInstillStore(
-    (state) => state.updateSelectResourceDialogIsOpen
+    (state) => state.updateSelectResourceDialogIsOpen,
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeDropdownMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeDropdownMenu.tsx
@@ -16,7 +16,7 @@ const NodeDropdownMenuRoot = ({
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const pipelineIsReadOnly = useInstillStore(
-    (store: InstillStore) => store.pipelineIsReadOnly
+    (store: InstillStore) => store.pipelineIsReadOnly,
   );
 
   return (
@@ -82,7 +82,7 @@ const NodeDropdownMenuItem = (
   props: {
     onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
     children: React.ReactNode;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { onClick, children, ...passThrough } = props;
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeIDEditor.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeIDEditor.tsx
@@ -147,7 +147,7 @@ export const NodeIDEditor = ({ currentNodeID }: { currentNodeID: string }) => {
       updatePipelineRecipeIsDirty,
       selectedConnectorNodeId,
       updateSelectedConnectorNodeId,
-    ]
+    ],
   );
 
   return (
@@ -171,7 +171,7 @@ export const NodeIDEditor = ({ currentNodeID }: { currentNodeID: string }) => {
                     {...field}
                     className={cn(
                       "!absolute !bottom-0 !left-0 !right-0 !top-0 bg-transparent p-1 focus:!ring-1 focus:!ring-semantic-accent-default",
-                      textStyle
+                      textStyle,
                     )}
                     ref={nodeIDInputRef}
                     value={field.value ?? ""}

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeSortableFieldWrapper.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeSortableFieldWrapper.tsx
@@ -50,7 +50,7 @@ export const NodeSortableFieldWrapper = ({
       key={path}
       className={cn(
         "nodrag nowheel group relative flex cursor-default flex-row gap-x-2 bg-semantic-bg-base-bg",
-        isDragging ? "z-10" : ""
+        isDragging ? "z-10" : "",
       )}
     >
       <button

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeWrapper.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeWrapper.tsx
@@ -96,7 +96,7 @@ export const NodeWrapper = ({
         className={cn(
           "absolute left-0 top-0 w-[var(--pipeline-builder-node-available-width)] rounded border border-semantic-warning-default bg-semantic-warning-bg p-2",
           noteIsOpen ? "" : "hidden",
-          "-translate-y-[calc(100%+16px)]"
+          "-translate-y-[calc(100%+16px)]",
         )}
       >
         <Textarea
@@ -120,7 +120,7 @@ export const NodeWrapper = ({
                   }
 
                   return node;
-                })
+                }),
               );
               updatePipelineRecipeIsDirty(() => true);
             }, 1000);
@@ -136,7 +136,7 @@ export const NodeWrapper = ({
             {
               "outline outline-2 outline-offset-1 outline-semantic-accent-default":
                 nodeID === selectedConnectorNodeId,
-            }
+            },
           )}
         >
           <div className="flex flex-col px-3 py-2.5">{children}</div>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarContent.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarContent.tsx
@@ -22,7 +22,7 @@ export const NodeBottomBarContent = ({
   const { selectedValue } = useNodeBottomBarContext();
 
   const triggerResponse = useInstillStore(
-    (store) => store.testModeTriggerResponse
+    (store) => store.testModeTriggerResponse,
   );
 
   switch (selectedValue) {

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarContext.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarContext.tsx
@@ -20,7 +20,7 @@ export const useNodeBottomBarContext = () => {
   const context = React.useContext(NodeBottomBarContext);
   if (context === undefined) {
     throw new Error(
-      "useNodeBottomBarContext must be used within a BottomBarProvider"
+      "useNodeBottomBarContext must be used within a BottomBarProvider",
     );
   }
   return context;
@@ -39,7 +39,7 @@ export const NodeBottomBarProvider = ({
       selectedValue,
       setSelectedValue,
     }),
-    [selectedValue]
+    [selectedValue],
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/node-bottom-bar/NodeBottomBarMenu.tsx
@@ -22,7 +22,7 @@ const NodeBottomBarMenuItemPrimitive = (
   props: {
     children: React.ReactNode;
     value: string;
-  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   const { children, value, onClick, ...passThrough } = props;
 
@@ -35,7 +35,7 @@ const NodeBottomBarMenuItemPrimitive = (
         "h-full border-b border-[#1D2433] border-opacity-0 px-1.5 py-1.5 font-sans text-[10px] font-semibold hover:bg-semantic-bg-line",
         selectedValue === value
           ? "border-opacity-100 text-semantic-fg-primary"
-          : "text-semantic-fg-disabled"
+          : "text-semantic-fg-disabled",
       )}
       onClick={onClick}
     >
@@ -56,7 +56,7 @@ export const NodeBottomBarMenu = ({
 }) => {
   const { setSelectedValue } = useNodeBottomBarContext();
   const pipelineIsReadOnly = useInstillStore(
-    (store) => store.pipelineIsReadOnly
+    (store) => store.pipelineIsReadOnly,
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/NodeControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/NodeControlPanel.tsx
@@ -110,7 +110,7 @@ export const NodeControlPanel = ({
       }
 
       nodePrefix = transformConnectorDefinitionIDToComponentIDPrefix(
-        nodeData.definition.id
+        nodeData.definition.id,
       );
 
       nodeType = "generalNode";
@@ -129,7 +129,7 @@ export const NodeControlPanel = ({
       isEditingIterator
         ? [...nodes, ...tempSavedNodesForEditingIteratorFlow].map((e) => e.id)
         : getAllNodeID(nodes),
-      nodePrefix
+      nodePrefix,
     );
 
     const nodeID = `${nodePrefix}-${nodeIndex}`;

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/VariableResponseNodeControlPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/control-panel/VariableResponseNodeControlPanel.tsx
@@ -26,7 +26,7 @@ export function VariableResponseNodeControlPanel({
 }) {
   const [moreOptionsIsOpen, setMoreOptionsIsOpen] = React.useState(false);
   const pipelineIsReadOnly = useInstillStore(
-    (store) => store.pipelineIsReadOnly
+    (store) => store.pipelineIsReadOnly,
   );
 
   return (
@@ -58,7 +58,7 @@ export function VariableResponseNodeControlPanel({
                       "h-3 w-6 transition-colors duration-500",
                       disabledReferenceHint
                         ? "stroke-semantic-fg-secondary"
-                        : "stroke-semantic-accent-default"
+                        : "stroke-semantic-accent-default",
                     )}
                   />
                 </button>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/general-node/DataConnectorFreeForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/general-node/DataConnectorFreeForm.tsx
@@ -146,7 +146,7 @@ export const DataConnectorFreeForm = ({
                     </div>
                   </div>
                 );
-              }
+              },
             )
           : null}
       </div>
@@ -271,7 +271,7 @@ export const DataConnectorFreeForm = ({
                     </div>
                   </div>
                 );
-              }
+              },
             )
           : null}
       </div>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/general-node/GeneralNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/general-node/GeneralNode.tsx
@@ -94,7 +94,7 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
         supportInstillCredit,
         updateSupportInstillCredit,
         updateIsUsingInstillCredit,
-      }
+      },
     );
 
   const { outputSchema } = React.useMemo(() => {
@@ -105,7 +105,7 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
 
     return getGeneralComponentInOutputSchema(
       data,
-      selectedConditionMap ? selectedConditionMap["task"] : undefined
+      selectedConditionMap ? selectedConditionMap["task"] : undefined,
     );
   }, [data, selectedConditionMap]);
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/iterator-node/IteratorNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/iterator-node/IteratorNode.tsx
@@ -98,7 +98,7 @@ export const IteratorNode = ({ data, id }: NodeProps<IteratorNodeData>) => {
       updateIsEditingIterator,
       updateNodes,
       updateTempSavedNodesForEditingIteratorFlow,
-    ]
+    ],
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/ResponseNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/ResponseNode.tsx
@@ -85,7 +85,7 @@ export const ResponseNode = ({ data, id }: NodeProps<ResponseNodeData>) => {
   });
 
   const onCreateFreeFormField = (
-    formData: z.infer<typeof ResponseNodeFreeFormSchema>
+    formData: z.infer<typeof ResponseNodeFreeFormSchema>,
   ) => {
     if (Object.keys(data.fields).includes(formData.key)) {
       if (isEditing) {
@@ -314,7 +314,7 @@ export const ResponseNode = ({ data, id }: NodeProps<ResponseNodeData>) => {
                             value: item.value,
                             instillUiOrder: index,
                           },
-                        ])
+                        ]),
                       );
 
                       node.data = {
@@ -359,7 +359,7 @@ export const ResponseNode = ({ data, id }: NodeProps<ResponseNodeData>) => {
                 "my-auto h-4 w-4 stroke-semantic-accent-default",
                 disabledAddFieldButton
                   ? "stroke-semantic-fg-secondary"
-                  : "stroke-semantic-accent-default"
+                  : "stroke-semantic-accent-default",
               )}
             />
           </Button>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/ResponseNodeFreeForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/ResponseNodeFreeForm.tsx
@@ -96,7 +96,7 @@ export const ResponseNodeFreeForm = ({
                           if (!isUserInputKey && !isEditing) {
                             form.setValue(
                               "key",
-                              constructFieldKey(event.target.value)
+                              constructFieldKey(event.target.value),
                             );
                           }
                           field.onChange(event);

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/UserDefinedFieldItem.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/response-node/UserDefinedFieldItem.tsx
@@ -24,7 +24,7 @@ export const UserDefinedFieldItem = ({
   onEditField: (key: string) => void;
 }) => {
   const { isOwner, currentVersion, pipelineIsReadOnly } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNode.tsx
@@ -146,7 +146,7 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
   };
 
   function onCreateFreeFormField(
-    formData: z.infer<typeof TriggerNodeFreeFormSchema>
+    formData: z.infer<typeof TriggerNodeFreeFormSchema>,
   ) {
     if (!selectedType) {
       return;
@@ -176,7 +176,7 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
 
     const field = triggerNodeFields[selectedType].getFieldConfiguration(
       formData.title,
-      formData.description
+      formData.description,
     );
 
     updateRecentlyUsedStartComponentFieldTypes((prev) => {
@@ -248,12 +248,12 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
   const useTriggerPipelineRelease = useTriggerUserPipelineRelease();
 
   async function onTriggerPipeline(
-    formData: z.infer<typeof TriggerPipelineFormSchema>
+    formData: z.infer<typeof TriggerPipelineFormSchema>,
   ) {
     if (!pipelineName || !formData) return;
 
     const input = recursiveHelpers.removeUndefinedAndNullFromArray(
-      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(formData)
+      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(formData),
     );
 
     // Backend need to have the encoded JSON input. So we need to double check
@@ -411,16 +411,16 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
 
                       if (over && active.id !== over.id) {
                         const oldIndex = triggerPipelineFormFields.findIndex(
-                          (e) => e.key === active.id
+                          (e) => e.key === active.id,
                         );
                         const newIndex = triggerPipelineFormFields.findIndex(
-                          (e) => e.key === over.id
+                          (e) => e.key === over.id,
                         );
 
                         const newFieldItems = arrayMove(
                           triggerPipelineFormFields,
                           oldIndex,
-                          newIndex
+                          newIndex,
                         );
 
                         if (newFieldItems.length > 0) {
@@ -431,7 +431,7 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
                                   ([key, value]) => {
                                     const newFieldIndex =
                                       newFieldItems.findIndex(
-                                        (e) => e.key === key
+                                        (e) => e.key === key,
                                       );
 
                                     if (newFieldIndex !== -1) {
@@ -445,8 +445,8 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
                                     }
 
                                     return [key, value];
-                                  }
-                                )
+                                  },
+                                ),
                               );
 
                               node.data = {
@@ -493,7 +493,7 @@ export const VariableNode = ({ data, id }: NodeProps<TriggerNodeData>) => {
                     "my-auto h-4 w-4 stroke-semantic-accent-default",
                     disabledAddFieldButton
                       ? "stroke-semantic-fg-secondary"
-                      : "stroke-semantic-accent-default"
+                      : "stroke-semantic-accent-default",
                   )}
                 />
               </Button>

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeFields.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeFields.tsx
@@ -11,7 +11,7 @@ export type TriggerNodeInputField = {
   order: number;
   getFieldConfiguration: (
     title: string,
-    description?: string
+    description?: string,
   ) => PipelineVariableField;
 };
 

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeFreeForm.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeFreeForm.tsx
@@ -57,7 +57,7 @@ export const TriggerNodeFreeForm = ({
   selectedType: Nullable<string>;
   setSelectedType: React.Dispatch<React.SetStateAction<Nullable<string>>>;
   onCreateFreeFormField: (
-    formData: z.infer<typeof TriggerNodeFreeFormSchema>
+    formData: z.infer<typeof TriggerNodeFreeFormSchema>,
   ) => void;
   onCancel: () => void;
   isEditing: boolean;
@@ -120,7 +120,7 @@ export const TriggerNodeFreeForm = ({
                           if (!isUserInputKey && !isEditing) {
                             form.setValue(
                               "key",
-                              constructFieldKey(event.target.value)
+                              constructFieldKey(event.target.value),
                             );
                           }
                           field.onChange(event);

--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeTypeSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/variable-node/VariableNodeTypeSelect.tsx
@@ -18,7 +18,7 @@ export const VariableNodeTypeSelect = ({
   id: string;
 }) => {
   const recentlyUsedStartComponentFieldTypes = useInstillStore(
-    (store) => store.recentlyUsedStartComponentFieldTypes
+    (store) => store.recentlyUsedStartComponentFieldTypes,
   );
 
   const recentlyUsedTypes = React.useMemo(() => {
@@ -49,7 +49,7 @@ export const VariableNodeTypeSelect = ({
                   key={key}
                   className={cn(
                     "!px-1 !py-0 data-[highlighted]:!rounded data-[highlighted]:!bg-[#F1F3F9] data-[highlighted]:!stroke-semantic-fg-primary",
-                    selectedType === key ? "bg-[#F1F3F9]" : ""
+                    selectedType === key ? "bg-[#F1F3F9]" : "",
                   )}
                   value={key}
                   disabledCheck={true}
@@ -74,7 +74,7 @@ export const VariableNodeTypeSelect = ({
           <div className="flex flex-col gap-y-2">
             {Object.entries(triggerNodeFields)
               .filter(
-                ([key]) => !recentlyUsedStartComponentFieldTypes.includes(key)
+                ([key]) => !recentlyUsedStartComponentFieldTypes.includes(key),
               )
               .sort((a, b) => a[1].order - b[1].order)
               .map(([key, field]) => (
@@ -82,7 +82,7 @@ export const VariableNodeTypeSelect = ({
                   key={key}
                   className={cn(
                     "!px-1 !py-0 data-[highlighted]:!rounded data-[highlighted]:!bg-[#F1F3F9] data-[highlighted]:!stroke-semantic-fg-primary",
-                    selectedType === key ? "bg-[#F1F3F9]" : ""
+                    selectedType === key ? "bg-[#F1F3F9]" : "",
                   )}
                   value={key}
                   disabledCheck={true}

--- a/packages/toolkit/src/view/pipeline-builder/components/release-menu/ReleaseMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/release-menu/ReleaseMenu.tsx
@@ -104,7 +104,7 @@ export const ReleaseMenu = ({ onRelease }: { onRelease?: () => void }) => {
       toast,
       routeInfo.isSuccess,
       routeInfo.data.pipelineName,
-    ]
+    ],
   );
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/components/right-panel/PipelineGeneralComponentFormOnRightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/right-panel/PipelineGeneralComponentFormOnRightPanel.tsx
@@ -37,7 +37,7 @@ export const PipelineGeneralComponentFormOnRightPanel = ({
       secrets: entitySecrets,
       enabledCollapsibleFormGroup: true,
       collapsibleDefaultOpen: true,
-    }
+    },
   );
 
   useUpdaterOnRightPanel({

--- a/packages/toolkit/src/view/pipeline-builder/components/right-panel/RightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/right-panel/RightPanel.tsx
@@ -26,7 +26,7 @@ export const RightPanel = () => {
   const selectedGeneralNode = React.useMemo(() => {
     return nodes.find(
       (node) =>
-        node.id === currentAdvancedConfigurationNodeID && isGeneralNode(node)
+        node.id === currentAdvancedConfigurationNodeID && isGeneralNode(node),
     ) as Node<GeneralNodeData> | undefined;
   }, [nodes, currentAdvancedConfigurationNodeID]);
 

--- a/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/Release.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/Release.tsx
@@ -7,7 +7,7 @@ import { ReleaseMenu } from "../release-menu";
 
 export const Release = () => {
   const pipelineRecipeIsDirty = useInstillStore(
-    (store) => store.pipelineRecipeIsDirty
+    (store) => store.pipelineRecipeIsDirty,
   );
 
   return (
@@ -20,7 +20,7 @@ export const Release = () => {
             "flex !h-8 cursor-pointer flex-row gap-x-2",
             pipelineRecipeIsDirty
               ? ""
-              : "!bg-semantic-accent-default !text-semantic-fg-on-default hover:!bg-semantic-accent-hover active:!bg-semantic-accent-pressed"
+              : "!bg-semantic-accent-default !text-semantic-fg-on-default hover:!bg-semantic-accent-hover active:!bg-semantic-accent-pressed",
           )}
         >
           Release

--- a/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/Save.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/Save.tsx
@@ -20,7 +20,7 @@ export const Save = ({
   setIsSaving: (value: boolean) => void;
 }) => {
   const { pipelineRecipeIsDirty, currentVersion } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
   const savePipeline = useSavePipeline({
     setIsSaving,
@@ -55,7 +55,7 @@ export const Save = ({
             "h-4 w-4",
             pipelineRecipeIsDirty
               ? "stroke-semantic-fg-primary"
-              : "stroke-[#bfbfbf]"
+              : "stroke-[#bfbfbf]",
           )}
         />
       )}

--- a/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/TopControlMenu.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/top-control-menu/TopControlMenu.tsx
@@ -37,7 +37,7 @@ export const TopControlMenu = ({
   const [isSaving, setIsSaving] = React.useState(false);
   const addNode = useAddNodeWithDefinition({ reactFlowInstance });
   const { pipelineIsNew, isEditingIterator } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
 
   const routeInfo = useRouteInfo();
@@ -54,7 +54,7 @@ export const TopControlMenu = ({
                 navigate(`/${routeInfo.data.namespaceId}/pipelines`);
               } else {
                 navigate(
-                  `/${routeInfo.data.namespaceId}/pipelines/${routeInfo.data.resourceId}`
+                  `/${routeInfo.data.namespaceId}/pipelines/${routeInfo.data.resourceId}`,
                 );
               }
             }}

--- a/packages/toolkit/src/view/pipeline-builder/lib/checkComponentType.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/checkComponentType.tsx
@@ -5,13 +5,13 @@ import {
 } from "../../../lib";
 
 export function isPipelineGeneralComponent(
-  component: PipelineComponent
+  component: PipelineComponent,
 ): component is PipelineGeneralComponent {
   return component.type !== "iterator";
 }
 
 export function isPipelineIteratorComponent(
-  component: PipelineComponent
+  component: PipelineComponent,
 ): component is PipelineIteratorComponent {
   return component.type === "iterator";
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/checkIsValidComponentMetadata.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/checkIsValidComponentMetadata.ts
@@ -2,7 +2,7 @@ import { GeneralRecord, Nullable } from "../../../lib";
 import { PipelineMetadata } from "../type";
 
 export function checkIsValidComponentMetadata(
-  metadata?: Nullable<GeneralRecord>
+  metadata?: Nullable<GeneralRecord>,
 ): metadata is PipelineMetadata {
   if (
     metadata &&

--- a/packages/toolkit/src/view/pipeline-builder/lib/checkNodeType.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/checkNodeType.tsx
@@ -8,25 +8,25 @@ import {
 } from "../type";
 
 export function isIteratorNode(
-  node: Node<NodeData>
+  node: Node<NodeData>,
 ): node is Node<IteratorNodeData> {
   return node.type === "iteratorNode";
 }
 
 export function isVariableNode(
-  node: Node<NodeData>
+  node: Node<NodeData>,
 ): node is Node<TriggerNodeData> {
   return node.type === "variableNode";
 }
 
 export function isResponseNode(
-  node: Node<NodeData>
+  node: Node<NodeData>,
 ): node is Node<ResponseNodeData> {
   return node.type === "responseNode";
 }
 
 export function isGeneralNode(
-  node: Node<NodeData>
+  node: Node<NodeData>,
 ): node is Node<GeneralNodeData> {
   return node.type === "generalNode";
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromNodes.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composeEdgesFromNodes.ts
@@ -47,7 +47,7 @@ export function composeEdgesFromNodes(nodes: Node<NodeData>[]) {
 
 function getConnectedReferencesFromNodes(
   nodes: Node<NodeData>[],
-  overwriteNodeID?: string
+  overwriteNodeID?: string,
 ) {
   let references: ReferenceWithNodeInfo[] = [];
   for (const node of nodes) {
@@ -81,13 +81,13 @@ function getConnectedReferencesFromNodes(
       const inputReference = getReferencesFromAny(node.data.input);
 
       const nodesInInterator = createNodesFromPipelineComponents(
-        node.data.component
+        node.data.component,
       );
 
       // All the components inside the iterator will belong to the iterator itself
       const componentsReferences = getConnectedReferencesFromNodes(
         nodesInInterator,
-        node.id
+        node.id,
       );
 
       references = [
@@ -166,7 +166,7 @@ function getAvailableReferencesFromNodes(nodes: Node<NodeData>[]) {
           outputProperty.path?.includes(".")
             ? outputProperty.path?.split(".").pop()
             : outputProperty.path
-        }`
+        }`,
       );
     }
 
@@ -204,14 +204,15 @@ function composeEdgeForReference({
       (availableReference) =>
         checkReferenceIsAvailable(
           reference.referenceValue.withoutCurlyBraces,
-          availableReference
-        )
+          availableReference,
+        ),
     );
 
     // check whether we already have an edge for this reference
     const hasNoEdgeForThisReference =
       currentEdges.find(
-        (edge) => edge.source === "variable" && edge.target === reference.nodeID
+        (edge) =>
+          edge.source === "variable" && edge.target === reference.nodeID,
       ) === undefined;
 
     if (referenceIsAvailable && hasNoEdgeForThisReference && reference.nodeID) {
@@ -229,8 +230,8 @@ function composeEdgeForReference({
       (availableReference) =>
         checkReferenceIsAvailable(
           reference.referenceValue.withoutCurlyBraces,
-          availableReference
-        )
+          availableReference,
+        ),
     );
 
     const hasNoEdgeForThisReference =
@@ -238,7 +239,7 @@ function composeEdgeForReference({
         (edge) =>
           edge.source ===
             reference.referenceValue.withoutCurlyBraces.split(".")[0] &&
-          edge.target === reference.nodeID
+          edge.target === reference.nodeID,
       ) === undefined;
 
     if (referenceIsAvailable && hasNoEdgeForThisReference && reference.nodeID) {
@@ -256,7 +257,7 @@ function composeEdgeForReference({
 
 function checkReferenceIsAvailable(
   value: string,
-  availableReference: string
+  availableReference: string,
 ): boolean {
   const referenceValueWithoutArray = value.replaceAll(/\[[^\]]+\]/g, "");
 

--- a/packages/toolkit/src/view/pipeline-builder/lib/composePipelineComponentMapFromNodes.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composePipelineComponentMapFromNodes.ts
@@ -7,7 +7,7 @@ import { recursiveHelpers } from "./recursive-helpers";
 
 export function composePipelineComponentMapFromNodes(
   nodes: Node<NodeData>[],
-  retainDefinition?: boolean
+  retainDefinition?: boolean,
 ) {
   const componentMap: PipelineComponentMap = {};
 
@@ -25,11 +25,11 @@ export function composePipelineComponentMapFromNodes(
                   definition: retainDefinition ? e.definition : undefined,
                   input:
                     recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-                      recursiveHelpers.parseToNum(structuredClone(e.input))
+                      recursiveHelpers.parseToNum(structuredClone(e.input)),
                     ),
                   setup: e.setup
                     ? recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-                        recursiveHelpers.parseToNum(structuredClone(e.setup))
+                        recursiveHelpers.parseToNum(structuredClone(e.setup)),
                       )
                     : undefined,
                 },
@@ -37,7 +37,7 @@ export function composePipelineComponentMapFromNodes(
             }
 
             return [key, e];
-          })
+          }),
         ),
       };
 
@@ -48,11 +48,11 @@ export function composePipelineComponentMapFromNodes(
       componentMap[node.id] = {
         ...node.data,
         input: recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-          recursiveHelpers.parseToNum(structuredClone(node.data.input))
+          recursiveHelpers.parseToNum(structuredClone(node.data.input)),
         ),
         setup: node.data.setup
           ? recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-              recursiveHelpers.parseToNum(structuredClone(node.data.setup))
+              recursiveHelpers.parseToNum(structuredClone(node.data.setup)),
             )
           : undefined,
         definition: retainDefinition ? node.data.definition : undefined,

--- a/packages/toolkit/src/view/pipeline-builder/lib/composePipelineInputSnippet.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composePipelineInputSnippet.ts
@@ -2,7 +2,7 @@ import { GeneralRecord, InstillJSONSchema } from "../../../lib";
 import { InstillAIOpenAPIProperty } from "./getPropertiesFromOpenAPISchema";
 
 export function composePipelineInputSnippet(
-  properties: InstillAIOpenAPIProperty[]
+  properties: InstillAIOpenAPIProperty[],
 ) {
   const input: GeneralRecord = {};
 

--- a/packages/toolkit/src/view/pipeline-builder/lib/composePipelineRecipeFromNodes.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/composePipelineRecipeFromNodes.tsx
@@ -11,7 +11,7 @@ import {
 import { isPipelineGeneralComponent } from "./checkComponentType";
 
 export function composePipelineRecipeFromNodes(
-  nodes: Node<NodeData>[]
+  nodes: Node<NodeData>[],
 ): PipelineRecipe {
   const recipeComponent: PipelineComponentMap = {};
 
@@ -34,12 +34,12 @@ export function composePipelineRecipeFromNodes(
                   definition: undefined,
                   input: e.input
                     ? recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-                        recursiveHelpers.parseToNum(structuredClone(e.input))
+                        recursiveHelpers.parseToNum(structuredClone(e.input)),
                       )
                     : undefined,
                   setup: e.setup
                     ? recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-                        recursiveHelpers.parseToNum(structuredClone(e.setup))
+                        recursiveHelpers.parseToNum(structuredClone(e.setup)),
                       )
                     : undefined,
                   condition: e.condition,
@@ -51,7 +51,7 @@ export function composePipelineRecipeFromNodes(
             }
 
             return [key, e];
-          })
+          }),
         ),
       };
 
@@ -64,11 +64,11 @@ export function composePipelineRecipeFromNodes(
         task: node.data.task,
         type: node.data.type,
         input: recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-          recursiveHelpers.parseToNum(structuredClone(node.data.input))
+          recursiveHelpers.parseToNum(structuredClone(node.data.input)),
         ),
         setup: node.data.setup
           ? recursiveHelpers.replaceNullAndEmptyStringWithUndefined(
-              recursiveHelpers.parseToNum(structuredClone(node.data.setup))
+              recursiveHelpers.parseToNum(structuredClone(node.data.setup)),
             )
           : undefined,
         definition: undefined,
@@ -80,11 +80,11 @@ export function composePipelineRecipeFromNodes(
   }
 
   const variableNode = nodes.find(
-    (node) => node.id === "variable" && isVariableNode(node)
+    (node) => node.id === "variable" && isVariableNode(node),
   ) as Node<TriggerNodeData> | undefined;
 
   const responseNode = nodes.find(
-    (node) => node.id === "response" && isResponseNode(node)
+    (node) => node.id === "response" && isResponseNode(node),
   ) as Node<ResponseNodeData> | undefined;
 
   return {

--- a/packages/toolkit/src/view/pipeline-builder/lib/createGraphLayout.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/createGraphLayout.tsx
@@ -65,7 +65,7 @@ const elk = new ELK({
 
 export async function createGraphLayout(
   nodes: Node<NodeData>[],
-  edges: Edge[]
+  edges: Edge[],
 ) {
   const elkNodes: ElkNode[] = [];
   const elkEdges: ElkExtendedEdge[] = [];

--- a/packages/toolkit/src/view/pipeline-builder/lib/createNodesFromPipelineComponents.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/createNodesFromPipelineComponents.tsx
@@ -15,7 +15,7 @@ export type CreateNodesFromPipelineComponentsOptions = {
 
 export function createNodesFromPipelineComponents(
   component: PipelineComponentMap,
-  options?: CreateNodesFromPipelineComponentsOptions
+  options?: CreateNodesFromPipelineComponentsOptions,
 ) {
   const nodes: Node<NodeData>[] = [];
 

--- a/packages/toolkit/src/view/pipeline-builder/lib/createNodesFromPipelineRecipe.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/createNodesFromPipelineRecipe.tsx
@@ -9,7 +9,7 @@ export type CreateNodesFromPipelineRecipeOptions = {
 
 export function createNodesFromPipelineRecipe(
   recipe: PipelineRecipe,
-  options?: CreateNodesFromPipelineRecipeOptions
+  options?: CreateNodesFromPipelineRecipeOptions,
 ) {
   const metadata = options?.metadata;
   const nodes: Node<NodeData>[] = [];

--- a/packages/toolkit/src/view/pipeline-builder/lib/extractReferencesFromConfiguration.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/extractReferencesFromConfiguration.ts
@@ -5,7 +5,7 @@ import { extractPipelineComponentReferenceFromString } from "./extractPipelineCo
 export function extractReferencesFromConfiguration(
   configuration: GeneralRecord,
   nodeId: string,
-  currentPath: string[] = []
+  currentPath: string[] = [],
 ) {
   const results: PipelineComponentReference[] = [];
 

--- a/packages/toolkit/src/view/pipeline-builder/lib/generateUniqueIndex.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/generateUniqueIndex.ts
@@ -1,6 +1,6 @@
 export function generateUniqueIndex(
   componentIDs: string[],
-  initialPrefix: string
+  initialPrefix: string,
 ) {
   const prefix = `${initialPrefix}-`;
   let nodeIdx = 0;

--- a/packages/toolkit/src/view/pipeline-builder/lib/getGeneralComponentConfiguration.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getGeneralComponentConfiguration.ts
@@ -1,7 +1,7 @@
 import { PipelineGeneralComponent } from "../../../lib";
 
 export const getGeneralComponentConfiguration = (
-  component: PipelineGeneralComponent
+  component: PipelineGeneralComponent,
 ) => {
   return {
     input: component.input,

--- a/packages/toolkit/src/view/pipeline-builder/lib/getGeneralComponentInOutputSchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getGeneralComponentInOutputSchema.ts
@@ -7,7 +7,7 @@ import { JSONSchema7 } from "json-schema";
 
 export function getGeneralComponentInOutputSchema(
   component: PipelineGeneralComponent,
-  task?: string
+  task?: string,
 ) {
   let inputSchema: Nullable<InstillJSONSchema> = null;
   let outputSchema: Nullable<InstillJSONSchema> = null;

--- a/packages/toolkit/src/view/pipeline-builder/lib/getPropertiesFromOpenAPISchema.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getPropertiesFromOpenAPISchema.ts
@@ -9,7 +9,7 @@ export function getPropertiesFromOpenAPISchema(
   schema: InstillJSONSchema,
   parentKey?: string,
   title?: string,
-  parentIsArray?: boolean
+  parentIsArray?: boolean,
 ) {
   let properties: InstillAIOpenAPIProperty[] = [];
 
@@ -35,7 +35,7 @@ export function getPropertiesFromOpenAPISchema(
           ...getPropertiesFromOpenAPISchema(
             value,
             [...parentKeyList, key].join("."),
-            key
+            key,
           ),
         ];
       });
@@ -49,7 +49,7 @@ export function getPropertiesFromOpenAPISchema(
           schema.items as InstillJSONSchema,
           parentKey,
           undefined,
-          true
+          true,
         ) as InstillJSONSchema["items"],
         path: parentKey,
         title: schema.title ? schema.title : title,

--- a/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromAny.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromAny.ts
@@ -8,7 +8,7 @@ export function getReferencesFromAny(value: any) {
 
   function getReferences(
     value: any,
-    references: InstillReference[] = []
+    references: InstillReference[] = [],
   ): InstillReference[] {
     if (Array.isArray(value)) {
       for (const item of value) {

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useAddNodeWithDefinition.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useAddNodeWithDefinition.tsx
@@ -41,7 +41,7 @@ export function useAddNodeWithDefinition({
 
   return React.useCallback(
     (
-      definition: ConnectorDefinition | OperatorDefinition | IteratorDefinition
+      definition: ConnectorDefinition | OperatorDefinition | IteratorDefinition,
     ) => {
       if (!reactFlowInstance) return;
 
@@ -87,7 +87,7 @@ export function useAddNodeWithDefinition({
       // Construct the default component ID prefix. For example, if the definition
       // is `connector-definitions/instill_ai`, the prefix will be `instill_ai`
       const nodePrefix = transformConnectorDefinitionIDToComponentIDPrefix(
-        definition.id
+        definition.id,
       );
 
       // Generate a new component index
@@ -99,7 +99,7 @@ export function useAddNodeWithDefinition({
         isEditingIterator
           ? [...nodes, ...tempSavedNodesForEditingIteratorFlow].map((e) => e.id)
           : getAllNodeID(nodes),
-        nodePrefix
+        nodePrefix,
       );
 
       const nodeID = `${nodePrefix}-${nodeIndex}`;
@@ -187,6 +187,6 @@ export function useAddNodeWithDefinition({
       updatePipelineRecipeIsDirty,
       isEditingIterator,
       tempSavedNodesForEditingIteratorFlow,
-    ]
+    ],
   );
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useCheckIsHidden.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useCheckIsHidden.tsx
@@ -30,7 +30,7 @@ export function useCheckIsHidden(type: "onNode" | "onRightPanel") {
         return isHidden;
       }
     },
-    [type]
+    [type],
   );
 
   return checkIsHidden;

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/usePipelineBuilderGraph.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/usePipelineBuilderGraph.tsx
@@ -79,7 +79,7 @@ export function usePipelineBuilderGraph() {
         updatePipelineId(() =>
           routeInfo.data.resourceId
             ? routeInfo.data.resourceId.toString()
-            : null
+            : null,
         );
       }
       return;

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useRenamePipeline.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useRenamePipeline.tsx
@@ -90,7 +90,7 @@ export function useRenamePipeline() {
           }
 
           router.push(
-            `/${routeInfo.data.namespaceId}/pipelines/${newId}/editor`
+            `/${routeInfo.data.namespaceId}/pipelines/${newId}/editor`,
           );
 
           toast({
@@ -181,7 +181,7 @@ export function useRenamePipeline() {
 
         updatePipelineId(() => newId);
         updatePipelineName(
-          () => `${routeInfo.data.namespaceName}/pipelines/${newId}`
+          () => `${routeInfo.data.namespaceName}/pipelines/${newId}`,
         );
       } catch (error) {
         if (isAxiosError(error)) {
@@ -221,6 +221,6 @@ export function useRenamePipeline() {
       updatePipelineIsNew,
       updatePipelineName,
       updatePipelineRecipeIsDirty,
-    ]
+    ],
   );
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useSavePipeline.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useSavePipeline.tsx
@@ -238,6 +238,6 @@ export function useSavePipeline(props: UseSavePipelineProps = {}) {
       updateNodes,
       updateTempSavedNodesForEditingIteratorFlow,
       updateEdges,
-    ]
+    ],
   );
 }

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnNode.tsx
@@ -84,9 +84,9 @@ export function useUpdaterOnNode({
         updatePipelineRecipeIsDirty(() => true);
         prevValue.current = updateData;
       },
-      300
+      300,
     ),
-    [currentNodeData, updateEdges, updateNodes, updatePipelineRecipeIsDirty]
+    [currentNodeData, updateEdges, updateNodes, updatePipelineRecipeIsDirty],
   );
 
   const prevValue = React.useRef<Nullable<GeneralRecord>>(null);

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnRightPanel.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/useUpdaterOnRightPanel.tsx
@@ -87,9 +87,9 @@ export function useUpdaterOnRightPanel({
         updatePipelineRecipeIsDirty(() => true);
         prevValue.current = updateData;
       },
-      300
+      300,
     ),
-    [updateEdges, updateNodes, updatePipelineRecipeIsDirty]
+    [updateEdges, updateNodes, updatePipelineRecipeIsDirty],
   );
 
   React.useEffect(() => {

--- a/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceNullAndEmptyStringWithUndefined.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceNullAndEmptyStringWithUndefined.ts
@@ -11,7 +11,7 @@ export type RecursiveReplaceNullAndEmptyStringWithUndefined<T> = T extends null
       : T;
 
 export function recursiveReplaceNullAndEmptyStringWithUndefined<T>(
-  obj: T
+  obj: T,
 ): RecursiveReplaceNullAndEmptyStringWithUndefined<T> {
   if ((obj as any) === "") {
     return undefined as any;
@@ -24,7 +24,7 @@ export function recursiveReplaceNullAndEmptyStringWithUndefined<T>(
   if ((obj as any).constructor.name === "Object" || Array.isArray(obj)) {
     for (const key in obj) {
       obj[key] = recursiveReplaceNullAndEmptyStringWithUndefined(
-        obj[key]
+        obj[key],
       ) as any;
     }
   }

--- a/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceTargetValue.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/recursive-helpers/recursiveReplaceTargetValue.ts
@@ -3,14 +3,14 @@
 export function recursiveReplaceTargetValue(
   value: any,
   targetValue: any,
-  replacement: any
+  replacement: any,
 ) {
   if (typeof value === "object") {
     for (const key in value) {
       value[key] = recursiveReplaceTargetValue(
         value[key],
         targetValue,
-        replacement
+        replacement,
       );
     }
   }
@@ -20,7 +20,7 @@ export function recursiveReplaceTargetValue(
       value[key] = recursiveReplaceTargetValue(
         value[key],
         targetValue,
-        replacement
+        replacement,
       );
     }
   }

--- a/packages/toolkit/src/view/pipeline/PipelineTablePlaceholder.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelineTablePlaceholder.tsx
@@ -12,7 +12,7 @@ export type PipelineTablePlaceholderProps = Pick<
 >;
 
 export const PipelineTablePlaceholder = (
-  props: PipelineTablePlaceholderProps
+  props: PipelineTablePlaceholderProps,
 ) => {
   const { marginBottom, enableCreateButton } = props;
   const width = "w-[136px]";

--- a/packages/toolkit/src/view/pipeline/PipelinesTable.tsx
+++ b/packages/toolkit/src/view/pipeline/PipelinesTable.tsx
@@ -30,7 +30,7 @@ export const PipelinesTable = (props: PipelinesTableProps) => {
             <button
               onClick={() => {
                 router.push(
-                  `/${pipelineNameFragments[1]}/pipelines/${pipelineNameFragments[3]}`
+                  `/${pipelineNameFragments[1]}/pipelines/${pipelineNameFragments[3]}`,
                 );
               }}
             >

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -202,7 +202,7 @@ export const Head = ({
                                 "!h-8 !w-[145px] gap-x-1 !rounded-sm !border border-[#E1E6EF] !py-1 px-3 !transition-opacity !duration-300 !ease-in-out",
                                 isOpen
                                   ? "border-opacity-100 !bg-semantic-accent-bg "
-                                  : "border-opacity-0"
+                                  : "border-opacity-0",
                               )}
                               size="sm"
                               variant="tertiaryColour"
@@ -365,7 +365,7 @@ export const Head = ({
                     <Button
                       onClick={() => {
                         router.push(
-                          `/${routeInfo.data.namespaceId}/pipelines/${routeInfo.data.resourceId}/editor`
+                          `/${routeInfo.data.namespaceId}/pipelines/${routeInfo.data.resourceId}/editor`,
                         );
                       }}
                       size="sm"
@@ -423,7 +423,7 @@ const VersionButton = ({
       key={id}
       className={cn(
         "w-full !px-2 !py-1.5",
-        currentVersion === id ? "!bg-semantic-bg-secondary" : ""
+        currentVersion === id ? "!bg-semantic-bg-secondary" : "",
       )}
       variant={"tertiaryColour"}
       onClick={onClick}
@@ -432,7 +432,7 @@ const VersionButton = ({
         <div className="my-auto h-2 w-[9px] rounded-full bg-semantic-secondary-default"></div>
         <p
           className={cn(
-            "w-full text-left text-semantic-fg-secondary product-body-text-3-medium"
+            "w-full text-left text-semantic-fg-secondary product-body-text-3-medium",
           )}
         >
           Version {id}

--- a/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/InOutPut.tsx
@@ -69,7 +69,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
 
       const pipelineVersion = releases.find(
         (release) =>
-          release.id === currentVersion || release.alias === currentVersion
+          release.id === currentVersion || release.alias === currentVersion,
       );
 
       if (pipelineVersion) {
@@ -88,7 +88,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
 
       const pipelineVersion = releases.find(
         (release) =>
-          release.id === currentVersion || release.alias === currentVersion
+          release.id === currentVersion || release.alias === currentVersion,
       );
 
       if (pipelineVersion) {
@@ -118,7 +118,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
       return;
 
     const input = recursiveHelpers.removeUndefinedAndNullFromArray(
-      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(formData)
+      recursiveHelpers.replaceNullAndEmptyStringWithUndefined(formData),
     );
 
     // Backend need to have the encoded JSON input. So we need to double check
@@ -218,7 +218,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
                 size="md"
                 onClick={() => {
                   router.push(
-                    `/${routeInfo.data.namespaceName}/pipelines/${routeInfo.data.resourceId}/editor`
+                    `/${routeInfo.data.namespaceName}/pipelines/${routeInfo.data.resourceId}/editor`,
                   );
                 }}
               >
@@ -270,7 +270,7 @@ export const InOutPut = ({ currentVersion }: InOutPutProps) => {
                 size="md"
                 onClick={() => {
                   router.push(
-                    `/${routeInfo.data.namespaceName}/pipelines/${routeInfo.data.resourceId}/editor`
+                    `/${routeInfo.data.namespaceName}/pipelines/${routeInfo.data.resourceId}/editor`,
                   );
                 }}
               >

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Menu.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Menu.tsx
@@ -32,7 +32,7 @@ export const Menu = ({ pipeline, handleDeletePipeline }: MenuProps) => {
   const [cloneDialogIsOpen, setCloneDialogIsOpen] = React.useState(false);
 
   const { updateDialogSharePipelineIsOpen } = useInstillStore(
-    useShallow(selector)
+    useShallow(selector),
   );
 
   const routeInfo = useRouteInfo();

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -69,7 +69,7 @@ export const ViewPipeline = () => {
       return null;
     }
     return pipeline.data.releases.find(
-      (release) => release.id === currentVersion
+      (release) => release.id === currentVersion,
     );
   }, [pipeline.isSuccess, pipeline.data, currentVersion]);
 

--- a/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/CreatePipelineDialog.tsx
@@ -144,7 +144,7 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
     };
 
     const targetNamespace = namespaces.find(
-      (account) => account.id === data.namespaceId
+      (account) => account.id === data.namespaceId,
     );
 
     if (targetNamespace) {
@@ -289,9 +289,9 @@ export const CreatePipelineDialog = ({ className }: { className?: string }) => {
                         <span className="ml-2 break-all product-body-text-3-semibold">
                           {form.watch("id") !== "" && form.watch("id")
                             ? `${env(
-                                "NEXT_PUBLIC_CONSOLE_BASE_URL"
+                                "NEXT_PUBLIC_CONSOLE_BASE_URL",
                               )}/${form.getValues(
-                                "namespaceId"
+                                "namespaceId",
                               )}/pipelines/${form.getValues("id")}`
                             : null}
                         </span>

--- a/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipelines/ViewPipelines.tsx
@@ -41,7 +41,7 @@ export const ViewPipelines = () => {
     React.useState<Visibility>(
       visibility === "VISIBILITY_PUBLIC"
         ? "VISIBILITY_PUBLIC"
-        : "VISIBILITY_UNSPECIFIED"
+        : "VISIBILITY_UNSPECIFIED",
     );
 
   const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
@@ -103,7 +103,7 @@ export const ViewPipelines = () => {
       debounce((value: string) => {
         setSearchCode(value);
       }, 300),
-    []
+    [],
   );
 
   return (

--- a/packages/toolkit/src/view/settings/SettingSidebar.tsx
+++ b/packages/toolkit/src/view/settings/SettingSidebar.tsx
@@ -31,7 +31,7 @@ export const SettingSidebarItem = ({
       className={cn(
         "flex w-40 flex-row items-center rounded px-3 py-[9px] hover:bg-semantic-accent-bg",
         highlighted ? "bg-semantic-accent-bg" : "",
-        className
+        className,
       )}
     >
       <div className="flex flex-row items-center space-x-3">
@@ -41,7 +41,7 @@ export const SettingSidebarItem = ({
             "text-semantic-fg-primary product-body-text-2-semibold",
             highlighted
               ? "text-semantic-accent-default"
-              : "text-semantic-fg-secondary"
+              : "text-semantic-fg-secondary",
           )}
         >
           {name}

--- a/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
+++ b/packages/toolkit/src/view/settings/api-tokens/CreateAPITokenDialog.tsx
@@ -54,7 +54,7 @@ export const CreateAPITokenDialog = () => {
 
   const createAPIToken = useCreateApiToken();
   const handleCreateAPIToken = async (
-    data: z.infer<typeof CreateTokenSchema>
+    data: z.infer<typeof CreateTokenSchema>,
   ) => {
     if (!accessToken) return;
 

--- a/packages/toolkit/src/view/settings/secrets/CreateSecretDialog.tsx
+++ b/packages/toolkit/src/view/settings/secrets/CreateSecretDialog.tsx
@@ -82,7 +82,7 @@ export const CreateSecretDialog = () => {
 
   const createSecret = useCreateUserSecret();
   const handleCreateAPIToken = async (
-    data: z.infer<typeof CreateSecretSchema>
+    data: z.infer<typeof CreateSecretSchema>,
   ) => {
     if (!accessToken || !me.isSuccess) return;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       prettier:
         specifier: latest
         version: 3.2.4
-      prettier-plugin-tailwindcss:
-        specifier: latest
-        version: 0.5.11(prettier@3.2.4)
       turbo:
         specifier: latest
         version: 1.11.3


### PR DESCRIPTION
Because

- Due to lacking of root level prettier configuration, the VSCode plugin always pick the machine default  configuration which further causes confusion among developer
- The lint-stage configurations are separated into different stage
  - We prettier all the `js, ts, jsx, tsx` file on the root level lint-stage
  - We lint all the `js, ts, jsx, tsx` file on the sub-packages level lint-stage
  - In this way we can make sure the lint-stage catch the nearest eslint configuration within the packages

This commit

- fix prettier issue around root folder and vscode plugin
