### PR TITLE
fix(pipeline-editor): fix console not correctly handle array:semi-structured edge case

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -209,6 +209,25 @@ export function pickComponentOutputFieldsFromInstillFormTree(
     const arrayType = tree.instillFormat.replaceAll("array:", "").split("/")[0];
 
     if (arrayType?.includes("structured")) {
+      // Some time even the type hint is array:semi-structured, backend will still be possible
+      // to return array of string or array of number. So we need to handle that case here
+      if (Array.isArray(propertyValue) && propertyValue.length > 0) {
+        const firstElement = propertyValue[0];
+        if (
+          typeof firstElement === "string" ||
+          typeof firstElement === "number"
+        ) {
+          return (
+            <ComponentOutputFields.ObjectField
+              mode={mode}
+              title={title}
+              object={propertyValue}
+              hideField={hideField}
+            />
+          );
+        }
+      }
+
       return (
         <ComponentOutputFields.ObjectsField
           mode={mode}

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -215,7 +215,8 @@ export function pickComponentOutputFieldsFromInstillFormTree(
         const firstElement = propertyValue[0];
         if (
           typeof firstElement === "string" ||
-          typeof firstElement === "number"
+          typeof firstElement === "number" ||
+          typeof firstElement === "boolean"
         ) {
           return (
             <ComponentOutputFields.ObjectField


### PR DESCRIPTION
Because

- Even backend hint frontend that the response is array:semi-structured, we still need to handle the possibility that backend can return array of primitives type

This commit

- fix console not correctly handle array:semi-structured edge case
