### PR TITLE
feat: use CMD and ctrl instead of ⌘ to hint shortcut

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/EditorViewSectionBar.tsx
+++ b/packages/toolkit/src/view/recipe-editor/EditorViewSectionBar.tsx
@@ -50,11 +50,11 @@ export const EditorViewSectionBar = ({
       </HorizontalSortableWrapper>
       <button className="ml-auto px-2" onClick={onToggleExpand}>
         {isExpanded ? (
-          <EditorButtonTooltipWrapper tooltipContent="Restore pane">
+          <EditorButtonTooltipWrapper tooltipContent="Restore panel">
             <Icons.Minimize01 className="w-3 h-3 stroke-semantic-fg-primary" />
           </EditorButtonTooltipWrapper>
         ) : (
-          <EditorButtonTooltipWrapper tooltipContent="Maximize pane">
+          <EditorButtonTooltipWrapper tooltipContent="Maximize panel">
             <Icons.Expand01 className="w-3 h-3 stroke-semantic-fg-primary" />
           </EditorButtonTooltipWrapper>
         )}

--- a/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
@@ -401,79 +401,92 @@ export const RecipeEditorView = () => {
                         ) : null}
                       </div>
                       <div className="flex flex-row">
-                        <button
-                          className="p-1.5"
-                          onClick={() => {
-                            if (currentExpandView === "left") {
-                              rightPanelRef.current?.resize(
-                                leftPanelDefaultSize,
-                              );
-                              setCurrentExpandView(null);
-                            } else {
-                              rightPanelRef.current?.resize(0);
-                              setCurrentExpandView("left");
-                            }
-                          }}
+                        <EditorButtonTooltipWrapper
+                          tooltipContent={
+                            currentExpandView === "left"
+                              ? "Minimize panel"
+                              : "Maximize panel"
+                          }
                         >
-                          {currentExpandView === "left" ? (
-                            <Icons.Minimize01 className="w-3 h-3 stroke-semantic-fg-primary" />
-                          ) : (
-                            <Icons.Expand01 className="w-3 h-3 stroke-semantic-fg-primary" />
-                          )}
-                        </button>
-                        <button className="p-1.5" onClick={handleDownload}>
-                          <Icons.Download01 className="w-3 h-3 stroke-semantic-fg-primary" />
-                        </button>
+                          <button
+                            className="p-1.5"
+                            onClick={() => {
+                              if (currentExpandView === "left") {
+                                rightPanelRef.current?.resize(
+                                  leftPanelDefaultSize,
+                                );
+                                setCurrentExpandView(null);
+                              } else {
+                                rightPanelRef.current?.resize(0);
+                                setCurrentExpandView("left");
+                              }
+                            }}
+                          >
+                            {currentExpandView === "left" ? (
+                              <Icons.Minimize01 className="w-3 h-3 stroke-semantic-fg-primary" />
+                            ) : (
+                              <Icons.Expand01 className="w-3 h-3 stroke-semantic-fg-primary" />
+                            )}
+                          </button>
+                        </EditorButtonTooltipWrapper>
+
+                        <EditorButtonTooltipWrapper tooltipContent="Download recipe">
+                          <button className="p-1.5" onClick={handleDownload}>
+                            <Icons.Download01 className="w-3 h-3 stroke-semantic-fg-primary" />
+                          </button>
+                        </EditorButtonTooltipWrapper>
                       </div>
                     </div>
                     <div className="flex h-7 shrink-0 items-center flex-row-reverse bg-semantic-bg-alt-primary border-b border-semantic-bg-line">
-                      <button
-                        onClick={async () => {
-                          if (!rawRecipeOnDom || !editorRef) {
-                            return;
-                          }
+                      <EditorButtonTooltipWrapper tooltipContent="Format recipe">
+                        <button
+                          onClick={async () => {
+                            if (!rawRecipeOnDom || !editorRef) {
+                              return;
+                            }
 
-                          const model = editorRef.getModel();
+                            const model = editorRef.getModel();
 
-                          if (!model) {
-                            return;
-                          }
+                            if (!model) {
+                              return;
+                            }
 
-                          let prettifiedRecipe: Nullable<string> = null;
-                          const currentPosition = editorRef?.getPosition();
+                            let prettifiedRecipe: Nullable<string> = null;
+                            const currentPosition = editorRef?.getPosition();
 
-                          try {
-                            prettifiedRecipe =
-                              await prettifyYaml(rawRecipeOnDom);
-                          } catch (error) {
-                            prettifiedRecipe = rawRecipeOnDom;
-                            console.error(error);
-                          }
+                            try {
+                              prettifiedRecipe =
+                                await prettifyYaml(rawRecipeOnDom);
+                            } catch (error) {
+                              prettifiedRecipe = rawRecipeOnDom;
+                              console.error(error);
+                            }
 
-                          // Replace the entire content
-                          model.pushEditOperations(
-                            [],
-                            [
-                              {
-                                range: model.getFullModelRange(),
-                                text: prettifiedRecipe,
-                              },
-                            ],
-                            () => null,
-                          );
+                            // Replace the entire content
+                            model.pushEditOperations(
+                              [],
+                              [
+                                {
+                                  range: model.getFullModelRange(),
+                                  text: prettifiedRecipe,
+                                },
+                              ],
+                              () => null,
+                            );
 
-                          // Restore the cursor position
-                          if (currentPosition) {
-                            editorRef?.setPosition(currentPosition);
-                          }
-                        }}
-                        className="flex flex-row items-center gap-x-1 px-1"
-                      >
-                        <Icons.AlignLeft className="w-3 h-3 stroke-semantic-fg-secondary" />
-                        <span className="text-xs font-sans text-semantic-fg-secondary">
-                          Format
-                        </span>
-                      </button>
+                            // Restore the cursor position
+                            if (currentPosition) {
+                              editorRef?.setPosition(currentPosition);
+                            }
+                          }}
+                          className="flex flex-row items-center gap-x-1 px-1"
+                        >
+                          <Icons.AlignLeft className="w-3 h-3 stroke-semantic-fg-secondary" />
+                          <span className="text-xs font-sans text-semantic-fg-secondary">
+                            Format
+                          </span>
+                        </button>
+                      </EditorButtonTooltipWrapper>
                     </div>
 
                     <div className="w-full flex-1 bg-semantic-bg-primary">

--- a/packages/toolkit/src/view/recipe-editor/RunButton.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RunButton.tsx
@@ -6,6 +6,7 @@ import { Button, Icons } from "@instill-ai/design-system";
 
 import { InstillStore, useInstillStore, useShallow } from "../../lib";
 import { EditorButtonTooltipWrapper } from "./EditorButtonTooltipWrapper";
+import { useIsMac } from "./lib";
 
 const selector = (store: InstillStore) => ({
   isTriggeringPipeline: store.isTriggeringPipeline,
@@ -13,13 +14,16 @@ const selector = (store: InstillStore) => ({
 });
 
 export const RunButton = () => {
+  const isMac = useIsMac();
   const { isTriggeringPipeline, runButtonRef } = useInstillStore(
     useShallow(selector),
   );
 
   return (
     <div className="flex flex-row gap-x-1 items-center">
-      <EditorButtonTooltipWrapper tooltipContent="⌘ Return">
+      <EditorButtonTooltipWrapper
+        tooltipContent={isMac ? "CMD Return" : "CTRL Return"}
+      >
         <Button
           size="md"
           variant="primary"

--- a/packages/toolkit/src/view/recipe-editor/commands/ActionCmdk.tsx
+++ b/packages/toolkit/src/view/recipe-editor/commands/ActionCmdk.tsx
@@ -7,6 +7,7 @@ import { Command, Icons } from "@instill-ai/design-system";
 
 import { InstillStore, useInstillStore, useShallow } from "../../../lib";
 import { EditorButtonTooltipWrapper } from "../EditorButtonTooltipWrapper";
+import { useIsMac } from "../lib";
 import { CommandShortcutBadge } from "./CommandShortcutBadge";
 
 const selector = (store: InstillStore) => ({
@@ -17,6 +18,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const ActionCmdk = () => {
+  const isMac = useIsMac();
   const commandRef = React.useRef<Nullable<HTMLDivElement>>(null);
   const {
     openActionCmdk,
@@ -27,7 +29,7 @@ export const ActionCmdk = () => {
 
   return (
     <React.Fragment>
-      <EditorButtonTooltipWrapper tooltipContent="Search ⌘ K">
+      <EditorButtonTooltipWrapper tooltipContent={isMac ? "CMD K" : "CTRL K"}>
         <button
           onClick={() => {
             updateOpenActionCmdk(() => true);

--- a/packages/toolkit/src/view/recipe-editor/commands/ComponentCmdo.tsx
+++ b/packages/toolkit/src/view/recipe-editor/commands/ComponentCmdo.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../../lib/use-instill-form/transform";
 import { generateUniqueNodeIdFromDefinition } from "../../pipeline-builder/lib/generateUniqueNodeIdFromDefinition";
 import { EditorButtonTooltipWrapper } from "../EditorButtonTooltipWrapper";
+import { useIsMac } from "../lib";
 
 const selector = (store: InstillStore) => ({
   accessToken: store.accessToken,
@@ -70,14 +71,13 @@ function generateDefaultValue(schema: InstillJSONSchema, taskName?: string) {
     skipPath: ["setup.api-key"],
   });
 
-  console.log(data);
-
   return data;
 }
 
 export const ComponentCmdo = () => {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const routeInfo = useRouteInfo();
+  const isMac = useIsMac();
   const {
     accessToken,
     enabledQuery,
@@ -410,7 +410,9 @@ export const ComponentCmdo = () => {
       }}
     >
       <Dialog.Trigger asChild>
-        <EditorButtonTooltipWrapper tooltipContent="⌘ O">
+        <EditorButtonTooltipWrapper
+          tooltipContent={isMac ? "CMD O" : "CTRL  O"}
+        >
           <Button
             onClick={() => {
               updateOpenComponentCmdo(() => true);

--- a/packages/toolkit/src/view/recipe-editor/dialogs/ImportRecipeDialog.tsx
+++ b/packages/toolkit/src/view/recipe-editor/dialogs/ImportRecipeDialog.tsx
@@ -7,6 +7,7 @@ import { Button, Dialog, Icons } from "@instill-ai/design-system";
 
 import { InstillStore, useInstillStore, useShallow } from "../../../lib";
 import { EditorButtonTooltipWrapper } from "../EditorButtonTooltipWrapper";
+import { useIsMac } from "../lib";
 import { validateVSCodeYaml } from "../lib/validateVSCodeYaml";
 
 const selector = (store: InstillStore) => ({
@@ -15,6 +16,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const ImportRecipeDialog = () => {
+  const isMac = useIsMac();
   const [open, setOpen] = React.useState(false);
   const [error, setError] = React.useState<Nullable<string>>(null);
   const [recipe, setRecipe] = React.useState<Nullable<string>>(null);
@@ -30,7 +32,7 @@ export const ImportRecipeDialog = () => {
         setOpen(open);
       }}
     >
-      <EditorButtonTooltipWrapper tooltipContent="⌘ I">
+      <EditorButtonTooltipWrapper tooltipContent={isMac ? "CMD I" : "CTRL I"}>
         <Button
           onClick={() => {
             importRecipeInputTriggerRef?.current?.click();

--- a/packages/toolkit/src/view/recipe-editor/lib/index.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/index.ts
@@ -6,4 +6,5 @@ export * from "./tomorrowTheme";
 export * from "./useEditorCommandListener";
 export * from "./useAutonomousEditorRecipeUpdater";
 export * from "./useDebouncedRecipeUpdater";
+export * from "./useIsMac";
 export * from "./validateVSCodeYaml";

--- a/packages/toolkit/src/view/recipe-editor/lib/useIsMac.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/useIsMac.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import * as React from "react";
+
+export function useIsMac() {
+  const isMac = React.useMemo(() => {
+    console.log("navigator.userAgent", navigator.userAgent);
+    return navigator.userAgent.includes("Macintosh");
+  }, []);
+
+  return isMac;
+}


### PR DESCRIPTION
Because

- use CMD and ctrl instead of ⌘ to hint shortcut

This commit

- use CMD and ctrl instead of ⌘ to hint shortcut
