### PR TITLE
fix: fix model api snippet not correctly cast with double quote for authorization token

### DIFF
--- a/packages/toolkit/src/constant/model.ts
+++ b/packages/toolkit/src/constant/model.ts
@@ -106,8 +106,8 @@ export const getInstillTaskHttpRequestExample = (model?: Model) => {
   const apiVersion = env("NEXT_PUBLIC_MODEL_API_VERSION");
 
   return `curl --location 'https://api.instill.tech/${apiVersion}/${model.name}/trigger' \\
---header 'Content-Type: application/json' \\
---header 'Authorization: Bearer $INSTILL_API_TOKEN' \\
+--header "Content-Type: application/json" \\
+--header "Authorization: Bearer $INSTILL_API_TOKEN" \\
 --data '{
   "taskInputs": [
     {

--- a/packages/toolkit/src/view/pipeline-builder/components/PipelineToolkitDialog.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/PipelineToolkitDialog.tsx
@@ -84,7 +84,10 @@ export const PipelineToolkitDialog = (props: PipelineToolkitDialogProps) => {
             </Tabs.List>
             <div className="flex h-full w-full">
               <Tabs.Content className={tabContentStyle} value="snippet">
-                <ScrollArea.Root className="h-full">
+                <ScrollArea.Root
+                  viewPortClassName="max-w-[496px]"
+                  className="h-full"
+                >
                   <CodeBlock
                     codeString={snippet}
                     wrapLongLines={true}
@@ -95,6 +98,10 @@ export const PipelineToolkitDialog = (props: PipelineToolkitDialogProps) => {
                       fontSize: "14px",
                       backgroundColor: "white",
                       width: "100%",
+                      maxWidth: "496px",
+                      padding: "48px 12px",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-all",
                     }}
                   />
                 </ScrollArea.Root>
@@ -109,6 +116,7 @@ export const PipelineToolkitDialog = (props: PipelineToolkitDialogProps) => {
                       fontSize: "14px",
                       backgroundColor: "white",
                       width: "100%",
+                      padding: "0 8px 0 8px",
                     }}
                   />
                 </ScrollArea.Root>

--- a/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippet.ts
+++ b/packages/toolkit/src/view/pipeline-builder/components/triggerPipelineSnippet.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-useless-escape */
 
 export const triggerPipelineSnippet = `curl -X POST '{vdp-pipeline-base-url}/v1beta/{pipeline-name}/{trigger-endpoint}' \\
---header 'Content-Type: application/json' \\
---header 'Authorization: Bearer $INSTILL_API_TOKEN' \\
+--header "Content-Type: application/json" \\
+--header "Authorization: Bearer $INSTILL_API_TOKEN" \\
 --data '{input-array}'
 `;


### PR DESCRIPTION
Because

- fix model api snippet not correctly cast with double quote for authorization token

This commit

- fix model api snippet not correctly cast with double quote for authorization token
