### PR TITLE
feat: hide the TASK_CUSTOM model type

### DIFF
--- a/packages/toolkit/src/view/model/CreateModelForm.tsx
+++ b/packages/toolkit/src/view/model/CreateModelForm.tsx
@@ -370,7 +370,9 @@ export const CreateModelForm = () => {
                           </Select.Trigger>
                           <Select.Content>
                             <Select.Group>
-                              {InstillModelTask.map((task) => {
+                              {InstillModelTask.filter(
+                                (task) => task !== "TASK_CUSTOM",
+                              ).map((task) => {
                                 const { label } =
                                   getModelInstanceTaskToolkit(task);
 


### PR DESCRIPTION
Because

- hide the TASK_CUSTOM model type

This commit

- hide the TASK_CUSTOM model type