### PR TITLE
fix: add requester ID to the model operation request

### DIFF
--- a/packages/sdk/src/model/ModelClient.ts
+++ b/packages/sdk/src/model/ModelClient.ts
@@ -634,9 +634,11 @@ export class ModelClient extends APIResource {
   async getNamespaceModelOperationResult({
     namespaceModelName,
     view,
+    requesterUid,
   }: {
     namespaceModelName: string;
     view: ResourceView;
+    requesterUid?: string;
   }) {
     try {
       const queryString = getQueryString({
@@ -644,9 +646,14 @@ export class ModelClient extends APIResource {
         view,
       });
 
+      const additionalHeaders = getInstillAdditionalHeaders({ requesterUid });
+
       const data =
         await this._client.get<GetNamespaceModelOperationResultResponse>(
           queryString,
+          {
+            additionalHeaders,
+          },
         );
 
       return Promise.resolve(data);

--- a/packages/toolkit/src/lib/react-query-service/model/useLastModelTriggerResult.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useLastModelTriggerResult.ts
@@ -11,6 +11,7 @@ export function useLastModelTriggerResult({
   enabled,
   view = "VIEW_BASIC",
   retry,
+  requesterUid,
 }: {
   modelId: Nullable<string>;
   userId: Nullable<string>;
@@ -18,6 +19,7 @@ export function useLastModelTriggerResult({
   enabled: boolean;
   view?: ResourceView;
   retry?: false | number;
+  requesterUid?: string;
 }) {
   let enableQuery = false;
   const queryKey = ["models", "operation"];
@@ -43,6 +45,7 @@ export function useLastModelTriggerResult({
       const operation = await client.model.getNamespaceModelOperationResult({
         namespaceModelName: `namespaces/${userId}/models/${modelId}`,
         view,
+        requesterUid,
       });
 
       return Promise.resolve(operation);

--- a/packages/toolkit/src/lib/react-query-service/model/useModelVersionTriggerResult.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useModelVersionTriggerResult.ts
@@ -12,6 +12,7 @@ export function useModelVersionTriggerResult({
   enabled,
   view = "VIEW_BASIC",
   retry,
+  requesterUid,
 }: {
   modelId: Nullable<string>;
   userId: Nullable<string>;
@@ -20,6 +21,7 @@ export function useModelVersionTriggerResult({
   enabled: boolean;
   view?: ResourceView;
   retry?: false | number;
+  requesterUid?: string;
 }) {
   let enableQuery = false;
   const queryKey = ["models", "operation"];
@@ -50,6 +52,7 @@ export function useModelVersionTriggerResult({
       const operation = await client.model.getNamespaceModelOperationResult({
         namespaceModelName: `namespaces/${userId}/models/${modelId}/versions/${versionId}`,
         view,
+        requesterUid,
       });
 
       return Promise.resolve(operation);

--- a/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
+++ b/packages/toolkit/src/lib/vdp-sdk/operation/queries.ts
@@ -25,7 +25,7 @@ export async function getOperationQuery({
   }
 }
 
-export async function checkUntilOperationIsDoen({
+export async function checkUntilOperationIsDone({
   operationName,
   accessToken,
 }: {
@@ -42,7 +42,7 @@ export async function checkUntilOperationIsDoen({
       return Promise.resolve(true);
     } else {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      const result = await checkUntilOperationIsDoen({
+      const result = await checkUntilOperationIsDone({
         operationName,
         accessToken,
       });

--- a/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
@@ -124,6 +124,9 @@ export const ModelPlayground = ({
   });
 
   const namespaces = useUserNamespaces();
+  const targetNamespace = namespaces.find(
+    (namespace) => namespace.id === navigationNamespaceAnchor,
+  );
 
   const isModelTriggerable = useMemo(() => {
     return accessToken && model && modelState
@@ -149,6 +152,7 @@ export const ModelPlayground = ({
     versionId: activeVersion,
     view: "VIEW_FULL",
     enabled: !!activeVersion && enabledQuery,
+    requesterUid: targetNamespace ? targetNamespace.uid : undefined,
   });
 
   const pollForResponse = React.useCallback(async () => {


### PR DESCRIPTION
The model operation endpoint required the Instill requester id to be present in headers.