### PR TITLE
fix: fix object output is wrong when BE response semi-structure result type but the result is actually string

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/component-output/ObjectField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/component-output/ObjectField.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import JsonView from "@uiw/react-json-view";
 
 import { CopyToClipboardButton } from "../../../../components";
@@ -7,6 +8,7 @@ import { customTheme } from "../../../react-json-view";
 import { GeneralRecord, Nullable } from "../../../type";
 import { ComponentOutputFieldBaseProps } from "../../types";
 import { FieldRoot } from "./FieldRoot";
+import { MDTextViewer } from "./MDTextViewer";
 import { NoOutput } from "./NoOutput";
 
 export type ObjectFieldProps = {
@@ -16,34 +18,45 @@ export type ObjectFieldProps = {
 export const ObjectField = (props: ObjectFieldProps) => {
   const { title, object, hideField } = props;
 
+  const isJSON = React.useMemo(() => {
+    if (!object) {
+      return false;
+    }
+
+    return typeof object === "object" && object !== null;
+  }, [object]);
+
   return (
     <FieldRoot title={title} fieldKey={`${title}-field`}>
       {!hideField ? (
         object ? (
-          <div className="relative flex w-full flex-col">
-            <CopyToClipboardButton
-              className="absolute right-2 top-2 !border-none !bg-transparent !text-semantic-fg-on-default"
-              iconClassName="!stroke-semantic-bg-primary"
-              text={JSON.stringify(object, null, 2)}
-            />
-            <JsonView
-              value={object ?? {}}
-              style={{
-                ...customTheme,
-                padding: "12px",
-                borderRadius: "8px",
-                fontSize: "12px",
-                overflow: "auto",
-                maxHeight: "400px",
-              }}
-              enableClipboard={false}
-              displayObjectSize={false}
-              indentWidth={8}
-              shortenTextAfterLength={0}
-              displayDataTypes={false}
-              collapsed={3}
-            />
-          </div>
+          isJSON ? (
+            <div className="relative flex w-full flex-col">
+              <CopyToClipboardButton
+                className="absolute right-2 top-2 !border-none !bg-transparent !text-semantic-fg-on-default"
+                iconClassName="!stroke-semantic-bg-primary"
+                text={JSON.stringify(object, null, 2)}
+              />
+              <JsonView
+                value={object ?? {}}
+                style={{
+                  ...customTheme,
+                  padding: "12px",
+                  borderRadius: "8px",
+                  fontSize: "12px",
+                  overflow: "auto",
+                  maxHeight: "400px",
+                }}
+                enableClipboard={false}
+                displayObjectSize={false}
+                indentWidth={8}
+                shortenTextAfterLength={0}
+                displayDataTypes={false}
+              />
+            </div>
+          ) : (
+            <MDTextViewer text={String(object)} forceFormatted={true} />
+          )
         ) : (
           <NoOutput />
         )

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -329,6 +329,7 @@ export function pickComponentOutputFieldsFromInstillFormTree(
 
   // Process structured type like semi-structured, structured/detection_object...etc
   if (singularType?.includes("structured")) {
+    console.log("structured", tree, propertyValue);
     return (
       <ComponentOutputFields.ObjectField
         mode={mode}

--- a/packages/toolkit/src/view/catalog/components/lib/helpers.tsx
+++ b/packages/toolkit/src/view/catalog/components/lib/helpers.tsx
@@ -250,6 +250,30 @@ export const convertTagsToArray = (
   return [];
 };
 
+export const formatName = (name: string) => {
+  // First, lowercase the name and replace invalid characters with hyphens
+  let formatted = name.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+
+  // Remove leading hyphens
+  formatted = formatted.replace(/^-+/, "");
+
+  // Ensure it starts with a letter
+  if (!/^[a-z]/.test(formatted)) {
+    formatted = "c" + formatted;
+  }
+
+  // Remove consecutive hyphens
+  formatted = formatted.replace(/-+/g, "-");
+
+  // Truncate to 32 characters
+  formatted = formatted.slice(0, 32);
+
+  // Remove trailing hyphens
+  formatted = formatted.replace(/-+$/, "");
+
+  return formatted;
+};
+
 export const isFile = (value: unknown): value is File => {
   return typeof window !== "undefined" && value instanceof File;
 };

--- a/packages/toolkit/src/view/pipeline/view-pipeline/PipelinePlayground.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/PipelinePlayground.tsx
@@ -89,7 +89,7 @@ export const PipelinePlayground = ({
       );
 
       if (pipelineVersion) {
-        return pipelineVersion?.recipe.variable ?? null;
+        return pipelineVersion?.recipe?.variable ?? null;
       }
     }
 
@@ -108,7 +108,7 @@ export const PipelinePlayground = ({
       );
 
       if (pipelineVersion) {
-        return pipelineVersion?.recipe.output ?? null;
+        return pipelineVersion?.recipe?.output ?? null;
       }
     }
 


### PR DESCRIPTION
Because

- For example, when output a is semi-structured, it's value should be `{"foo": 123}`, but sometime when BE can't recognize the correct type, it might directly send 123, which is a primitive type, we need to deal with this

This commit

- fix object output is wrong when BE response semi-structure result type but the result is actually string
