### PR TITLE
fix: fix typo in the pipeline api tab

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineApi.tsx
@@ -114,7 +114,7 @@ export const PipelineApi = ({ pipeline, releases }: PipelineApiProps) => {
           <CodeString>
             {owner.id}/{pipeline?.id}
           </CodeString>{" "}
-          using Instill API.
+          using API.
         </div>
         <CodeBlock
           codeString={runSnippet}


### PR DESCRIPTION
Because

- fix typo in the pipeline api tab

This commit

-  fix typo in the pipeline api tab