### PR TITLE
fix(editor): fix maximize and minimize view will cause preview not focus

### DIFF
--- a/packages/toolkit/src/lib/use-instill-store/editorSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/editorSlice.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Monaco } from "@monaco-editor/react";
 import { editor } from "monaco-editor";
+import { ReactFlowInstance } from "reactflow";
 import { StateCreator } from "zustand";
 
 import { Nullable } from "../type";
@@ -55,7 +56,6 @@ export const createEditorSlice: StateCreator<
         monacoRef: fn(state.monacoRef),
       };
     }),
-  cursorPosition: 0,
   editorMultiScreenModel: {
     main: {
       views: [],
@@ -127,13 +127,15 @@ export const createEditorSlice: StateCreator<
         triggerPipelineStreamMap: fn(state.triggerPipelineStreamMap),
       };
     }),
-  forceStopTriggerPipelineStream: false,
-  updateForceStopTriggerPipelineStream: (fn: (prev: boolean) => boolean) =>
+  editorPreviewReactFlowInstance: null,
+  updateEditorPreviewReactFlowInstance: (
+    fn: (prev: Nullable<ReactFlowInstance>) => Nullable<ReactFlowInstance>,
+  ) =>
     set((state) => {
       return {
         ...state,
-        forceStopTriggerPipelineStream: fn(
-          state.forceStopTriggerPipelineStream,
+        editorPreviewReactFlowInstance: fn(
+          state.editorPreviewReactFlowInstance,
         ),
       };
     }),

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -7,7 +7,14 @@ import type {
 } from "instill-sdk";
 import { Monaco } from "@monaco-editor/react";
 import { editor } from "monaco-editor";
-import { Edge, Node, OnConnect, OnEdgesChange, OnNodesChange } from "reactflow";
+import {
+  Edge,
+  Node,
+  OnConnect,
+  OnEdgesChange,
+  OnNodesChange,
+  ReactFlowInstance,
+} from "reactflow";
 
 import { NodeData } from "../../view";
 import { Nullable } from "../type";
@@ -134,10 +141,19 @@ export type GeneralSlice = {
   ) => void;
 };
 
