### PR TITLE
fix: incorrect endpoint to run pipeline

### DIFF
--- a/packages/toolkit/src/constant/pipeline.ts
+++ b/packages/toolkit/src/constant/pipeline.ts
@@ -106,8 +106,8 @@ export const getInstillPipelineHttpRequestExample = ({
   inputsString,
   version,
 }: {
-  pipelineName: Nullable<string>;
-  inputsString: Nullable<string>;
+  pipelineName?: string;
+  inputsString?: string;
   version: Nullable<string>;
 }) => {
   if (!pipelineName || !inputsString) {

--- a/packages/toolkit/src/constant/pipeline.ts
+++ b/packages/toolkit/src/constant/pipeline.ts
@@ -116,9 +116,8 @@ export const getInstillPipelineHttpRequestExample = ({
 
   let snippet = triggerPipelineSnippet;
 
-  const triggerEndpoint = version && version !== "latest" 
-    ? `releases/${version}/trigger` 
-    : "trigger";
+  const triggerEndpoint =
+    version && version !== "latest" ? `releases/${version}/trigger` : "trigger";
 
   snippet = snippet
     .replace(/\{vdp-pipeline-base-url\}/g, env("NEXT_PUBLIC_API_GATEWAY_URL"))

--- a/packages/toolkit/src/constant/pipeline.ts
+++ b/packages/toolkit/src/constant/pipeline.ts
@@ -106,8 +106,8 @@ export const getInstillPipelineHttpRequestExample = ({
   inputsString,
   version,
 }: {
-  pipelineName?: string;
-  inputsString?: string;
+  pipelineName: Nullable<string>;
+  inputsString: Nullable<string>;
   version: Nullable<string>;
 }) => {
   if (!pipelineName || !inputsString) {
@@ -116,7 +116,9 @@ export const getInstillPipelineHttpRequestExample = ({
 
   let snippet = triggerPipelineSnippet;
 
-  const triggerEndpoint = version ? `releases/${version}/trigger` : "trigger";
+  const triggerEndpoint = version && version !== "latest" 
+    ? `releases/${version}/trigger` 
+    : "trigger";
 
   snippet = snippet
     .replace(/\{vdp-pipeline-base-url\}/g, env("NEXT_PUBLIC_API_GATEWAY_URL"))


### PR DESCRIPTION
Because

The endpoint from the Instill Cloud Toolkit should be:

https://api.instill.tech/v1beta/organizations/instill-ai/pipelines/ticket-triage-demo/trigger 

The endpoint from the Instill Cloud Toolkit is:

https://api.instill.tech/v1beta/organizations/instill-ai/pipelines/ticket-triage-demo/releases/latest/trigger


