### PR TITLE
chore: enforce more strict Typescript rule among codebase

### DIFF
--- a/packages/design-system/src/new-ui/Breadcrumb/Breadcrumb.tsx
+++ b/packages/design-system/src/new-ui/Breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ export type BreadcrumbProps = {
 };
 
 const Breadcrumb = ({ items }: BreadcrumbProps) => {
-  const activeLink = items.filter((item, index) => index != items.length - 1);
+  const activeLink = items.filter((_, index) => index != items.length - 1);
   return (
     <div className="mb-4 flex items-center gap-x-2 text-sm">
       {activeLink.map((item) => (

--- a/packages/design-system/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
+++ b/packages/design-system/src/ui/Buttons/CollapseSidebarButton/CollapseSidebarButton.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { CollapseLeftIcon, CollapseRightIcon } from "../../Icons";
 import ButtonBase, { ButtonBaseProps } from "../ButtonBase";
 

--- a/packages/design-system/src/ui/Buttons/OutlineButton/OutlineButton.tsx
+++ b/packages/design-system/src/ui/Buttons/OutlineButton/OutlineButton.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import ButtonBase, { ButtonBaseProps } from "../ButtonBase";
 
 export type OutlineButtonRequiredKeys = "type" | "color" | "hoveredShadow";

--- a/packages/design-system/src/ui/Buttons/SolidButton/SolidButton.tsx
+++ b/packages/design-system/src/ui/Buttons/SolidButton/SolidButton.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import ButtonBase, { ButtonBaseProps } from "../ButtonBase";
 
 export type SolidButtonRequiredKeys = "type" | "color";

--- a/packages/design-system/src/ui/Buttons/TextButton/TextButton.tsx
+++ b/packages/design-system/src/ui/Buttons/TextButton/TextButton.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import ButtonBase, { ButtonBaseProps } from "../ButtonBase";
 
 export type TextButtonRequiredKeys = "type" | "color";

--- a/packages/design-system/src/ui/InputDescriptions/BasicInputDescription/BasicInputDescription.tsx
+++ b/packages/design-system/src/ui/InputDescriptions/BasicInputDescription/BasicInputDescription.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   InputDescriptionBase,
   InputDescriptionBaseProps,

--- a/packages/design-system/src/ui/InputLabels/BasicInputLabel/BasicInputLabel.tsx
+++ b/packages/design-system/src/ui/InputLabels/BasicInputLabel/BasicInputLabel.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import InputLabelBase, { InputLabelBaseProps } from "../InputLabelBase";
 
 export type BasicInputLabelOmitKeys =

--- a/packages/design-system/src/ui/InputLabels/TextAreaInputLabel/TextAreaInputLabel.tsx
+++ b/packages/design-system/src/ui/InputLabels/TextAreaInputLabel/TextAreaInputLabel.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import InputLabelBase, { InputLabelBaseProps } from "../InputLabelBase";
 
 export type TextAreaInputLabelKeys =

--- a/packages/design-system/src/ui/Progress/DarkBgSquareProgress/DarkBgSquareProgress.tsx
+++ b/packages/design-system/src/ui/Progress/DarkBgSquareProgress/DarkBgSquareProgress.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SquareProgressBase, {
   SquareProgressBaseProps,
 } from "../SquareProgressBase";

--- a/packages/design-system/src/ui/Progress/NoBgSquareProgress/NoBgSquareProgress.tsx
+++ b/packages/design-system/src/ui/Progress/NoBgSquareProgress/NoBgSquareProgress.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SquareProgressBase, {
   SquareProgressBaseProps,
 } from "../SquareProgressBase";

--- a/packages/design-system/src/ui/Progress/SquareProgressBase/SquareProgressBase.tsx
+++ b/packages/design-system/src/ui/Progress/SquareProgressBase/SquareProgressBase.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import cn from "clsx";
 
 import "./SquareProgressBase.css";

--- a/packages/design-system/src/ui/Progress/WhiteBgSquareProgress/WhiteBgSquareProgress.tsx
+++ b/packages/design-system/src/ui/Progress/WhiteBgSquareProgress/WhiteBgSquareProgress.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SquareProgressBase, {
   SquareProgressBaseProps,
 } from "../SquareProgressBase";

--- a/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
+++ b/packages/design-system/src/ui/ProgressMessageBoxs/BasicProgressMessageBox/BasicProgressMessageBox.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import ProgressMessageBoxBase, {
   ProgressMessageBoxBaseProps,
 } from "../ProgressMessageBoxBase";

--- a/packages/design-system/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
+++ b/packages/design-system/src/ui/SingleSelects/BasicSingleSelect/BasicSingleSelect.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/packages/design-system/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
+++ b/packages/design-system/src/ui/TextAreas/BasicTextArea/BasicTextArea.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/packages/design-system/src/ui/TextFields/BasicTextField/BasicTextField.tsx
+++ b/packages/design-system/src/ui/TextFields/BasicTextField/BasicTextField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/packages/design-system/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
+++ b/packages/design-system/src/ui/TextFields/ProtectedBasicTextField/ProtectedBasicTextField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/packages/design-system/src/ui/ToggleFields/BasicToggleField/BasicToggleField.tsx
+++ b/packages/design-system/src/ui/ToggleFields/BasicToggleField/BasicToggleField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/packages/design-system/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
+++ b/packages/design-system/src/ui/ToggleFields/StatefulToggleField/StatefulToggleField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Nullable, State } from "../../../types/general";
 import {
   basicInputDescriptionConfig,

--- a/packages/design-system/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.tsx
+++ b/packages/design-system/src/ui/UploadFileFields/BasicUploadFileField/BasicUploadFileField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import {
   basicInputDescriptionConfig,
   BasicInputDescriptionOmitKeys,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,8 @@
     "declaration": true,
     "sourceMap": true,
     "emitDeclarationOnly": true,
-    "strict": true
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   }
 }


### PR DESCRIPTION
Because

We are enforcing more strict Typescript rule to the codebase

```json
"noUnusedLocals": true,
"noUnusedParameters": true
```

This commit

- enforce more strict Typescript rule among codebase
