### PR TITLE
fix: remove empty tags on pipeline update

### DIFF
--- a/apps/console/src/app/(providers)/amplitude-client-provider.tsx
+++ b/apps/console/src/app/(providers)/amplitude-client-provider.tsx
@@ -11,7 +11,14 @@ export const AmplitudeProvider = ({
 }) => {
   const [amplitudeIsInit, setAmplitudeIsInit] = React.useState(false);
   return (
-    <AmplitudeCtx.Provider value={{ amplitudeIsInit, setAmplitudeIsInit }}>
+    <AmplitudeCtx.Provider
+      value={{
+        amplitudeIsInit,
+        setAmplitudeIsInit,
+        userBlockCookieUsage: false,
+        setUserBlockCookieUsage: null,
+      }}
+    >
       {children}
     </AmplitudeCtx.Provider>
   );

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineSettings.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineSettings.tsx
@@ -109,7 +109,8 @@ export const PipelineSettings = ({
         data.tags
           ?.trim()
           .split(",")
-          .map((item) => item.trim()) || [],
+          .map((item) => item.trim())
+          .filter((item) => item) || [],
     };
 
     try {


### PR DESCRIPTION
Because

- we could save empty tags updating pipeline

This commit

- now empty tags are being filtered out
