### PR TITLE
fix: fix navlink wrongly highlight when user is in /explore and /feature page

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.97.0-rc.24",
+  "version": "0.97.0-rc.28",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/components/top-bar/ExploreLink.tsx
+++ b/packages/toolkit/src/components/top-bar/ExploreLink.tsx
@@ -7,7 +7,8 @@ import cn from "clsx";
 export const ExploreLink = () => {
   const pathname = usePathname();
 
-  const isActive = pathname.startsWith("/hub");
+  const isActive =
+    pathname.startsWith("/explore") || pathname.startsWith("/featured");
 
   return (
     <div className="my-auto flex flex-row gap-x-1">

--- a/packages/toolkit/src/components/top-bar/NavLinks.tsx
+++ b/packages/toolkit/src/components/top-bar/NavLinks.tsx
@@ -36,7 +36,7 @@ const navLinkItems: NavLinkProps[] = [
     strict: true,
   },
   {
-    pathname: "dashboard/pipeline",
+    pathname: "dashboard",
     Icon: Icons.BarChartSquare02,
     title: "Dashboard",
   },
@@ -133,6 +133,7 @@ export const NavLinks = ({ isExploreRoute }: { isExploreRoute?: boolean }) => {
               Icon={Icon}
               title={title}
               isExploreRoute={isExploreRoute}
+              strict={true}
             />
           ))
         : null}


### PR DESCRIPTION
Because

- fix navlink wrongly highlight when user is in /explore and /feature page

This commit

- fix navlink wrongly highlight when user is in /explore and /feature page
