### PR TITLE
feat: import smart hint that user can directly input space to trigger hint window

### DIFF
--- a/packages/toolkit/src/components/top-bar/CloudTopbarDropdown.tsx
+++ b/packages/toolkit/src/components/top-bar/CloudTopbarDropdown.tsx
@@ -60,12 +60,12 @@ export const CloudTopbarDropdown = () => {
       <DropdownMenu.Trigger className="!my-auto !h-10 !w-10">
         <NamespaceAvatarWithFallback.Root
           src={me.data.profile?.avatar ?? null}
-          className="my-auto h-8 w-8 cursor-pointer"
+          className="my-auto h-10 w-10 cursor-pointer"
           fallback={
             <NamespaceAvatarWithFallback.Fallback
               namespaceId={me.data.id}
               displayName={me.data.profile?.displayName ?? null}
-              className="h-8 w-8"
+              className="h-10 w-10"
             />
           }
         />


### PR DESCRIPTION
Because

- For some enum fields like openAI's model or component's task, we want to hint user full list to enhance UX

This commit

- import smart hint that user can directly input space to trigger hint window
