### PR TITLE
feat(editor): scroll to target component line when click the node

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/GeneralNode.tsx
@@ -98,6 +98,8 @@ export const GeneralNode = ({ data, id }: NodeProps<GeneralNodeData>) => {
         column: 0,
       });
 
+      editorRef.revealLineInCenter(adjustedLine);
+
       // We need this happen after the editor is updated
       setTimeout(() => {
         editorRef.focus();

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/IteratorNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/IteratorNode.tsx
@@ -89,6 +89,8 @@ export const IteratorNode = ({ data, id }: NodeProps<IteratorNodeData>) => {
         column: 0,
       });
 
+      editorRef.revealLineInCenter(adjustedLine);
+
       // We need this happen after the editor is updated
       setTimeout(() => {
         editorRef.focus();


### PR DESCRIPTION
Because

- When a user clicks on a component in the preview, the cursor in the left editor panel will not only move to the corresponding code, but the screen will also automatically center the relevant line.

This commit

- scroll to target component line when click the node
