### PR TITLE
fix: fix duplicated page indicator on explore/featured related pages

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.98.3",
+  "version": "0.99.0-rc.2",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/components/top-bar/AppTopbar.tsx
+++ b/packages/toolkit/src/components/top-bar/AppTopbar.tsx
@@ -50,7 +50,8 @@ export const AppTopbar = ({
   const navigate = useGuardPipelineBuilderUnsavedChangesNavigation();
 
   const isCloud = env("NEXT_PUBLIC_APP_ENV") === "CLOUD";
-  const isExploreRoute = pathname.startsWith("/hub");
+  const isExploreRoute =
+    pathname.startsWith("/featured") || pathname.startsWith("/explore");
 
   return (
     <div className="flex w-full flex-col">


### PR DESCRIPTION
Because

- We have duplicated indicator on featured/explore related pages
![CleanShot 2024-08-12 at 16 03 31](https://github.com/user-attachments/assets/39defacf-0702-45db-a2e5-1d75cf677692)

This commit

- fix duplicated page indicator on explore/featured related pages
