### PR TITLE
feat(editor): add the pipeline run output placeholder view 

### DIFF
--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelinePlayground.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelinePlayground.tsx
@@ -450,7 +450,7 @@ export const PipelinePlayground = ({
               alt="Square shapes"
             />
             <p className="font-mono text-sm italic text-semantic-fg-disabled">
-              Execute the pipeline to view the results
+              Run the pipeline to view the results
             </p>
           </div>
         )}

--- a/packages/toolkit/src/view/recipe-editor/Output.tsx
+++ b/packages/toolkit/src/view/recipe-editor/Output.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import * as React from "react";
+import Image from "next/image";
+
 import {
   InstillJSONSchema,
   InstillStore,
@@ -25,11 +30,32 @@ export const Output = ({
     chooseTitleFrom: "title",
   });
 
+  const hasOutput = React.useMemo(() => {
+    if (triggerPipelineStreamMap?.pipeline?.output) {
+      return true;
+    }
+    return false;
+  }, [triggerPipelineStreamMap]);
+
   return (
     <div className="flex flex-col py-4 w-full h-full">
-      <div className="flex flex-col gap-y-1 rounded bg-semantic-bg-primary">
-        {componentOutputFields}
-      </div>
+      {hasOutput ? (
+        <div className="flex flex-col gap-y-1 rounded bg-semantic-bg-primary">
+          {componentOutputFields}
+        </div>
+      ) : (
+        <div className="flex flex-row items-center justify-center gap-x-4 pt-24">
+          <Image
+            src="/images/models/no-result.svg"
+            width={41}
+            height={40}
+            alt="Square shapes"
+          />
+          <p className="font-mono text-sm italic text-semantic-fg-disabled">
+            Run the pipeline to view the results
+          </p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Because

- We want to make the user understand that they need to run the pipeline before viewing the result

This commit

- add the pipeline run output placeholder view 
