### PR TITLE
fix: redirect user to 404 if they are on editor and pipeline is not exist

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.103.0-rc.3",
+  "version": "0.103.0-rc.6",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/navigation";
 import { arrayMove } from "@dnd-kit/sortable";
 import { Nullable } from "instill-sdk";
 
@@ -79,6 +80,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const RecipeEditorView = () => {
+  const router = useRouter();
   const {
     accessToken,
     enabledQuery,
@@ -116,6 +118,13 @@ export const RecipeEditorView = () => {
     accessToken,
     enabled: enabledQuery,
   });
+
+  // redirect to 404 if the pipeline is not found
+  React.useEffect(() => {
+    if (pipeline.isError) {
+      router.push("/404");
+    }
+  }, [pipeline.isError]);
 
   const sortedReleases = useSortedReleases({
     pipelineName: routeInfo.data.pipelineName,


### PR DESCRIPTION
Because

- redirect user to 404 if they are on editor and pipeline is not exist

This commit

- redirect user to 404 if they are on editor and pipeline is not exist
