### PR TITLE
fix: replace log in to clone with log in to run button on the model page

### DIFF
--- a/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
@@ -384,11 +384,11 @@ export const ModelPlayground = ({
                   onClick={() => {
                     navigateBackAfterLogin();
                   }}
-                  className="!normal-case"
-                  variant="secondaryGrey"
+                  className="!h-8 !normal-case"
+                  variant="secondaryColour"
                   size="md"
                 >
-                  Log in to Clone
+                  Log in to Run
                 </Button>
               )}
             </div>


### PR DESCRIPTION
Because

- replace log in to clone with log in to run button on the model page

This commit

- replace log in to clone with log in to run button on the model page
