### PR TITLE
fix: fixed private tag in the pipeline/model header

### DIFF
--- a/packages/toolkit/src/view/model/view-model/ModelHead.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelHead.tsx
@@ -109,23 +109,16 @@ export const ModelSettingsHead = ({
                 /<span className="text-semantic-fg-primary">{model?.id}</span>
               </div>
               {modelState ? <StateLabel state={modelState} /> : null}
-              <Tag
-                className="my-auto h-6 gap-x-1 !border-0 !py-0 !text-sm"
-                variant="lightNeutral"
-                size="sm"
-              >
-                {model?.visibility === "VISIBILITY_PUBLIC" ? (
-                  <React.Fragment>
-                    <Icons.BookOpen02 className="h-3 w-3 stroke-semantic-fg-primary" />
-                    Public
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    Private
-                    <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
-                  </React.Fragment>
-                )}
-              </Tag>
+              {model?.visibility !== "VISIBILITY_PUBLIC" ? (
+                <Tag
+                  className="my-auto h-6 gap-x-1 !border-0 !py-0 !text-sm"
+                  variant="lightNeutral"
+                  size="sm"
+                >
+                  <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
+                  Private
+                </Tag>
+              ) : null}
               {model?.sourceUrl ? (
                 <ExternalLink href={model.sourceUrl}>
                   <GitHubIcon

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -260,22 +260,15 @@ export const Head = ({
                           </Popover.Content>
                         </Popover.Root>
                       ) : null}
-                      {pipeline.isSuccess ? (
+                      {pipeline.isSuccess &&
+                      !isPublicPipeline(pipeline.data) ? (
                         <Tag
-                          className="my-auto h-6 !border-0 !py-0"
+                          className="my-auto h-6 gap-x-1 !border-0 !py-0 !text-sm"
                           variant="lightNeutral"
                           size="sm"
                         >
-                          {isPublicPipeline(pipeline.data) ? (
-                            <div className="flex flex-row gap-x-1">
-                              <span className="my-auto">Public</span>
-                            </div>
-                          ) : (
-                            <div className="flex flex-row gap-x-1">
-                              <span className="my-auto">Private</span>
-                              <Icons.Lock03 className="my-auto h-3 w-3 stroke-semantic-fg-primary" />
-                            </div>
-                          )}
+                          <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
+                          Private
                         </Tag>
                       ) : null}
                     </React.Fragment>


### PR DESCRIPTION
Because

- the styles of the tag were different

This commit

- unified the styles and updated the logic to show only "Private" tag
