### PR TITLE
fix: make multiple graphics inputs use cover object fit instead of contain

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/ImagesField.tsx
@@ -25,7 +25,7 @@ export const ImagesField = (props: ImagesFieldProps) => {
                   key={`${title}-${image}-field`}
                   alt={`${title}-images-{idx}`}
                   src={image}
-                  className="object-contain"
+                  className="object-cover"
                 />
               );
             })

--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/VideosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/VideosField.tsx
@@ -25,7 +25,7 @@ export const VideosField = (props: VideosFieldProps) => {
                 <VideoPreview
                   key={`${title}-${video}-field`}
                   src={video}
-                  className="object-contain"
+                  className="object-cover"
                 />
               );
             })}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
@@ -69,7 +69,7 @@ export const ImagesField = ({
                           className={cn(
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain",
+                              : "h-[140px] object-cover",
                           )}
                         />
                       ) : (
@@ -79,7 +79,7 @@ export const ImagesField = ({
                             "w-full bg-semantic-bg-secondary",
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain",
+                              : "h-[140px] object-cover",
                           )}
                         />
                       );
@@ -91,7 +91,7 @@ export const ImagesField = ({
                         "w-full",
                         mode === "build"
                           ? "h-[55px] bg-semantic-bg-secondary object-cover"
-                          : "h-[140px] object-contain",
+                          : "h-[140px] object-cover",
                       )}
                     />
                   ))}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
@@ -69,7 +69,7 @@ export const VideosField = ({
                           className={
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain"
+                              : "h-[140px] object-cover"
                           }
                         />
                       ) : (
@@ -79,7 +79,7 @@ export const VideosField = ({
                             "w-full bg-semantic-bg-secondary",
                             mode === "build"
                               ? "h-[55px] object-cover"
-                              : "h-[140px] object-contain",
+                              : "h-[140px] object-cover",
                           )}
                         />
                       );
@@ -91,7 +91,7 @@ export const VideosField = ({
                         "w-full",
                         mode === "build"
                           ? "h-[55px] bg-semantic-bg-secondary object-cover"
-                          : "h-[140px] object-contain",
+                          : "h-[140px] object-cover",
                       )}
                     />
                   ))}


### PR DESCRIPTION
Because

- multiple graphics elements inputs had white backgrounds , because of the `object-fit: contain` css prop

This commit

- made them use `object-fit: cover`
