### PR TITLE
fix: readme editor html fix, wording updates, remove GitHub and License from pipeline

### DIFF
--- a/packages/design-system/src/ui-helpers/getModelHardwareToolkit.ts
+++ b/packages/design-system/src/ui-helpers/getModelHardwareToolkit.ts
@@ -9,7 +9,7 @@ export const getModelHardwareToolkit = (hardwareName: string) => {
     case "NVIDIA_L4":
       return "NVIDIA L4";
     case "NVIDIA_A100":
-      return "NVIDIA A100 (in shortage)";
+      return "NVIDIA A100";
     case "Custom":
       return "Custom";
     default:

--- a/packages/toolkit/src/components/ReadmeEditor.tsx
+++ b/packages/toolkit/src/components/ReadmeEditor.tsx
@@ -72,7 +72,9 @@ export const ReadmeEditor = ({
   const renderMarkdown = () => {
     return (
       <div className="markdown-body w-full overflow-x-auto p-6">
-        <Markdown>{content || placeholder || ""}</Markdown>
+        <Markdown options={{ disableParsingRawHTML: true }}>
+          {content || placeholder || ""}
+        </Markdown>
       </div>
     );
   };
@@ -204,10 +206,11 @@ export const ReadmeEditor = ({
           }}
         >
           <MarkdownEditor
+            suppressHtmlProcessing
             readOnly={!canEdit}
             markdown={content}
             onChange={debouncedUpdateModelReadme}
-            className="bg-semantic-fg-on-default overflow-y-auto h-full [&_.cm-editor]:outline-none [&_.cm-gutters]:bg-semantic-bg-alt-primary [&_.cm-activeLine]:bg-semantic-bg-alt-primary [&_.cm-activeLineGutter]:bg-semantic-bg-alt-primary"
+            className="bg-semantic-fg-on-default overflow-y-auto h-full [&_.cm-editor]:outline-none [&_.cm-gutters]:bg-semantic-bg-alt-primary [&_.cm-activeLine]:bg-semantic-bg-alt-primary [&_.cm-activeLineGutter]:bg-semantic-bg-alt-primary [&_.cm-tooltip-autocomplete]:bg-semantic-bg-base-bg"
           />
         </div>
       ) : (

--- a/packages/toolkit/src/view/model/view-model/ModelApi.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelApi.tsx
@@ -65,7 +65,7 @@ export const ModelApi = ({ model }: ModelApiProps) => {
         />
         {model?.inputSchema || model?.outputSchema ? (
           <ModelSectionHeader className="mt-5">
-            Model JSON schema
+            JSON schema
           </ModelSectionHeader>
         ) : null}
         {model?.inputSchema ? (

--- a/packages/toolkit/src/view/model/view-model/ModelApi.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelApi.tsx
@@ -64,9 +64,7 @@ export const ModelApi = ({ model }: ModelApiProps) => {
           customStyle={defaultCodeSnippetStyles}
         />
         {model?.inputSchema || model?.outputSchema ? (
-          <ModelSectionHeader className="mt-5">
-            JSON schema
-          </ModelSectionHeader>
+          <ModelSectionHeader className="mt-5">JSON schema</ModelSectionHeader>
         ) : null}
         {model?.inputSchema ? (
           <React.Fragment>

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -8,7 +8,6 @@ import { Pipeline } from "instill-sdk";
 
 import {
   Button,
-  GitHubIcon,
   Icons,
   Popover,
   ScrollArea,
@@ -171,26 +170,10 @@ export const Head = ({
               Private
             </Tag>
           ) : null}
-          {pipeline?.sourceUrl ? (
-            <HeadExternalLink href={pipeline.sourceUrl}>
-              <GitHubIcon
-                width="w-[18px]"
-                height="h-[18px]"
-                color="fill-semantic-bg-secondary-alt-primary"
-              />
-              GitHub
-            </HeadExternalLink>
-          ) : null}
           {pipeline?.documentationUrl ? (
             <HeadExternalLink href={pipeline.documentationUrl}>
               <Icons.Link01 className="h-3.5 w-3.5 stroke-semantic-bg-secondary-alt-primary" />
               Link
-            </HeadExternalLink>
-          ) : null}
-          {pipeline?.license ? (
-            <HeadExternalLink href={pipeline.license}>
-              <Icons.Scales02 className="h-3.5 w-3.5 stroke-semantic-bg-secondary-alt-primary" />
-              License
             </HeadExternalLink>
           ) : null}
           {!!releases?.length && pipeline ? (

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
@@ -121,7 +121,7 @@ export const PipelineApi = ({ pipeline, releases }: PipelineApiProps) => {
         />
         {formSchema ? (
           <ModelSectionHeader className="mt-5">
-            Pipeline JSON schema
+            JSON schema
           </ModelSectionHeader>
         ) : null}
         {formSchema?.input ? (

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
@@ -120,9 +120,7 @@ export const PipelineApi = ({ pipeline, releases }: PipelineApiProps) => {
           customStyle={defaultCodeSnippetStyles}
         />
         {formSchema ? (
-          <ModelSectionHeader className="mt-5">
-            JSON schema
-          </ModelSectionHeader>
+          <ModelSectionHeader className="mt-5">JSON schema</ModelSectionHeader>
         ) : null}
         {formSchema?.input ? (
           <React.Fragment>

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineSettings.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineSettings.tsx
@@ -174,32 +174,6 @@ export const PipelineSettings = ({
             />
             <Form.Field
               control={form.control}
-              name="sourceUrl"
-              render={({ field }) => {
-                return (
-                  <Form.Item className="flex flex-col gap-y-2.5 md:w-1/2">
-                    <Form.Label className="product-body-text-3-semibold">
-                      GitHub
-                    </Form.Label>
-                    <Form.Control>
-                      <Input.Root>
-                        <Input.Core
-                          {...field}
-                          className="!product-body-text-2-regular"
-                          type="text"
-                          placeholder="GitHub repo url"
-                          required={false}
-                          value={field.value || ""}
-                        />
-                      </Input.Root>
-                    </Form.Control>
-                    <Form.Message />
-                  </Form.Item>
-                );
-              }}
-            />
-            <Form.Field
-              control={form.control}
               name="documentationUrl"
               render={({ field }) => {
                 return (
@@ -214,32 +188,6 @@ export const PipelineSettings = ({
                           className="!product-body-text-2-regular"
                           type="text"
                           placeholder="Documentation or other relevant url"
-                          required={false}
-                          value={field.value || ""}
-                        />
-                      </Input.Root>
-                    </Form.Control>
-                    <Form.Message />
-                  </Form.Item>
-                );
-              }}
-            />
-            <Form.Field
-              control={form.control}
-              name="license"
-              render={({ field }) => {
-                return (
-                  <Form.Item className="flex flex-col gap-y-2.5 md:w-1/2">
-                    <Form.Label className="product-body-text-3-semibold">
-                      License
-                    </Form.Label>
-                    <Form.Control>
-                      <Input.Root>
-                        <Input.Core
-                          {...field}
-                          className="!product-body-text-2-regular"
-                          type="text"
-                          placeholder="Model license url"
                           required={false}
                           value={field.value || ""}
                         />


### PR DESCRIPTION
Because

- there are minor bugs and an issue with the readme editor

This commit

- in a way fixes INS-5366
- API wording update
- removed GitHub and License fields from the pipeline