### PR TITLE
fix(editor): fix the broken documentation link of instill-model component

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.101.0-rc.14",
+  "version": "0.101.0-rc.15",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
@@ -140,6 +140,10 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
         break;
     }
 
+    if (data.definition.id === "instill-model") {
+      documentationUrl = "https://www.instill.tech/docs/component/ai/instill";
+    }
+
     if (!documentationUrl) {
       return;
     }


### PR DESCRIPTION
Because

- fix the broken documentation link of instill-model component

This commit

- fix the broken documentation link of instill-model component
