### PR TITLE
fix(vdp): fix recipe editor sidebar tooltip not respond to whether the sidebar is open or not

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RecipeEditorView.tsx
@@ -321,7 +321,9 @@ export const RecipeEditorView = () => {
       <div className="flex flex-row px-3 h-12 items-center bg-semantic-bg-secondary">
         <div className="flex flex-row w-1/2">
           <div className="flex flex-row gap-x-2">
-            <EditorButtonTooltipWrapper tooltipContent="Open sidebar">
+            <EditorButtonTooltipWrapper
+              tooltipContent={isSidebarOpen ? "Close Sidebar" : "Open Sidebar"}
+            >
               <Button
                 size="sm"
                 className="!w-8 !h-8 items-center justify-center"


### PR DESCRIPTION
Because

- fix recipe editor sidebar tooltip not respond to whether the sidebar is open or not

This commit

- fix recipe editor sidebar tooltip not respond to whether the sidebar is open or not
