### PR TITLE
fix(pipeline/models): fix add redirections

### DIFF
--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -1,19 +1,27 @@
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
-import { fetchNamespaceType, fetchUserModel } from '@instill-ai/toolkit/server';
-import { Nullable } from '@instill-ai/toolkit';
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { Nullable } from "@instill-ai/toolkit";
+import { fetchNamespaceType, fetchUserModel } from "@instill-ai/toolkit/server";
 
 type RedirectionModelPageProps = {
   params: { id: string; entity: string };
 };
 
-async function getModelData(entity: string, id: string, accessToken: Nullable<string>) {
+async function getModelData(
+  entity: string,
+  id: string,
+  accessToken: Nullable<string>,
+) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+    if (
+      namespaceType === "NAMESPACE_USER" ||
+      namespaceType === "NAMESPACE_ORGANIZATION"
+    ) {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
       return await fetchUserModel({
         modelName: `${namespaceName}/models/${id}`,
@@ -26,7 +34,9 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
   return null;
 }
 
-export default async function RedirectionModelPage({ params }: RedirectionModelPageProps) {
+export default async function RedirectionModelPage({
+  params,
+}: RedirectionModelPageProps) {
   const { entity, id } = params;
   const cookieStore = cookies();
   const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
@@ -39,5 +49,5 @@ export default async function RedirectionModelPage({ params }: RedirectionModelP
   if (modelData) {
     return redirect(`/${entity}/models/${id}/playground`);
   }
-  return redirect('/404');
+  return redirect("/404");
 }

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { fetchNamespaceType, fetchUserModel } from '@instill-ai/toolkit/server';
 import { Nullable } from '@instill-ai/toolkit';
 
-type Props = {
+type RedirectionModelPageProps = {
   params: { id: string; entity: string };
 };
 
@@ -26,7 +26,7 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
   }
 }
 
-export default async function RedirectionModelPage({ params }: Props) {
+export default async function RedirectionModelPage({ params }: RedirectionModelPageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -22,27 +22,27 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
     }
   } catch (error) {
     console.error(error);
-    return null;
+    return Promise.reject(null);
   }
 }
 
 export default async function RedirectionModelPage({ params }: Props) {
   const { entity, id } = params;
-  
+
   const cookieStore = cookies();
   const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
   let accessToken: Nullable<string> = null;
   if (authSessionCookie) {
     accessToken = JSON.parse(authSessionCookie).accessToken;
   }
-  
+
   const modelData = await getModelData(entity, id, accessToken);
-  
+
   // Redirect to 404 if the model doesn't exist
   if (!modelData) {
     return redirect('/404');
   }
-  
+
   // If the model exists, redirect to the playground
   return redirect(`/${entity}/models/${id}/playground`);
 }

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { fetchNamespaceType, fetchUserModel } from '@instill-ai/toolkit/server';
+import { Nullable } from '@instill-ai/toolkit';
+
+type Props = {
+  params: { id: string; entity: string };
+};
+
+async function getModelData(entity: string, id: string, accessToken: Nullable<string>) {
+  try {
+    const namespaceType = await fetchNamespaceType({
+      namespace: entity,
+      accessToken,
+    });
+    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+      const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
+      return await fetchUserModel({
+        modelName: `${namespaceName}/models/${id}`,
+        accessToken,
+      });
+    }
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+export default async function ModelPage({ params }: Props) {
+  const { entity, id } = params;
+  
+  const cookieStore = cookies();
+  const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
+  let accessToken: Nullable<string> = null;
+  if (authSessionCookie) {
+    accessToken = JSON.parse(authSessionCookie).accessToken;
+  }
+  
+  const modelData = await getModelData(entity, id, accessToken);
+  
+  // Redirect to 404 if the model doesn't exist
+  if (!modelData) {
+    return redirect('/404');
+  }
+  
+  // If the model exists, redirect to the playground
+  return redirect(`/${entity}/models/${id}/playground`);
+}

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -1,19 +1,27 @@
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
-import { fetchNamespaceType, fetchUserModel } from '@instill-ai/toolkit/server';
-import { Nullable } from '@instill-ai/toolkit';
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { Nullable } from "@instill-ai/toolkit";
+import { fetchNamespaceType, fetchUserModel } from "@instill-ai/toolkit/server";
 
 type RedirectionModelPageProps = {
   params: { id: string; entity: string };
 };
 
-async function getModelData(entity: string, id: string, accessToken: Nullable<string>) {
+async function getModelData(
+  entity: string,
+  id: string,
+  accessToken: Nullable<string>,
+) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+    if (
+      namespaceType === "NAMESPACE_USER" ||
+      namespaceType === "NAMESPACE_ORGANIZATION"
+    ) {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
       return await fetchUserModel({
         modelName: `${namespaceName}/models/${id}`,
@@ -27,7 +35,9 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
   return null; // Return null if namespaceType doesn't match
 }
 
-export default async function RedirectionModelPage({ params }: RedirectionModelPageProps) {
+export default async function RedirectionModelPage({
+  params,
+}: RedirectionModelPageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();
@@ -42,13 +52,13 @@ export default async function RedirectionModelPage({ params }: RedirectionModelP
 
     // Redirect to 404 if the model doesn't exist
     if (!modelData) {
-      return redirect('/404');
+      return redirect("/404");
     }
 
     // If the model exists, redirect to the playground
     return redirect(`/${entity}/models/${id}/playground`);
   } catch (error) {
     console.error("Error in RedirectionModelPage:", error);
-    return redirect('/404'); // Redirect to 404 on any error
+    return redirect("/404"); // Redirect to 404 on any error
   }
 }

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -1,43 +1,36 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-
-import { Nullable } from "@instill-ai/toolkit";
-import { fetchNamespaceType, fetchUserModel } from "@instill-ai/toolkit/server";
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { Nullable } from '@instill-ai/toolkit';
+import { fetchNamespaceType, fetchUserModel } from '@instill-ai/toolkit/server';
 
 type RedirectionModelPageProps = {
   params: { id: string; entity: string };
 };
 
-async function getModelData(
-  entity: string,
-  id: string,
-  accessToken: Nullable<string>,
-) {
+async function getModelData(entity: string, id: string, accessToken: Nullable<string>) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (
-      namespaceType === "NAMESPACE_USER" ||
-      namespaceType === "NAMESPACE_ORGANIZATION"
-    ) {
+    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
-      return await fetchUserModel({
+      const modelData = await fetchUserModel({
         modelName: `${namespaceName}/models/${id}`,
         accessToken,
       });
+      if (modelData) {
+        return modelData;
+      }
     }
+    return Promise.reject(null);
   } catch (error) {
     console.error(error);
-    return null;
+    return Promise.reject(null);
   }
-  return null; // Return null if namespaceType doesn't match
 }
 
-export default async function RedirectionModelPage({
-  params,
-}: RedirectionModelPageProps) {
+export default async function RedirectionModelPage({ params }: RedirectionModelPageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();
@@ -48,17 +41,11 @@ export default async function RedirectionModelPage({
   }
 
   try {
-    const modelData = await getModelData(entity, id, accessToken);
-
-    // Redirect to 404 if the model doesn't exist
-    if (!modelData) {
-      return redirect("/404");
-    }
-
+    await getModelData(entity, id, accessToken);
     // If the model exists, redirect to the playground
     return redirect(`/${entity}/models/${id}/playground`);
   } catch (error) {
     console.error("Error in RedirectionModelPage:", error);
-    return redirect("/404"); // Redirect to 404 on any error
+    return redirect('/404'); // Redirect to 404 if the model doesn't exist or on any error
   }
 }

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -22,8 +22,9 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
     }
   } catch (error) {
     console.error(error);
-    return Promise.reject(null);
+    return null;
   }
+  return null; // Return null if namespaceType doesn't match
 }
 
 export default async function RedirectionModelPage({ params }: RedirectionModelPageProps) {
@@ -36,13 +37,18 @@ export default async function RedirectionModelPage({ params }: RedirectionModelP
     accessToken = JSON.parse(authSessionCookie).accessToken;
   }
 
-  const modelData = await getModelData(entity, id, accessToken);
+  try {
+    const modelData = await getModelData(entity, id, accessToken);
 
-  // Redirect to 404 if the model doesn't exist
-  if (!modelData) {
-    return redirect('/404');
+    // Redirect to 404 if the model doesn't exist
+    if (!modelData) {
+      return redirect('/404');
+    }
+
+    // If the model exists, redirect to the playground
+    return redirect(`/${entity}/models/${id}/playground`);
+  } catch (error) {
+    console.error("Error in RedirectionModelPage:", error);
+    return redirect('/404'); // Redirect to 404 on any error
   }
-
-  // If the model exists, redirect to the playground
-  return redirect(`/${entity}/models/${id}/playground`);
 }

--- a/apps/console/src/app/[entity]/models/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/page.tsx
@@ -26,7 +26,7 @@ async function getModelData(entity: string, id: string, accessToken: Nullable<st
   }
 }
 
-export default async function ModelPage({ params }: Props) {
+export default async function RedirectionModelPage({ params }: Props) {
   const { entity, id } = params;
   
   const cookieStore = cookies();

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -1,46 +1,36 @@
-import { cookies } from "next/headers";
-import { redirect } from "next/navigation";
-
-import { Nullable } from "@instill-ai/toolkit";
-import {
-  fetchNamespacePipeline,
-  fetchNamespaceType,
-} from "@instill-ai/toolkit/server";
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { fetchNamespacePipeline, fetchNamespaceType } from '@instill-ai/toolkit/server';
+import { Nullable } from '@instill-ai/toolkit';
 
 type RedirectionPipelinePageProps = {
   params: { id: string; entity: string };
 };
 
-async function getPipelineData(
-  entity: string,
-  id: string,
-  accessToken: Nullable<string>,
-) {
+async function getPipelineData(entity: string, id: string, accessToken: Nullable<string>) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (
-      namespaceType === "NAMESPACE_USER" ||
-      namespaceType === "NAMESPACE_ORGANIZATION"
-    ) {
+    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
-      return await fetchNamespacePipeline({
+      const pipelineData = await fetchNamespacePipeline({
         namespacePipelineName: `${namespaceName}/pipelines/${id}`,
         accessToken,
       });
+      if (pipelineData) {
+        return pipelineData;
+      }
     }
+    return Promise.reject(null);
   } catch (error) {
     console.error(error);
-    return null;
+    return Promise.reject(null);
   }
-  return null; // Return null if namespaceType doesn't match
 }
 
-export default async function RedirectionPipelinePage({
-  params,
-}: RedirectionPipelinePageProps) {
+export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();
@@ -51,17 +41,11 @@ export default async function RedirectionPipelinePage({
   }
 
   try {
-    const pipelineData = await getPipelineData(entity, id, accessToken);
-
-    // Redirect to 404 if the pipeline doesn't exist
-    if (!pipelineData) {
-      return redirect("/404");
-    }
-
+    await getPipelineData(entity, id, accessToken);
     // If the pipeline exists, redirect to the playground
     return redirect(`/${entity}/pipelines/${id}/playground`);
   } catch (error) {
     console.error("Error in RedirectionPipelinePage:", error);
-    return redirect("/404"); // Redirect to 404 on any error
+    return redirect('/404'); // Redirect to 404 if the pipeline doesn't exist or on any error
   }
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { cookies } from 'next/headers';
-import { fetchNamespacePipeline, fetchNamespaceType, fetchUser } from '@instill-ai/toolkit/server';
+import { fetchNamespacePipeline, fetchNamespaceType } from '@instill-ai/toolkit/server';
 import { Nullable } from '@instill-ai/toolkit';
 
 type Props = {
@@ -27,33 +27,7 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
   }
 }
 
-async function isOwner(entity: string, id: string, accessToken: Nullable<string>) {
-  if (!accessToken) {
-    return false;
-  }
-  try {
-    const currentUser = await fetchUser({
-      userName: entity,
-      accessToken
-    });
-    if (!currentUser) {
-      return false;
-    }
-    const pipeline = await fetchNamespacePipeline({
-      namespacePipelineName: `users/${entity}/pipelines/${id}`,
-      accessToken,
-    });
-    if (!pipeline) {
-      return false;
-    }
-    return currentUser.id.toString() === pipeline.owner.toString();
-  } catch (error) {
-    console.error("Error checking ownership:", error);
-    return false;
-  }
-}
-
-export default async function PipelinePage({ params, searchParams }: Props) {
+export default async function RedirectionPipelinePage({ params, searchParams }: Props) {
   const { entity, id } = params;
   const tab = searchParams.tab as string | undefined;
   
@@ -70,20 +44,10 @@ export default async function PipelinePage({ params, searchParams }: Props) {
   if (!pipelineData) {
     return redirect('/404');
   }
-  
-  const isResourceOwner = await isOwner(entity, id, accessToken);
-  
+    
   // Redirect to playground if pipeline exists and no specific tab is requested
   if (!tab) {
     return redirect(`/${entity}/pipelines/${id}/playground`);
   }
   
-  // Redirect to playground if not owner and trying to access settings
-  if (tab === 'settings' && !isResourceOwner) {
-    return redirect(`/${entity}/pipelines/${id}/playground`);
-  }
-  
-  // If we reach here, it means we have a valid tab
-  // You can add more specific tab handling here if needed
-  return redirect(`/${entity}/pipelines/${id}/${tab}`);
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -24,6 +24,7 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
     console.error(error);
     return null;
   }
+  return null; // Return null if namespaceType doesn't match
 }
 
 export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
@@ -36,14 +37,18 @@ export default async function RedirectionPipelinePage({ params }: RedirectionPip
     accessToken = JSON.parse(authSessionCookie).accessToken;
   }
 
-  const pipelineData = await getPipelineData(entity, id, accessToken);
+  try {
+    const pipelineData = await getPipelineData(entity, id, accessToken);
 
-  // Redirect to 404 if the pipeline doesn't exist
-  if (!pipelineData) {
-    return redirect('/404');
+    // Redirect to 404 if the pipeline doesn't exist
+    if (!pipelineData) {
+      return redirect('/404');
+    }
+
+    // If the pipeline exists, redirect to the playground
+    return redirect(`/${entity}/pipelines/${id}/playground`);
+  } catch (error) {
+    console.error("Error in RedirectionPipelinePage:", error);
+    return redirect('/404'); // Redirect to 404 on any error
   }
-
-  // If the pipeline exists, redirect to the playground
-  return redirect(`/${entity}/pipelines/${id}/playground`);
-
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -1,0 +1,89 @@
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { fetchNamespacePipeline, fetchNamespaceType, fetchUser } from '@instill-ai/toolkit/server';
+import { Nullable } from '@instill-ai/toolkit';
+
+type Props = {
+  params: { id: string; entity: string };
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+async function getPipelineData(entity: string, id: string, accessToken: Nullable<string>) {
+  try {
+    const namespaceType = await fetchNamespaceType({
+      namespace: entity,
+      accessToken,
+    });
+    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+      const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
+      return await fetchNamespacePipeline({
+        namespacePipelineName: `${namespaceName}/pipelines/${id}`,
+        accessToken,
+      });
+    }
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+async function isOwner(entity: string, id: string, accessToken: Nullable<string>) {
+  if (!accessToken) {
+    return false;
+  }
+  try {
+    const currentUser = await fetchUser({
+      userName: entity,
+      accessToken
+    });
+    if (!currentUser) {
+      return false;
+    }
+    const pipeline = await fetchNamespacePipeline({
+      namespacePipelineName: `users/${entity}/pipelines/${id}`,
+      accessToken,
+    });
+    if (!pipeline) {
+      return false;
+    }
+    return currentUser.id.toString() === pipeline.owner.toString();
+  } catch (error) {
+    console.error("Error checking ownership:", error);
+    return false;
+  }
+}
+
+export default async function PipelinePage({ params, searchParams }: Props) {
+  const { entity, id } = params;
+  const tab = searchParams.tab as string | undefined;
+  
+  const cookieStore = cookies();
+  const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
+  let accessToken: Nullable<string> = null;
+  if (authSessionCookie) {
+    accessToken = JSON.parse(authSessionCookie).accessToken;
+  }
+  
+  const pipelineData = await getPipelineData(entity, id, accessToken);
+  
+  // Redirect to 404 if the pipeline doesn't exist
+  if (!pipelineData) {
+    return redirect('/404');
+  }
+  
+  const isResourceOwner = await isOwner(entity, id, accessToken);
+  
+  // Redirect to playground if pipeline exists and no specific tab is requested
+  if (!tab) {
+    return redirect(`/${entity}/pipelines/${id}/playground`);
+  }
+  
+  // Redirect to playground if not owner and trying to access settings
+  if (tab === 'settings' && !isResourceOwner) {
+    return redirect(`/${entity}/pipelines/${id}/playground`);
+  }
+  
+  // If we reach here, it means we have a valid tab
+  // You can add more specific tab handling here if needed
+  return redirect(`/${entity}/pipelines/${id}/${tab}`);
+}

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -5,7 +5,6 @@ import { Nullable } from '@instill-ai/toolkit';
 
 type Props = {
   params: { id: string; entity: string };
-  searchParams: { [key: string]: string | string[] | undefined };
 };
 
 async function getPipelineData(entity: string, id: string, accessToken: Nullable<string>) {
@@ -27,27 +26,21 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
   }
 }
 
-export default async function RedirectionPipelinePage({ params, searchParams }: Props) {
+export default async function RedirectionPipelinePage({ params }: Props) {
   const { entity, id } = params;
-  const tab = searchParams.tab as string | undefined;
-  
+
   const cookieStore = cookies();
   const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
   let accessToken: Nullable<string> = null;
   if (authSessionCookie) {
     accessToken = JSON.parse(authSessionCookie).accessToken;
   }
-  
+
   const pipelineData = await getPipelineData(entity, id, accessToken);
-  
+
   // Redirect to 404 if the pipeline doesn't exist
   if (!pipelineData) {
     return redirect('/404');
   }
-    
-  // Redirect to playground if pipeline exists and no specific tab is requested
-  if (!tab) {
-    return redirect(`/${entity}/pipelines/${id}/playground`);
-  }
-  
+
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -1,19 +1,30 @@
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
-import { fetchNamespacePipeline, fetchNamespaceType } from '@instill-ai/toolkit/server';
-import { Nullable } from '@instill-ai/toolkit';
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { Nullable } from "@instill-ai/toolkit";
+import {
+  fetchNamespacePipeline,
+  fetchNamespaceType,
+} from "@instill-ai/toolkit/server";
 
 type RedirectionPipelinePageProps = {
   params: { id: string; entity: string };
 };
 
-async function getPipelineData(entity: string, id: string, accessToken: Nullable<string>) {
+async function getPipelineData(
+  entity: string,
+  id: string,
+  accessToken: Nullable<string>,
+) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+    if (
+      namespaceType === "NAMESPACE_USER" ||
+      namespaceType === "NAMESPACE_ORGANIZATION"
+    ) {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
       return await fetchNamespacePipeline({
         namespacePipelineName: `${namespaceName}/pipelines/${id}`,
@@ -27,7 +38,9 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
   return null; // Return null if namespaceType doesn't match
 }
 
-export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
+export default async function RedirectionPipelinePage({
+  params,
+}: RedirectionPipelinePageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();
@@ -42,13 +55,13 @@ export default async function RedirectionPipelinePage({ params }: RedirectionPip
 
     // Redirect to 404 if the pipeline doesn't exist
     if (!pipelineData) {
-      return redirect('/404');
+      return redirect("/404");
     }
 
     // If the pipeline exists, redirect to the playground
     return redirect(`/${entity}/pipelines/${id}/playground`);
   } catch (error) {
     console.error("Error in RedirectionPipelinePage:", error);
-    return redirect('/404'); // Redirect to 404 on any error
+    return redirect("/404"); // Redirect to 404 on any error
   }
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -15,24 +15,19 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
     });
     if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
-      const pipelineData = await fetchNamespacePipeline({
+      return await fetchNamespacePipeline({
         namespacePipelineName: `${namespaceName}/pipelines/${id}`,
         accessToken,
       });
-      if (pipelineData) {
-        return pipelineData;
-      }
     }
-    return Promise.reject(null);
   } catch (error) {
-    console.error(error);
-    return Promise.reject(null);
+    return null;
   }
+  return null;
 }
 
 export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
   const { entity, id } = params;
-
   const cookieStore = cookies();
   const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
   let accessToken: Nullable<string> = null;
@@ -40,12 +35,9 @@ export default async function RedirectionPipelinePage({ params }: RedirectionPip
     accessToken = JSON.parse(authSessionCookie).accessToken;
   }
 
-  try {
-    await getPipelineData(entity, id, accessToken);
-    // If the pipeline exists, redirect to the playground
+  const pipelineData = await getPipelineData(entity, id, accessToken);
+  if (pipelineData) {
     return redirect(`/${entity}/pipelines/${id}/playground`);
-  } catch (error) {
-    console.error("Error in RedirectionPipelinePage:", error);
-    return redirect('/404'); // Redirect to 404 if the pipeline doesn't exist or on any error
   }
+  return redirect('/404');
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -43,4 +43,7 @@ export default async function RedirectionPipelinePage({ params }: RedirectionPip
     return redirect('/404');
   }
 
+  // If the pipeline exists, redirect to the playground
+  return redirect(`/${entity}/pipelines/${id}/playground`);
+
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -1,19 +1,30 @@
-import { redirect } from 'next/navigation';
-import { cookies } from 'next/headers';
-import { fetchNamespacePipeline, fetchNamespaceType } from '@instill-ai/toolkit/server';
-import { Nullable } from '@instill-ai/toolkit';
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { Nullable } from "@instill-ai/toolkit";
+import {
+  fetchNamespacePipeline,
+  fetchNamespaceType,
+} from "@instill-ai/toolkit/server";
 
 type RedirectionPipelinePageProps = {
   params: { id: string; entity: string };
 };
 
-async function getPipelineData(entity: string, id: string, accessToken: Nullable<string>) {
+async function getPipelineData(
+  entity: string,
+  id: string,
+  accessToken: Nullable<string>,
+) {
   try {
     const namespaceType = await fetchNamespaceType({
       namespace: entity,
       accessToken,
     });
-    if (namespaceType === "NAMESPACE_USER" || namespaceType === "NAMESPACE_ORGANIZATION") {
+    if (
+      namespaceType === "NAMESPACE_USER" ||
+      namespaceType === "NAMESPACE_ORGANIZATION"
+    ) {
       const namespaceName = `${namespaceType === "NAMESPACE_USER" ? "users" : "organizations"}/${entity}`;
       return await fetchNamespacePipeline({
         namespacePipelineName: `${namespaceName}/pipelines/${id}`,
@@ -26,7 +37,9 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
   return null;
 }
 
-export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
+export default async function RedirectionPipelinePage({
+  params,
+}: RedirectionPipelinePageProps) {
   const { entity, id } = params;
   const cookieStore = cookies();
   const authSessionCookie = cookieStore.get("instill-auth-session")?.value;
@@ -39,5 +52,5 @@ export default async function RedirectionPipelinePage({ params }: RedirectionPip
   if (pipelineData) {
     return redirect(`/${entity}/pipelines/${id}/playground`);
   }
-  return redirect('/404');
+  return redirect("/404");
 }

--- a/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/page.tsx
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { fetchNamespacePipeline, fetchNamespaceType } from '@instill-ai/toolkit/server';
 import { Nullable } from '@instill-ai/toolkit';
 
-type Props = {
+type RedirectionPipelinePageProps = {
   params: { id: string; entity: string };
 };
 
@@ -26,7 +26,7 @@ async function getPipelineData(entity: string, id: string, accessToken: Nullable
   }
 }
 
-export default async function RedirectionPipelinePage({ params }: Props) {
+export default async function RedirectionPipelinePage({ params }: RedirectionPipelinePageProps) {
   const { entity, id } = params;
 
   const cookieStore = cookies();

--- a/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
+++ b/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as React from 'react'
+import * as React from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import debounce from "lodash.debounce";
 
@@ -50,7 +50,6 @@ export const ModelHubListPageMainView = () => {
   React.useEffect(() => {
     setPageNumber(0);
   }, [selectedVisibilityOption, searchCode]);
-
 
   /* -------------------------------------------------------------------------
    * Query resource data

--- a/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
+++ b/packages/toolkit/src/view/model/ModelHubListPageMainView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import * as React from 'react'
 import { useRouter, useSearchParams } from "next/navigation";
 import debounce from "lodash.debounce";
 
@@ -26,7 +26,7 @@ export const ModelHubListPageMainView = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const visibility = searchParams.get("visibility");
-  const [pageNumber, setPageNumber] = useState(0);
+  const [pageNumber, setPageNumber] = React.useState(0);
   const routeInfo = useRouteInfo();
 
   const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
@@ -47,9 +47,10 @@ export const ModelHubListPageMainView = () => {
       : "VISIBILITY_UNSPECIFIED",
   );
 
-  useEffect(() => {
+  React.useEffect(() => {
     setPageNumber(0);
   }, [selectedVisibilityOption, searchCode]);
+
 
   /* -------------------------------------------------------------------------
    * Query resource data

--- a/packages/toolkit/src/view/model/view-model/ModelContentViewer.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelContentViewer.tsx
@@ -31,20 +31,23 @@ export const ModelContentViewer = ({
 }: ModelContentViewerProps) => {
   const router = useRouter();
   const routeInfo = useRouteInfo();
+
   React.useEffect(() => {
-    if (model) {
-      if (!model.permission.canEdit && selectedTab === "settings") {
-        const playgroundPath = `/${routeInfo.data?.namespaceId}/models/${model.id}/playground`;
-        router.push(playgroundPath);
-      }
+    if (
+      model &&
+      selectedTab === "settings" &&
+      !model.permission.canEdit
+    ) {
+      const playgroundPath = `/${routeInfo.data?.namespaceId}/models/${model.id}/playground`;
+      router.push(playgroundPath);
     }
-  }, [model, routeInfo.data?.namespaceId, router]);
+  }, [selectedTab, model, routeInfo.data?.namespaceId, router]);
+
   let content = null;
 
   switch (selectedTab) {
     case "api": {
       content = <ModelApi model={model} />;
-
       break;
     }
     case "versions": {
@@ -53,12 +56,13 @@ export const ModelContentViewer = ({
       ) : (
         <NoVersionsPlaceholder />
       );
-
       break;
     }
     case "settings": {
       if (model?.permission.canEdit) {
         content = <ModelSettingsEditForm model={model} onUpdate={onUpdate} />;
+      } else {
+        content = null;
       }
 
       break;

--- a/packages/toolkit/src/view/model/view-model/ModelContentViewer.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelContentViewer.tsx
@@ -33,11 +33,7 @@ export const ModelContentViewer = ({
   const routeInfo = useRouteInfo();
 
   React.useEffect(() => {
-    if (
-      model &&
-      selectedTab === "settings" &&
-      !model.permission.canEdit
-    ) {
+    if (model && selectedTab === "settings" && !model.permission.canEdit) {
       const playgroundPath = `/${routeInfo.data?.namespaceId}/models/${model.id}/playground`;
       router.push(playgroundPath);
     }

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
@@ -61,8 +61,8 @@ export const PipelineContentViewer = ({
       if (pipeline?.permission.canEdit) {
         content = <PipelineSettings pipeline={pipeline} onUpdate={onUpdate} />;
       }
-      else{
-        content = <PipelinePlayground pipeline={pipeline} releases={releases} />;
+      else {
+        content = null
       }
 
       break;

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
@@ -60,9 +60,8 @@ export const PipelineContentViewer = ({
     case "settings": {
       if (pipeline?.permission.canEdit) {
         content = <PipelineSettings pipeline={pipeline} onUpdate={onUpdate} />;
-      }
-      else {
-        content = null
+      } else {
+        content = null;
       }
 
       break;

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelineContentViewer.tsx
@@ -61,6 +61,9 @@ export const PipelineContentViewer = ({
       if (pipeline?.permission.canEdit) {
         content = <PipelineSettings pipeline={pipeline} onUpdate={onUpdate} />;
       }
+      else{
+        content = <PipelinePlayground pipeline={pipeline} releases={releases} />;
+      }
 
       break;
     }

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -79,12 +79,6 @@ export const ViewPipeline = () => {
   };
 
   React.useEffect(() => {
-    if (pipeline.isError) {
-      router.push("/404");
-    }
-  }, [pipeline.isError, router]);
-
-  React.useEffect(() => {
     if (releases.isSuccess) {
       if (activeVersion) {
         if (releases.data.length > 0) {

--- a/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/ViewPipeline.tsx
@@ -79,6 +79,12 @@ export const ViewPipeline = () => {
   };
 
   React.useEffect(() => {
+    if (pipeline.isError) {
+      router.push("/404");
+    }
+  }, [pipeline.isError, router]);
+
+  React.useEffect(() => {
     if (releases.isSuccess) {
       if (activeVersion) {
         if (releases.data.length > 0) {


### PR DESCRIPTION
Because

[https://instill.tech/ownerID/pipeline/pipelineID/settings ](https://instill.tech/ownerID/pipeline/pipelineID/playground) tab should be redirected to playground if not owner of pipeline

[https://instill.tech/ownerID/models/modelId/settings ](https://instill.tech/ownerID/pipeline/pipelineID/playground) tab should be redirected to playground if not owner of model

https://instill.tech/ownerID/models/modelIDshould redirect to playground (if exists)

https://instill.tech/ownerID/models/modelIDshould redirect to 404 (if not exists)

https://instill.tech/ownerID/models/modelID/{tab} (if non existent model) should redirect to 404. 

https://instill.tech/ownerID/pipeline/pipelineID should redirect to playground (if exists)

https://instill.tech/ownerID/pipeline/pipelineID should redirect to 404 (if not exists)

[https://instill.tech/ownerID/pipeline/pipelineID/](https://instill.tech/ownerID/pipeline/pipelineID/playground){tab} (if non existent pipeline) should redirect to 404
