### PR TITLE
fix: fix wrongly handle reference prefix cause connecting is missing

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/lib/PipelineFlowFactory/edgeHelpers/composeEdgesForReference.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/PipelineFlowFactory/edgeHelpers/composeEdgesForReference.ts
@@ -25,7 +25,7 @@ export function composeEdgesForReference({
   const referencePrefix =
     reference.referenceValue.withoutCurlyBraces.split(".")[0];
 
-  if (referencePrefix && referencePrefix.includes("on")) {
+  if (referencePrefix && referencePrefix.startsWith("on")) {
     const referenceIsAvailable = runOnNodeConnectableReferencePaths.some(
       (availableReference) =>
         matchReference(
@@ -56,7 +56,7 @@ export function composeEdgesForReference({
   }
 
   // 1. Check if the reference is toward variable
-  if (referencePrefix && referencePrefix.includes("variable")) {
+  if (referencePrefix && referencePrefix.startsWith("variable")) {
     const referenceIsAvailable = variableNodeConnectableReferencePaths.some(
       (availableReference) =>
         matchReference(


### PR DESCRIPTION
Because

- fix wrongly handle reference prefix cause connecting is missing

This commit

- fix wrongly handle reference prefix cause connecting is missing
