### PR TITLE
fix(pipeline-editor): fix video input-output always show play icon after playing once

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/common/VideoPreview.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/common/VideoPreview.tsx
@@ -30,6 +30,7 @@ export const VideoPreview = ({
         ref={videoRef}
         src={src}
         className={cn("w-full object-contain", className)}
+        onEnded={() => setIsPlaying(false)}
       />
       {isPlaying ? (
         <div className="absolute bottom-0 left-0 right-0 top-0 z-10 flex items-center justify-center">


### PR DESCRIPTION
Because

- fix video input-output always show play icon after playing once

This commit

- fix video input-output always show play icon after playing once
