### PR TITLE
feat(editor): replace null with empty string when add the component

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.ts
+++ b/packages/toolkit/src/lib/use-instill-form/transform/transformInstillFormTreeToDefaultValue.ts
@@ -11,6 +11,11 @@ export type TransformInstillFormTreeToDefaultValueOptions = {
   parentIsObjectArray?: boolean;
   parentIsFormCondition?: boolean;
   parentPath?: string;
+
+  // By default we use null to represent the absence of value.
+  // In some cases, we want to use empty string instead of null.
+  // This is to make the generated YAML looks nicer.
+  replaceNullWithEmptyString?: boolean;
 };
 
 export function transformInstillFormTreeToDefaultValue(
@@ -24,7 +29,8 @@ export function transformInstillFormTreeToDefaultValue(
   const parentIsObjectArray = options?.parentIsObjectArray ?? false;
   const parentIsFormCondition = options?.parentIsFormCondition ?? false;
   const parentPath = options?.parentPath ?? undefined;
-
+  const replaceNullWithEmptyString =
+    options?.replaceNullWithEmptyString ?? false;
   // We don't need to set the field key for formCondition because in the
   // conditions are formGroup, we will set the fieldKey there
 
@@ -76,6 +82,7 @@ export function transformInstillFormTreeToDefaultValue(
             stringify,
             parentPath: modifiedPath ?? undefined,
             parentIsFormCondition: true,
+            replaceNullWithEmptyString,
           });
 
           dot.setter(
@@ -100,6 +107,7 @@ export function transformInstillFormTreeToDefaultValue(
             stringify,
             parentPath: modifiedPath ?? undefined,
             parentIsFormCondition: true,
+            replaceNullWithEmptyString,
           });
 
           dot.setter(
@@ -124,6 +132,7 @@ export function transformInstillFormTreeToDefaultValue(
         skipPath,
         stringify,
         parentPath: modifiedPath ?? undefined,
+        replaceNullWithEmptyString,
       });
     }
 
@@ -139,6 +148,7 @@ export function transformInstillFormTreeToDefaultValue(
         stringify,
         parentIsObjectArray: true,
         parentPath: modifiedPath ?? undefined,
+        replaceNullWithEmptyString,
       });
     }
 
@@ -152,7 +162,9 @@ export function transformInstillFormTreeToDefaultValue(
     return initialData;
   }
 
