### PR TITLE
fix(pipeline-editor): fix user can not scroll in the node when it's overflow

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeWrapper.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/nodes/common/NodeWrapper.tsx
@@ -73,7 +73,7 @@ export const NodeWrapper = ({
 
   return (
     <div
-      className="relative"
+      className="relative nowheel"
       onClick={() => {
         updateSelectedConnectorNodeId(() => nodeID);
 


### PR DESCRIPTION
Because

- fix user can not scroll in the node when it's overflow

This commit

- fix user can not scroll in the node when it's overflow
