### PR TITLE
fix(editor): replace .txt with .yaml as download extension for low-code editor

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
@@ -226,7 +226,7 @@ export const RecipeEditorView = () => {
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = `${pipeline.data.id}_recipe.txt`;
+      link.download = `${pipeline.data.id}_recipe.yaml`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
Because

- Previously, we use .txt file extension for dowloaded recipe format. 

This commit

-  replace .txt with .yaml as download extension for low-code editor.
