### PR TITLE
feat: show private/public labels for model cards and on model page

### DIFF
--- a/packages/toolkit/src/components/card-model/Tags.tsx
+++ b/packages/toolkit/src/components/card-model/Tags.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import * as React from "react";
 import { Icons, Tag } from "@instill-ai/design-system";
-
 import { Visibility } from "../../lib";
 
 export type TagsProps = {
@@ -11,12 +11,11 @@ export type TagsProps = {
 };
 
 export const Tags = (props: TagsProps) => {
-  const { region, hardware } = props;
+  const { region, hardware, visibilityStatus } = props;
 
   return (
     <div className="flex shrink-0 flex-row gap-x-2">
-      {/* INS-5438: We tempoarily hide the private option for better visibility */}
-      {/* {visibilityStatus ? (
+      {visibilityStatus ? (
         <Tag
           variant="lightNeutral"
           size="md"
@@ -34,7 +33,7 @@ export const Tags = (props: TagsProps) => {
             </React.Fragment>
           )}
         </Tag>
-      ) : null} */}
+      ) : null}
       <Tag
         variant="lightNeutral"
         size="md"

--- a/packages/toolkit/src/components/card-model/Tags.tsx
+++ b/packages/toolkit/src/components/card-model/Tags.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as React from "react";
+
 import { Icons, Tag } from "@instill-ai/design-system";
+
 import { Visibility } from "../../lib";
 
 export type TagsProps = {

--- a/packages/toolkit/src/view/model/view-model/ModelHead.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelHead.tsx
@@ -89,17 +89,25 @@ export const ModelHead = ({
                 /<span className="text-semantic-fg-primary">{model?.id}</span>
               </div>
               {modelState ? <ModelStateLabel state={modelState} /> : null}
-              {/* INS-5438: We tempoarily hide the private option for better visibility */}
-              {/* {model?.visibility !== "VISIBILITY_PUBLIC" ? (
-                <Tag
-                  className="my-auto h-6 gap-x-1 !border-0 !py-0 !text-sm"
-                  variant="lightNeutral"
-                  size="sm"
-                >
-                  <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
-                  Private
-                </Tag>
-              ) : null} */}
+              <Tag
+                className="my-auto h-6 gap-x-1 !border-0 !py-0 !text-sm"
+                variant="lightNeutral"
+                size="sm"
+              >
+                {model?.visibility !== "VISIBILITY_PUBLIC"
+                  ? (
+                    <React.Fragment>
+                      <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
+                      Private
+                    </React.Fragment>
+                  ) : (
+                    <React.Fragment>
+                      <Icons.BookOpen02 className="h-3 w-3 stroke-semantic-fg-primary" />
+                      Public
+                    </React.Fragment>
+                  )
+                }
+              </Tag>
               {model?.sourceUrl ? (
                 <HeadExternalLink href={model.sourceUrl}>
                   <GitHubIcon

--- a/packages/toolkit/src/view/model/view-model/ModelHead.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelHead.tsx
@@ -94,19 +94,17 @@ export const ModelHead = ({
                 variant="lightNeutral"
                 size="sm"
               >
-                {model?.visibility !== "VISIBILITY_PUBLIC"
-                  ? (
-                    <React.Fragment>
-                      <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
-                      Private
-                    </React.Fragment>
-                  ) : (
-                    <React.Fragment>
-                      <Icons.BookOpen02 className="h-3 w-3 stroke-semantic-fg-primary" />
-                      Public
-                    </React.Fragment>
-                  )
-                }
+                {model?.visibility !== "VISIBILITY_PUBLIC" ? (
+                  <React.Fragment>
+                    <Icons.Lock03 className="h-3 w-3 stroke-semantic-fg-primary" />
+                    Private
+                  </React.Fragment>
+                ) : (
+                  <React.Fragment>
+                    <Icons.BookOpen02 className="h-3 w-3 stroke-semantic-fg-primary" />
+                    Public
+                  </React.Fragment>
+                )}
               </Tag>
               {model?.sourceUrl ? (
                 <HeadExternalLink href={model.sourceUrl}>


### PR DESCRIPTION
Because

- we need to show the private/public model status

This commit

- uncomment the labels code