-  let defaultValue: Nullable<string | number> = null;
+  let defaultValue: Nullable<string | number> = replaceNullWithEmptyString
+    ? ""
+    : null;
 
   if (!modifiedPath) {
     return initialData;
@@ -196,6 +208,8 @@ export function transformInstillFormTreeToDefaultValue(
               ? String(instillUpstreamValue.examples)
               : instillUpstreamValue.examples;
             break;
+          default:
+            defaultValue = replaceNullWithEmptyString ? "" : null;
         }
 
         dot.setter(initialData, modifiedPath, defaultValue);
@@ -215,7 +229,7 @@ export function transformInstillFormTreeToDefaultValue(
               : instillUpstreamValue.example;
             break;
           default:
-            defaultValue = null;
+            defaultValue = replaceNullWithEmptyString ? "" : null;
         }
 
         dot.setter(initialData, modifiedPath, defaultValue);
@@ -261,7 +275,7 @@ export function transformInstillFormTreeToDefaultValue(
         defaultValue = stringify ? String(tree.examples) : tree.examples;
         break;
       default:
-        defaultValue = null;
+        defaultValue = replaceNullWithEmptyString ? "" : null;
     }
 
     dot.setter(initialData, modifiedPath, defaultValue);
@@ -277,7 +291,7 @@ export function transformInstillFormTreeToDefaultValue(
         defaultValue = stringify ? String(tree.example) : tree.example;
         break;
       default:
-        defaultValue = null;
+        defaultValue = replaceNullWithEmptyString ? "" : null;
     }
 
     dot.setter(initialData, modifiedPath, defaultValue);

--- a/packages/toolkit/src/view/recipe-editor/commands/ComponentCmdo.tsx
+++ b/packages/toolkit/src/view/recipe-editor/commands/ComponentCmdo.tsx
@@ -48,6 +48,11 @@ const selector = (store: InstillStore) => ({
 
 const normalComponentIndent = "  ";
 
+const stringfyOptions: YAML.ToStringOptions = {
+  indent: 2,
+  nullStr: "",
+};
+
 function generateDefaultValue(schema: InstillJSONSchema, taskName?: string) {
   const formTree = transformInstillJSONSchemaToFormTree(schema);
 
@@ -64,6 +69,8 @@ function generateDefaultValue(schema: InstillJSONSchema, taskName?: string) {
     selectedConditionMap,
     skipPath: ["setup.api-key"],
   });
+
+  console.log(data);
 
   return data;
 }
@@ -157,10 +164,6 @@ export const ComponentCmdo = () => {
     if (!pipeline.isSuccess || !editorRef || !selectedComponentDefinition) {
       return;
     }
-
-    const stringfyOptions: YAML.ToStringOptions = {
-      indent: 2,
-    };
 
     const componentIds = pipeline.data.recipe?.component
       ? Object.keys(pipeline.data.recipe.component)
@@ -293,12 +296,15 @@ export const ComponentCmdo = () => {
         defaultTask.name,
       );
 
-      const doc = YAML.stringify({
-        [id]: {
-          type: definition.id,
-          ...defaultValue,
+      const doc = YAML.stringify(
+        {
+          [id]: {
+            type: definition.id,
+            ...defaultValue,
+          },
         },
-      });
+        stringfyOptions,
+      );
 
       setSelectedComponentDefaultValue(doc);
       setSelectedTaskName(defaultTask.name);
@@ -311,11 +317,14 @@ export const ComponentCmdo = () => {
 
       const id = generateUniqueNodeIdFromDefinition(definition, componentIds);
 
-      const doc = YAML.stringify({
-        [id]: {
-          type: "iterator",
+      const doc = YAML.stringify(
+        {
+          [id]: {
+            type: "iterator",
+          },
         },
-      });
+        stringfyOptions,
+      );
 
       setSelectedComponentDefaultValue(doc);
     }
@@ -361,12 +370,15 @@ export const ComponentCmdo = () => {
       defaultTask.name,
     );
 
-    const doc = YAML.stringify({
-      [id]: {
-        type: defaultDefinition.id,
-        ...defaultValue,
+    const doc = YAML.stringify(
+      {
+        [id]: {
+          type: defaultDefinition.id,
+          ...defaultValue,
+        },
       },
-    });
+      stringfyOptions,
+    );
 
     setSelectedComponentDefaultValue(doc);
   }


### PR DESCRIPTION
## Current State

When adding a new component, the default behavior is to add the full component recipe along with a null value. 

This can be confusing for users, as they might mistakenly believe that the null value is intended to be used for that field. Additionally, the full component recipe is quite lengthy and may overwhelm users.

## Proposed Change

Instead of displaying null, we will show an unset value (empty), making it clearer that the field is not yet assigned. 

Please view the change example below:

From
```
// Current
  openai-0:
    type: openai
    input:
      model: gpt-4o
      prompt: null
      system-message: You are a helpful assistant.
      images: null
      chat-history: null
      temperature: 1
      n: 1
      max-tokens: null
      response-format:
        type: text
      top-p: 1
      presence-penalty: null
      frequency-penalty: null
    condition: null
    setup:
      organization: null
    task: TASK_TEXT_GENERATION
```
To
```
  openai-0:
    type: openai
    input:
      model: gpt-4o
      prompt: 
      system-message: You are a helpful assistant.
      images: 
      chat-history: 
      temperature: 1
      n: 1
      max-tokens: 
      response-format:
        type: text
       top-p: 1
      presence-penalty: 
      frequency-penalty: 
    condition: 
    setup:
      organization: 
    task: TASK_TEXT_GENERATION
```