### PR TITLE
fix(pipeline-editor): fix iterator not correct take in objectArray and use it as a hint in iterator editor

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.96.0-rc.21",
+  "version": "0.96.0-rc.23",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormatToHumanReadableFormat.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormatToHumanReadableFormat.tsx
@@ -3,7 +3,15 @@ import { InstillHumanReadableFormat } from "../types";
 export function transformInstillFormatToHumanReadableFormat(
   format: string,
   arrayInArray?: boolean,
+  isObjectArray?: boolean,
 ): InstillHumanReadableFormat {
+  if (isObjectArray) {
+    return {
+      isArray: true,
+      format: "object",
+    };
+  }
+
   if (format.includes("array:")) {
     if (arrayInArray) {
       return {

--- a/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromNodes.ts
+++ b/packages/toolkit/src/lib/use-smart-hint/pickSmartHintsFromNodes.ts
@@ -164,11 +164,33 @@ export function pickSmartHintsFromNodes({
     ) as Node<IteratorNodeData> | undefined;
 
     if (targetIteratorNode) {
+      const targetIteratorInputPath = targetIteratorNode.data.input
+        .replace("${", "")
+        .replace("}", "");
+
       const targetHints = smartHints.find(
-        (hint) =>
-          hint.path ===
-          targetIteratorNode.data.input.replace("${", "").replace("}", ""),
+        (hint) => hint.path === targetIteratorInputPath,
       );
+
+      // Deal with user is using objectArray as iterator input
+      if (
+        targetHints &&
+        targetHints?.instillFormat === "null" &&
+        targetHints.type === "objectArray" &&
+        targetHints.properties
+      ) {
+        for (const property of targetHints.properties) {
+          smartHints = [
+            ...smartHints,
+            {
+              path: `${editingIteratorID}.element.${property.key}`,
+              key: property.key,
+              instillFormat: property.instillFormat,
+              type: property.type,
+            },
+          ];
+        }
+      }
 
       if (targetHints) {
         smartHints = [

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/IteratorEditor.tsx
@@ -40,6 +40,7 @@ export type InOutputOption = {
   path: string;
   instillFormat: string;
   description?: string;
+  type: string;
 };
 
 export const IteratorEditor = ({

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IterateElementHint.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IterateElementHint.tsx
@@ -18,6 +18,18 @@ export const IterateElmentHint = ({
     if (!selectedInputOption || !selectedInputOption?.instillFormat) {
       return null;
     }
+
+    if (
+      selectedInputOption.instillFormat === "null" &&
+      selectedInputOption.type === "objectArray"
+    ) {
+      return transformInstillFormatToHumanReadableFormat(
+        selectedInputOption.instillFormat,
+        false,
+        true,
+      );
+    }
+
     return transformInstillFormatToHumanReadableFormat(
       selectedInputOption.instillFormat,
     );

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
@@ -51,12 +51,14 @@ export const IteratorInput = ({ className }: { className?: string }) => {
       .filter(
         (hint) =>
           hint.instillFormat.includes("array:") ||
-          hint.instillFormat.includes("semi-structured"),
+          hint.instillFormat.includes("semi-structured") ||
+          (hint.instillFormat === "null" && hint.type === "objectArray"),
       )
       .map((hint) => ({
         path: hint.path,
         instillFormat: hint.instillFormat,
         description: hint.description,
+        type: hint.type,
       }));
   }, [tempSavedNodesForEditingIteratorFlow]);
 

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueSelect.tsx
@@ -48,6 +48,7 @@ export const OutputValueSelect = ({ outputKey }: { outputKey: string }) => {
       path: hint.path,
       instillFormat: hint.instillFormat,
       description: hint.description,
+      type: hint.type,
     }));
   }, [nodes]);
 


### PR DESCRIPTION
Because

- Iterator should be able to consume objectArray as input

This commit

- fix iterator not correct take in objectArray and use it as a hint in iterator editor