+export enum DefaultEditorViewIDs {
+  MAIN_PREVIEW_FLOW,
+  MAIN_INPUT,
+  MAIN_OUTPUT,
+  GETTING_STARTED,
+}
+
+export type EditorViewID = string | DefaultEditorViewIDs;
+
 export type EditorViewType = "preview" | "docs" | "input" | "output";
 
 export type EditorView = {
-  id: string;
+  id: EditorViewID;
   type: EditorViewType;
   view: React.ReactNode;
   title: string;
@@ -146,7 +162,7 @@ export type EditorView = {
 
 export type EditorViewSection = {
   views: EditorView[];
-  currentViewId: Nullable<string>;
+  currentViewId: Nullable<EditorViewID>;
 };
 
 export type EditorMultiScreenModel = {
@@ -164,7 +180,6 @@ export type EditorSlice = {
   updateSelectedComponentId: (
     fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
-  cursorPosition: number;
   editorRef: Nullable<editor.IStandaloneCodeEditor>;
   updateEditorRef: (
     fn: (
@@ -173,12 +188,23 @@ export type EditorSlice = {
   ) => void;
   monacoRef: Nullable<Monaco>;
   updateMonacoRef: (fn: (prev: Nullable<Monaco>) => Nullable<Monaco>) => void;
+
+  /**
+   * We use this value to control the multile screen editor
+   */
   editorMultiScreenModel: EditorMultiScreenModel;
   updateEditorMultiScreenModel: (
     fn: (prev: EditorMultiScreenModel) => EditorMultiScreenModel,
   ) => void;
-  rawRecipeOnDom: Nullable<string>;
 
+  /**
+   * This is used to store the react flow instance for the editor preview
+   * You can control the react flow instance via this instance
+   */
+  editorPreviewReactFlowInstance: Nullable<ReactFlowInstance>;
+  updateEditorPreviewReactFlowInstance: (
+    fn: (prev: Nullable<ReactFlowInstance>) => Nullable<ReactFlowInstance>,
+  ) => void;
   /**
    * This value is only for caching the user input in the editor.
    *
@@ -187,6 +213,7 @@ export type EditorSlice = {
    * from the monaco-editor to have history record for undo/redo.
    * @returns void
    */
+  rawRecipeOnDom: Nullable<string>;
   updateRawRecipeOnDom: (
     fn: (prev: Nullable<string>) => Nullable<string>,
   ) => void;
@@ -211,11 +238,6 @@ export type EditorSlice = {
     fn: (
       prev: Nullable<TriggerPipelineStreamMap>,
     ) => Nullable<TriggerPipelineStreamMap>,
-  ) => void;
-
-  forceStopTriggerPipelineStream: boolean;
-  updateForceStopTriggerPipelineStream: (
-    fn: (prev: boolean) => boolean,
   ) => void;
 };
 

--- a/packages/toolkit/src/view/recipe-editor/EditorViewBarItem.tsx
+++ b/packages/toolkit/src/view/recipe-editor/EditorViewBarItem.tsx
@@ -7,7 +7,7 @@ import { Nullable } from "instill-sdk";
 
 import { Button, cn, Icons } from "@instill-ai/design-system";
 
-import { EditorViewType } from "../../lib";
+import { EditorViewID, EditorViewType } from "../../lib";
 
 export const EditorViewBarItem = ({
   id,
@@ -18,12 +18,12 @@ export const EditorViewBarItem = ({
   onDelete,
   closeable,
 }: {
-  id: string;
+  id: EditorViewID;
   title: string;
   type: EditorViewType;
-  currentViewId: Nullable<string>;
-  onClick: (id: string) => void;
-  onDelete: (id: string) => void;
+  currentViewId: Nullable<EditorViewID>;
+  onClick: (id: EditorViewID) => void;
+  onDelete: (id: EditorViewID) => void;
   closeable: boolean;
 }) => {
   const {

--- a/packages/toolkit/src/view/recipe-editor/EditorViewSectionBar.tsx
+++ b/packages/toolkit/src/view/recipe-editor/EditorViewSectionBar.tsx
@@ -5,7 +5,7 @@ import { Nullable } from "instill-sdk";
 
 import { Icons } from "@instill-ai/design-system";
 
-import { EditorView } from "../../lib";
+import { EditorView, EditorViewID } from "../../lib";
 import { EditorViewBarItem } from "./EditorViewBarItem";
 import { HorizontalSortableWrapper } from "./HorizontalSortableWrapper";
 
@@ -22,9 +22,9 @@ export const EditorViewSectionBar = ({
   onDragEnd: (event: DragEndEvent) => void;
   isExpanded: boolean;
   onToggleExpand: () => void;
-  onClick: (id: string) => void;
-  onDelete: (id: string) => void;
-  currentViewId: Nullable<string>;
+  onClick: (id: EditorViewID) => void;
+  onDelete: (id: EditorViewID) => void;
+  currentViewId: Nullable<EditorViewID>;
 }) => {
   return (
     <div className="flex flex-row rounded-t min-h-8 pr-1 bg-semantic-bg-base-bg box-border border-b border-semantic-bg-line">

--- a/packages/toolkit/src/view/recipe-editor/VscodeEditor.tsx
+++ b/packages/toolkit/src/view/recipe-editor/VscodeEditor.tsx
@@ -406,7 +406,7 @@ export const VscodeEditor = () => {
           result.push({
             label: format,
             kind: monaco.languages.CompletionItemKind.Field,
-            insertText: `"${format}"`,
+            insertText: format,
             filterText: format,
             range: new monaco.Range(
               position.lineNumber,

--- a/packages/toolkit/src/view/recipe-editor/flow/Flow.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/Flow.tsx
@@ -5,7 +5,6 @@ import { PipelineRecipe } from "instill-sdk";
 import ReactFlow, {
   Background,
   BackgroundVariant,
-  ReactFlowInstance,
   SelectionMode,
   useEdgesState,
   useNodesState,
@@ -44,7 +43,15 @@ const edgeTypes = {
 
 const selector = (store: InstillStore) => ({
   updateSelectedComponentId: store.updateSelectedComponentId,
+  editorPreviewReactFlowInstance: store.editorPreviewReactFlowInstance,
+  updateEditorPreviewReactFlowInstance:
+    store.updateEditorPreviewReactFlowInstance,
 });
+
+export const fitViewOptions = {
+  includeHiddenNodes: true,
+  padding: 10,
+};
 
 export const Flow = ({
   pipelineId,
@@ -57,10 +64,12 @@ export const Flow = ({
 }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-  const [reactFlowInstance, setReactFlowInstance] =
-    React.useState<Nullable<ReactFlowInstance>>(null);
 
-  const { updateSelectedComponentId } = useInstillStore(useShallow(selector));
+  const {
+    updateSelectedComponentId,
+    editorPreviewReactFlowInstance,
+    updateEditorPreviewReactFlowInstance,
+  } = useInstillStore(useShallow(selector));
 
   React.useEffect(() => {
     if (!recipe || !pipelineMetadata) return;
@@ -78,21 +87,24 @@ export const Flow = ({
       .catch((err) => {
         console.error(err);
       });
-  }, [recipe, pipelineMetadata, setEdges, setNodes, reactFlowInstance]);
+  }, [
+    recipe,
+    pipelineMetadata,
+    setEdges,
+    setNodes,
+    editorPreviewReactFlowInstance,
+  ]);
 
   return (
     <div className="flex flex-col w-full h-full group">
       <div className="flex flex-row h-9 justify-between items-center bg-semantic-bg-alt-primary border-b border-semantic-bg-line">
         <button
           onClick={() => {
-            if (!reactFlowInstance) {
+            if (!editorPreviewReactFlowInstance) {
               return;
             }
 
-            reactFlowInstance.fitView({
-              includeHiddenNodes: true,
-              padding: 10,
-            });
+            editorPreviewReactFlowInstance.fitView(fitViewOptions);
           }}
           className="p-1.5"
         >
@@ -102,11 +114,11 @@ export const Flow = ({
           <button
             className="p-1.5"
             onClick={() => {
-              if (!reactFlowInstance) {
+              if (!editorPreviewReactFlowInstance) {
                 return;
               }
 
-              reactFlowInstance.zoomIn();
+              editorPreviewReactFlowInstance.zoomIn();
             }}
           >
             <Icons.Plus className="w-3 h-3 stroke-semantic-fg-primary" />
@@ -114,11 +126,11 @@ export const Flow = ({
           <button
             className="p-1.5"
             onClick={() => {
-              if (!reactFlowInstance) {
+              if (!editorPreviewReactFlowInstance) {
                 return;
               }
 
-              reactFlowInstance.zoomOut();
+              editorPreviewReactFlowInstance.zoomOut();
             }}
           >
             <Icons.Minus className="w-3 h-3 stroke-semantic-fg-primary" />
@@ -134,16 +146,15 @@ export const Flow = ({
         onEdgesChange={onEdgesChange}
         fitView={true}
         minZoom={0.5}
-        fitViewOptions={{
-          includeHiddenNodes: true,
-          padding: 10,
-        }}
+        fitViewOptions={fitViewOptions}
         onPaneClick={() => {
           updateSelectedComponentId(() => null);
         }}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
-        onInit={setReactFlowInstance}
+        onInit={(instance) => {
+          updateEditorPreviewReactFlowInstance(() => instance);
+        }}
         proOptions={{ hideAttribution: true }}
         elevateNodesOnSelect={true}
         // To enable Figma-like zoom-in-out experience

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
@@ -26,9 +26,6 @@ const selector = (store: InstillStore) => ({
   selectedComponentId: store.selectedComponentId,
   updateSelectedComponentId: store.updateSelectedComponentId,
   triggerPipelineStreamMap: store.triggerPipelineStreamMap,
-  forceStopTriggerPipelineStream: store.forceStopTriggerPipelineStream,
-  updateForceStopTriggerPipelineStream:
-    store.updateForceStopTriggerPipelineStream,
 });
 
 type ComponentErrorState =
@@ -108,11 +105,19 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
         column: 0,
       });
 
+      // We need this happen after the editor is updated
       setTimeout(() => {
         editorRef.focus();
-      }, 1);
+      });
     }
-  }, [editorRef, pipeline.isSuccess, updateEditorMultiScreenModel]);
+  }, [
+    id,
+    editorRef,
+    pipeline.isSuccess,
+    pipeline.data,
+    updateSelectedComponentId,
+    updateEditorMultiScreenModel,
+  ]);
 
   const handleOpenDocumentation = React.useCallback(() => {
     let documentationUrl: Nullable<string> = null;
@@ -174,7 +179,7 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
         currentViewId: viewId,
       },
     }));
-  }, [data, updateEditorMultiScreenModel]);
+  }, [id, data, updateEditorMultiScreenModel]);
 
   const errorState = React.useMemo<ComponentErrorState>(() => {
     if (!triggerPipelineStreamMap || !triggerPipelineStreamMap.component) {

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
@@ -116,7 +116,6 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
     pipeline.isSuccess,
     pipeline.data,
     updateSelectedComponentId,
-    updateEditorMultiScreenModel,
   ]);
 
   const handleOpenDocumentation = React.useCallback(() => {

--- a/packages/toolkit/src/view/recipe-editor/getting-started-view/GettingStartedView.tsx
+++ b/packages/toolkit/src/view/recipe-editor/getting-started-view/GettingStartedView.tsx
@@ -6,7 +6,7 @@ import { stackoverflowLight } from "react-syntax-highlighter/dist/esm/styles/hlj
 
 import { cn, Icons, Separator } from "@instill-ai/design-system";
 
-import { EditorView } from "../../../lib";
+import { DefaultEditorViewIDs, EditorView } from "../../../lib";
 import {
   addOutputCodeHint,
   addOutputCodeTemplate,
@@ -95,7 +95,7 @@ export const GettingStartedView = () => {
 };
 
 export const gettingStartedEditorView: EditorView = {
-  id: "getting-started",
+  id: DefaultEditorViewIDs.GETTING_STARTED,
   title: "Getting Started",
   type: "docs",
   view: <GettingStartedView />,

--- a/packages/toolkit/src/view/recipe-editor/input/Input.tsx
+++ b/packages/toolkit/src/view/recipe-editor/input/Input.tsx
@@ -15,6 +15,7 @@ import * as z from "zod";
 import { Form } from "@instill-ai/design-system";
 
 import {
+  DefaultEditorViewIDs,
   GeneralRecord,
   InstillStore,
   Nullable,
@@ -32,7 +33,6 @@ const selector = (store: InstillStore) => ({
   updateIsTriggeringPipeline: store.updateIsTriggeringPipeline,
   navigationNamespaceAnchor: store.navigationNamespaceAnchor,
   accessToken: store.accessToken,
-  triggerPipelineStreamMap: store.triggerPipelineStreamMap,
   updateTriggerPipelineStreamMap: store.updateTriggerPipelineStreamMap,
   updateEditorMultiScreenModel: store.updateEditorMultiScreenModel,
 });
@@ -50,7 +50,6 @@ export const Input = ({
     navigationNamespaceAnchor,
     accessToken,
     updateTriggerPipelineStreamMap,
-    triggerPipelineStreamMap,
     updateEditorMultiScreenModel,
   } = useInstillStore(useShallow(selector));
 
@@ -104,7 +103,7 @@ export const Input = ({
         ...prev,
         bottomRight: {
           ...prev.bottomRight,
-          currentViewId: "main-output",
+          currentViewId: DefaultEditorViewIDs.MAIN_OUTPUT,
         },
       }));
 
@@ -289,7 +288,6 @@ export const Input = ({
       isTriggeringPipeline,
       updateIsTriggeringPipeline,
       updateTriggerPipelineStreamMap,
-      triggerPipelineStreamMap,
       namespace,
       navigationNamespaceAnchor,
       accessToken,

--- a/packages/toolkit/src/view/recipe-editor/sidebar/SupportLinks.tsx
+++ b/packages/toolkit/src/view/recipe-editor/sidebar/SupportLinks.tsx
@@ -1,6 +1,11 @@
 import { Icons } from "@instill-ai/design-system";
 
-import { InstillStore, useInstillStore, useShallow } from "../../../lib";
+import {
+  DefaultEditorViewIDs,
+  InstillStore,
+  useInstillStore,
+  useShallow,
+} from "../../../lib";
 import { gettingStartedEditorView } from "../getting-started-view";
 
 const selector = (store: InstillStore) => ({
@@ -21,11 +26,11 @@ export const SupportLinks = () => {
             topRight: {
               views: [
                 ...prev.topRight.views.filter(
-                  (view) => view.id !== "getting-started",
+                  (view) => view.id !== DefaultEditorViewIDs.GETTING_STARTED,
                 ),
                 gettingStartedEditorView,
               ],
-              currentViewId: "getting-started",
+              currentViewId: DefaultEditorViewIDs.GETTING_STARTED,
             },
           }));
         }}


### PR DESCRIPTION
Because

- When user expand the top-right panel, the main preview canvas will lose its focus and behave weirdly

This commit

- fix maximize and minimize view will cause preview not focus
