### PR TITLE
feat: reduce the low-code editor font-size to 12px

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/VscodeEditor.tsx
+++ b/packages/toolkit/src/view/recipe-editor/VscodeEditor.tsx
@@ -1041,7 +1041,7 @@ export const VscodeEditor = () => {
           suggest: {
             showSnippets: true,
           },
-          fontSize: 18,
+          fontSize: 12,
           readOnly: currentVersion !== "latest",
           readOnlyMessage: {
             value:

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/NodeBase.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/NodeBase.tsx
@@ -153,7 +153,7 @@ export const NodeBase = ({
         )}
       >
         <div className="flex flex-col">
-          <p className="product-body-text-3-medium w-full text-center text-semantic-fg-disabled">
+          <p className="product-body-text-4-medium w-full text-center text-semantic-fg-disabled">
             {id}
           </p>
         </div>


### PR DESCRIPTION
Because

- reduce the low-code editor font-size to 12px

This commit

- reduce the low-code editor font-size to 12px
