### PR TITLE
feat: unify retry option of react-query, clean up metabase issue and browserlist

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -100,5 +100,10 @@
       "eslint --cache --fix",
       "prettier --write"
     ]
-  }
+  },
+  "browserslist": [
+    "last 2 version",
+    "> 1%",
+    "not dead"
+  ]
 }

--- a/apps/console/src/app/(providers)/react-query-client-provider.tsx
+++ b/apps/console/src/app/(providers)/react-query-client-provider.tsx
@@ -30,7 +30,7 @@ function makeQueryClient() {
           if (
             Object.hasOwnProperty.call(error, "status") &&
             //@ts-ignore
-            [401, 403, 404, 500, 502, 503, 504].includes(error.status)
+            [401, 403, 404].includes(error.status)
           ) {
             //@ts-ignore
             console.log(`Aborting retry due to ${error.status} status`);

--- a/apps/console/src/app/(providers)/root-provider.tsx
+++ b/apps/console/src/app/(providers)/root-provider.tsx
@@ -53,11 +53,11 @@ export const RootProvider = ({
 
   React.useEffect(() => {
     updateFeatureFlagWebhookEnabled(() => featureFlagWebhookEnabled);
-  }, [featureFlagWebhookEnabled]);
+  }, [featureFlagWebhookEnabled, updateFeatureFlagWebhookEnabled]);
 
   React.useEffect(() => {
     updateFeatureFlagApplicationEnabled(() => featureFlagApplicationEnabled);
-  }, [featureFlagApplicationEnabled]);
+  }, [featureFlagApplicationEnabled, updateFeatureFlagApplicationEnabled]);
 
   React.useEffect(() => {
     // When ever user leave /editor page to what ever destination
@@ -80,7 +80,14 @@ export const RootProvider = ({
     closeModal();
     dismissToast();
     setPreviousPathname(pathname);
-  }, [pathname]);
+  }, [
+    pathname,
+    closeModal,
+    dismissToast,
+    initPipelineBuilder,
+    initCreateResourceFormStore,
+    previousPathname,
+  ]);
 
   return (
     <ReactQueryProvider>

--- a/apps/console/src/app/404/page.tsx
+++ b/apps/console/src/app/404/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { NotFoundPageRender } from "./render";
 
 export async function generateMetadata() {
   const metadata: Metadata = {
     title: `Instill Core | Not Found`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/catalog/page.tsx
+++ b/apps/console/src/app/[entity]/catalog/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { KnowladgeBasePageRender } from "./render";
 
 export async function generateMetadata() {
   const metadata: Metadata = {
     title: `Instill Cloud | Catalog`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/dashboard/pipeline/[id]/page.tsx
+++ b/apps/console/src/app/[entity]/dashboard/pipeline/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { PipelineDashboardPageRender } from "./render";
 
 type Props = {
@@ -9,6 +11,9 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | ${params.id} Dashboard`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/dashboard/pipeline/page.tsx
+++ b/apps/console/src/app/[entity]/dashboard/pipeline/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { DashboardPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Dashboard`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/models/[id]/[...path]/page.tsx
+++ b/apps/console/src/app/[entity]/models/[id]/[...path]/page.tsx
@@ -4,6 +4,7 @@ import { Nullable } from "instill-sdk";
 
 import {
   fetchNamespaceModel,
+  generateNextMetaBase,
   getModelTabTitle,
   ModelTabNames,
 } from "@instill-ai/toolkit/server";
@@ -40,6 +41,9 @@ export async function generateMetadata({
     metadata = {
       title: `Instill Core | ${id} | ${getModelTabTitle(params.path[0] as ModelTabNames)}`,
       description: model?.description,
+      metadataBase: generateNextMetaBase({
+        defaultBase: "http://localhost:3000",
+      }),
       openGraph: {
         images: ["/instill-open-graph.png"],
       },
@@ -48,6 +52,9 @@ export async function generateMetadata({
     console.log(error);
     metadata = {
       title: `Instill Core | ${id} | ${getModelTabTitle(params.path[0] as ModelTabNames)}`,
+      metadataBase: generateNextMetaBase({
+        defaultBase: "http://localhost:3000",
+      }),
       openGraph: {
         images: ["/instill-open-graph.png"],
       },

--- a/apps/console/src/app/[entity]/models/create/page.tsx
+++ b/apps/console/src/app/[entity]/models/create/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { CreateModelPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Create Model`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/models/page.tsx
+++ b/apps/console/src/app/[entity]/models/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { ModelsPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Models`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/page.tsx
+++ b/apps/console/src/app/[entity]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 
 import { Nullable, User } from "@instill-ai/toolkit";
-import { fetchUser } from "@instill-ai/toolkit/server";
+import { fetchUser, generateNextMetaBase } from "@instill-ai/toolkit/server";
 
 import { ProfilePageRender } from "./render";
 
@@ -24,6 +24,9 @@ export async function generateMetadata({
 
     const metadata: Metadata = {
       title: `Instill Core | ${params.entity}`,
+      metadataBase: generateNextMetaBase({
+        defaultBase: "http://localhost:3000",
+      }),
       description: user.profile?.bio,
       openGraph: {
         images: ["/instill-open-graph.png"],

--- a/apps/console/src/app/[entity]/pipelines/[id]/[...path]/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/[...path]/page.tsx
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { Nullable } from "@instill-ai/toolkit";
 import {
   fetchNamespacePipeline,
+  generateNextMetaBase,
   getPipelineTabTitle,
   PipelineTabNames,
 } from "@instill-ai/toolkit/server";
@@ -40,6 +41,9 @@ export async function generateMetadata({
     metadata = {
       title: `Instill Core | ${id} | ${getPipelineTabTitle(params.path[0] as PipelineTabNames)}`,
       description: pipeline?.description,
+      metadataBase: generateNextMetaBase({
+        defaultBase: "http://localhost:3000",
+      }),
       openGraph: {
         images: ["/instill-open-graph.png"],
       },
@@ -47,6 +51,9 @@ export async function generateMetadata({
   } catch (error) {
     metadata = {
       title: `Instill Core | ${id} | ${getPipelineTabTitle(params.path[0] as PipelineTabNames)}`,
+      metadataBase: generateNextMetaBase({
+        defaultBase: "http://localhost:3000",
+      }),
       openGraph: {
         images: ["/instill-open-graph.png"],
       },

--- a/apps/console/src/app/[entity]/pipelines/[id]/editor/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/[id]/editor/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { RecipeEditorViewRender } from "./render";
 
 type Props = {
@@ -11,6 +13,9 @@ export async function generateMetadata({ params }: Props) {
 
   const metadata: Metadata = {
     title: `Instill Core | ${id}`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/[entity]/pipelines/page.tsx
+++ b/apps/console/src/app/[entity]/pipelines/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { PipelinesViewPageRender } from "./render";
 
 export async function generateMetadata() {
   const metadata: Metadata = {
     title: `Instill Core | Pipelines`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/login/page.tsx
+++ b/apps/console/src/app/login/page.tsx
@@ -1,4 +1,21 @@
+import { Metadata } from "next";
+
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { LoginPageRender } from "./render";
+
+export async function generateMetadata() {
+  const metadata: Metadata = {
+    title: "Instill Core | Login",
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
+    openGraph: {
+      images: ["/instill-open-graph.png"],
+    },
+  };
+  return Promise.resolve(metadata);
+}
 
 export default async function Page() {
   return <LoginPageRender />;

--- a/apps/console/src/app/onboarding/page.tsx
+++ b/apps/console/src/app/onboarding/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { OnboardingPageRender } from "./render";
 
 export async function generateMetadata() {
   const metadata: Metadata = {
     title: "Instill Core | Onboarding",
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/robots.ts
+++ b/apps/console/src/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: "/private/",
+      disallow: "/api/",
     },
     sitemap: "https://instill.tech/sitemap.xml",
   };

--- a/apps/console/src/app/settings/account/page.tsx
+++ b/apps/console/src/app/settings/account/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { AccountSettingPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Account Setting`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/settings/api-tokens/page.tsx
+++ b/apps/console/src/app/settings/api-tokens/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { ApiTokenSettingsPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | API Token Setting`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/settings/integrations/page.tsx
+++ b/apps/console/src/app/settings/integrations/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { IntegrationsSettingsPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Integrations`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/settings/page.tsx
+++ b/apps/console/src/app/settings/page.tsx
@@ -1,9 +1,14 @@
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Cloud | Setting`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/settings/profile/page.tsx
+++ b/apps/console/src/app/settings/profile/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { ProfileSettingPageRender } from "./rendex";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Profile Setting`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/app/settings/secrets/page.tsx
+++ b/apps/console/src/app/settings/secrets/page.tsx
@@ -1,10 +1,15 @@
 import { Metadata } from "next";
 
+import { generateNextMetaBase } from "@instill-ai/toolkit/server";
+
 import { SecretSettingdPageRender } from "./render";
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: Metadata = {
     title: `Instill Core | Secrets Setting`,
+    metadataBase: generateNextMetaBase({
+      defaultBase: "http://localhost:3000",
+    }),
     openGraph: {
       images: ["/instill-open-graph.png"],
     },

--- a/apps/console/src/lib/use-app-access-token/client.ts
+++ b/apps/console/src/lib/use-app-access-token/client.ts
@@ -55,7 +55,6 @@ export function useAppAccessToken(props?: UseAccessTokenProps) {
         return Promise.reject(error);
       }
     },
-    retry: false,
     refetchOnWindowFocus: false,
   });
 

--- a/apps/console/src/lib/useAppTrackToken.ts
+++ b/apps/console/src/lib/useAppTrackToken.ts
@@ -29,7 +29,6 @@ export function useAppTrackToken({ enabled }: { enabled: boolean }) {
         return Promise.reject(error);
       }
     },
-    retry: false,
     refetchOnWindowFocus: false,
     enabled,
   });

--- a/packages/toolkit/src/constant/index.ts
+++ b/packages/toolkit/src/constant/index.ts
@@ -4,3 +4,4 @@ export * from "./credit";
 export * from "./integration";
 export * from "./model";
 export * from "./resourceIdPrefix";
+export * from "./react-query";

--- a/packages/toolkit/src/constant/react-query.ts
+++ b/packages/toolkit/src/constant/react-query.ts
@@ -1,0 +1,1 @@
+export const REACT_QUERY_MAX_RETRIES = 3;

--- a/packages/toolkit/src/lib/react-query-service/connector/useComponentDefinitions.ts
+++ b/packages/toolkit/src/lib/react-query-service/connector/useComponentDefinitions.ts
@@ -8,12 +8,10 @@ export function useComponentDefinitions({
   componentType,
   accessToken,
   enabled,
-  retry,
 }: {
   componentType: ComponentType | "all";
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["component-definitions", componentType],
@@ -37,6 +35,5 @@ export function useComponentDefinitions({
       return Promise.resolve(connectorDefinitions);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/hub/useHubStats.ts
+++ b/packages/toolkit/src/lib/react-query-service/hub/useHubStats.ts
@@ -7,13 +7,7 @@ export type HubStatsResponse = {
   numberOfFeaturedPipelines: number;
 };
 
-export function useHubStats({
-  enabled,
-  retry,
-}: {
-  enabled: boolean;
-  retry?: false | number;
-}) {
+export function useHubStats({ enabled }: { enabled: boolean }) {
   return useQuery({
     queryKey: ["hub-stats"],
     queryFn: async () => {
@@ -25,6 +19,5 @@ export function useHubStats({
       return Promise.resolve(stats);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useInfiniteConnectionPipelines.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useInfiniteConnectionPipelines.ts
@@ -8,14 +8,12 @@ export function useInfiniteConnectionPipelines({
   connectionId,
   accessToken,
   enabled,
-  retry,
   filter,
 }: {
   namespaceId: Nullable<string>;
   connectionId: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
 }) {
   const queryKey = [
@@ -66,6 +64,5 @@ export function useInfiniteConnectionPipelines({
       return lastPage.nextPageToken;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useInfiniteIntegrationConnections.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useInfiniteIntegrationConnections.ts
@@ -7,13 +7,11 @@ export function useInfiniteIntegrationConnections({
   namespaceId,
   accessToken,
   enabled,
-  retry,
   filter,
 }: {
   namespaceId: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
 }) {
   const queryKey = ["integration-connections", namespaceId, "infinite"];
@@ -55,6 +53,5 @@ export function useInfiniteIntegrationConnections({
       return lastPage.nextPageToken;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useInfiniteIntegrations.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useInfiniteIntegrations.ts
@@ -6,12 +6,10 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 export function useInfiniteIntegrations({
   accessToken,
   enabled,
-  retry,
   filter,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
 }) {
   const queryKey = ["integrations", "infinite"];
@@ -47,6 +45,5 @@ export function useInfiniteIntegrations({
       return lastPage.nextPageToken;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useIntegration.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useIntegration.ts
@@ -7,14 +7,12 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 
 export function useIntegration({
   enabled,
-  retry,
   view = "VIEW_BASIC",
   integrationId,
   accessToken,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   view: ResourceView;
   integrationId: string;
 }) {
@@ -37,6 +35,5 @@ export function useIntegration({
       return Promise.resolve(data);
     },
     enabled: enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useIntegrationConnection.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useIntegrationConnection.ts
@@ -7,7 +7,6 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 
 export function useIntegrationConnection({
   enabled,
-  retry,
   view = "VIEW_BASIC",
   connectionId,
   namespaceId,
@@ -15,7 +14,6 @@ export function useIntegrationConnection({
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   view: ResourceView;
   connectionId: Nullable<string>;
   namespaceId: Nullable<string>;
@@ -46,6 +44,5 @@ export function useIntegrationConnection({
       return Promise.resolve(data);
     },
     enabled: enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/integration/useIntegrationConnections.ts
+++ b/packages/toolkit/src/lib/react-query-service/integration/useIntegrationConnections.ts
@@ -7,7 +7,6 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 
 export function useIntegrationConnections({
   enabled,
-  retry,
   view = "VIEW_BASIC",
   namespaceId,
   filter,
@@ -16,7 +15,6 @@ export function useIntegrationConnections({
   accessToken: Nullable<string>;
   namespaceId: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
   view: ResourceView;
 }) {
@@ -45,6 +43,5 @@ export function useIntegrationConnections({
       return Promise.resolve(data);
     },
     enabled: enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/metric/useCreditConsumptionChartRecords.ts
+++ b/packages/toolkit/src/lib/react-query-service/metric/useCreditConsumptionChartRecords.ts
@@ -6,7 +6,6 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 export function useCreditConsumptionChartRecords({
   enabled,
   accessToken,
-  retry,
   start,
   stop,
   owner,
@@ -18,7 +17,6 @@ export function useCreditConsumptionChartRecords({
   start: Nullable<string>;
   stop: Nullable<string>;
   aggregationWindow: Nullable<string>;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -75,6 +73,5 @@ export function useCreditConsumptionChartRecords({
       return Promise.resolve(data);
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggerComputationTimeCharts.ts
+++ b/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggerComputationTimeCharts.ts
@@ -8,12 +8,10 @@ export function usePipelineTriggerComputationTimeCharts({
   enabled,
   accessToken,
   filter,
-  retry,
 }: {
   enabled: boolean;
   accessToken: Nullable<string>;
   filter: Nullable<string>;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["charts", filter],
@@ -33,6 +31,5 @@ export function usePipelineTriggerComputationTimeCharts({
       return Promise.resolve(triggers);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggerMetric.ts
+++ b/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggerMetric.ts
@@ -8,12 +8,10 @@ export function usePipelineTriggerMetric({
   enabled,
   accessToken,
   filter,
-  retry,
 }: {
   enabled: boolean;
   accessToken: Nullable<string>;
   filter: Nullable<string>;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["tables", filter],
@@ -33,6 +31,5 @@ export function usePipelineTriggerMetric({
       return Promise.resolve(triggerMetric);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggers.ts
+++ b/packages/toolkit/src/lib/react-query-service/metric/usePipelineTriggers.ts
@@ -8,13 +8,11 @@ export function usePipelineTriggers({
   enabled,
   accessToken,
   filter,
-  retry,
   filterId,
 }: {
   enabled: boolean;
   accessToken: Nullable<string>;
   filter: Nullable<string>;
-  retry?: false | number;
   filterId: Nullable<string>;
 }) {
   const queryKey = ["metrics", "pipelines", "triggers"];
@@ -41,6 +39,5 @@ export function usePipelineTriggers({
       return Promise.resolve(triggers);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/use-api-tokens/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/use-api-tokens/client.ts
@@ -10,11 +10,9 @@ import { getUseApiTokensQueryKey } from "./server";
 export function useApiTokens({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   const queryKey = getUseApiTokensQueryKey();
   return useQuery({
@@ -33,6 +31,5 @@ export function useApiTokens({
       return Promise.resolve(tokens);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/use-authenticated-user/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/use-authenticated-user/client.ts
@@ -11,11 +11,9 @@ import {
 export function useAuthenticatedUser({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   const queryKey = getUseAuthenticatedUserQueryKey();
   return useQuery({
@@ -24,6 +22,5 @@ export function useAuthenticatedUser({
       return await fetchAuthenticatedUser({ accessToken });
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/use-namespace-type/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/use-namespace-type/client.ts
@@ -9,12 +9,10 @@ export function useNamespaceType({
   namespace,
   accessToken,
   enabled,
-  retry,
 }: {
   namespace: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -33,6 +31,5 @@ export function useNamespaceType({
       });
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/use-user/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/use-user/client.ts
@@ -9,12 +9,10 @@ export function useUser({
   userName,
   accessToken,
   enabled,
-  retry,
 }: {
   userName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -33,6 +31,5 @@ export function useUser({
       });
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useApiToken.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useApiToken.ts
@@ -7,12 +7,10 @@ export function useApiToken({
   tokenName,
   accessToken,
   enabled,
-  retry,
 }: {
   tokenName: string;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["api-tokens", tokenName],
@@ -30,6 +28,5 @@ export function useApiToken({
       return Promise.resolve(token);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useAuthenticatedUserSubscription.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useAuthenticatedUserSubscription.ts
@@ -6,11 +6,9 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 export function useAuthenticatedUserSubscription({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["authenticated-user", "subscription"],
@@ -27,6 +25,5 @@ export function useAuthenticatedUserSubscription({
       return Promise.resolve(subscription);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useMgmtDefinition.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useMgmtDefinition.ts
@@ -2,13 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { listRepoFileContent } from "../../github";
 
-export function useMgmtDefinition({
-  enabled,
-  retry,
-}: {
-  enabled: boolean;
-  retry?: false | number;
-}) {
+export function useMgmtDefinition({ enabled }: { enabled: boolean }) {
   return useQuery({
     queryKey: ["mgmt", "encoded-definition"],
     queryFn: async () => {
@@ -22,6 +16,5 @@ export function useMgmtDefinition({
       return Promise.resolve(decode);
     },
     enabled: enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useNamespacesRemainingCredit.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useNamespacesRemainingCredit.ts
@@ -18,12 +18,10 @@ export function useNamespacesRemainingCredit({
   namespaceNames,
   accessToken,
   enabled,
-  retry,
 }: {
   namespaceNames: string[];
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -62,7 +60,6 @@ export function useNamespacesRemainingCredit({
       return Promise.resolve(remainingCredits);
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
     refetchOnWindowFocus: false,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useRemainingCredit.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useRemainingCredit.ts
@@ -11,12 +11,10 @@ export function useRemainingCredit({
   ownerName,
   accessToken,
   enabled,
-  retry,
 }: {
   ownerName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -47,6 +45,5 @@ export function useRemainingCredit({
       return Promise.resolve(remainingCredit);
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/mgmt/useUsers.ts
+++ b/packages/toolkit/src/lib/react-query-service/mgmt/useUsers.ts
@@ -7,11 +7,9 @@ import { getInstillAPIClient } from "../../vdp-sdk";
 export function useUsers({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["users"],
@@ -30,6 +28,5 @@ export function useUsers({
       return Promise.resolve(users);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/misc/useBlogPosts.ts
+++ b/packages/toolkit/src/lib/react-query-service/misc/useBlogPosts.ts
@@ -107,6 +107,5 @@ export const useBlogPosts = () => {
   return useQuery({
     queryKey: ["blogPosts"],
     queryFn: fetchBlogPosts,
-    retry: 3,
   });
 };

--- a/packages/toolkit/src/lib/react-query-service/misc/useChangelogs.ts
+++ b/packages/toolkit/src/lib/react-query-service/misc/useChangelogs.ts
@@ -30,6 +30,5 @@ export const useChangelogs = () => {
         );
       return filteredAndSortedChangelogs.slice(0, 3);
     },
-    retry: 3,
   });
 };

--- a/packages/toolkit/src/lib/react-query-service/model/use-namespace-model/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/use-namespace-model/client.ts
@@ -9,12 +9,10 @@ export function useNamespaceModel({
   namespaceModelName,
   accessToken,
   enabled,
-  retry,
 }: {
   namespaceModelName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -31,6 +29,5 @@ export function useNamespaceModel({
       });
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useInfiniteModelVersions.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useInfiniteModelVersions.ts
@@ -15,13 +15,11 @@ export function useInfiniteModelVersions({
   enabledQuery,
   modelName,
   pageSize,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabledQuery: boolean;
   modelName: Nullable<string>;
   pageSize?: number;
-  retry?: false | number;
 }): UseInfiniteQueryResult<InfiniteData<ListModelVersionsResponse>, Error> {
   let enabled = false;
 
@@ -65,6 +63,5 @@ export function useInfiniteModelVersions({
       return lastPage.page + 1;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useInfiniteModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useInfiniteModels.ts
@@ -8,7 +8,6 @@ export function useInfiniteModels({
   accessToken,
   pageSize,
   enabledQuery,
-  retry,
   filter,
   visibility,
   orderBy,
@@ -17,7 +16,6 @@ export function useInfiniteModels({
   pageSize?: number;
   accessToken: Nullable<string>;
   enabledQuery: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
   orderBy: Nullable<string>;
@@ -62,6 +60,5 @@ export function useInfiniteModels({
       return lastPage.nextPageToken;
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useInfiniteUserModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useInfiniteUserModels.ts
@@ -8,14 +8,12 @@ export function useInfiniteUserModels({
   userName,
   accessToken,
   enabled,
-  retry,
   filter,
   visibility,
 }: {
   userName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
 }) {
@@ -61,6 +59,5 @@ export function useInfiniteUserModels({
       return lastPage.nextPageToken;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useLastModelTriggerResult.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useLastModelTriggerResult.ts
@@ -10,7 +10,6 @@ export function useLastModelTriggerResult({
   accessToken,
   enabled,
   view = "VIEW_BASIC",
-  retry,
   requesterUid,
 }: {
   modelId: Nullable<string>;
@@ -18,7 +17,6 @@ export function useLastModelTriggerResult({
   accessToken: Nullable<string>;
   enabled: boolean;
   view?: ResourceView;
-  retry?: false | number;
   requesterUid?: string;
 }) {
   let enableQuery = false;
@@ -51,6 +49,5 @@ export function useLastModelTriggerResult({
       return Promise.resolve(operation);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useModelDefinition.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useModelDefinition.ts
@@ -7,12 +7,10 @@ export function useModelDefinition({
   modelDefinitionName,
   accessToken,
   enabled,
-  retry,
 }: {
   modelDefinitionName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -39,6 +37,5 @@ export function useModelDefinition({
       return Promise.resolve(definition);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useModelDefinitions.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useModelDefinitions.ts
@@ -7,11 +7,9 @@ import { listModelDefinitionsQuery } from "../../vdp-sdk";
 export function useModelDefinitions({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["model-definitions"],
@@ -29,6 +27,5 @@ export function useModelDefinitions({
       return Promise.resolve(definitions);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useModelRegions.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useModelRegions.ts
@@ -5,10 +5,8 @@ import { listModelRegionsQuery } from "../../vdp-sdk";
 
 export function useModelRegions({
   accessToken,
-  retry,
 }: {
   accessToken: Nullable<string>;
-  retry?: false | number;
 }) {
   const queryKey = ["available-model-regions"];
 
@@ -23,6 +21,5 @@ export function useModelRegions({
 
       return Promise.resolve(regions);
     },
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useModelVersionTriggerResult.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useModelVersionTriggerResult.ts
@@ -11,7 +11,6 @@ export function useModelVersionTriggerResult({
   accessToken,
   enabled,
   view = "VIEW_BASIC",
-  retry,
   requesterUid,
 }: {
   modelId: Nullable<string>;
@@ -20,7 +19,6 @@ export function useModelVersionTriggerResult({
   accessToken: Nullable<string>;
   enabled: boolean;
   view?: ResourceView;
-  retry?: false | number;
   requesterUid?: string;
 }) {
   let enableQuery = false;
@@ -58,6 +56,5 @@ export function useModelVersionTriggerResult({
       return Promise.resolve(operation);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/usePaginatedModelRuns.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/usePaginatedModelRuns.ts
@@ -9,7 +9,6 @@ export function usePaginatedModelRuns({
   modelName,
   accessToken,
   enabled,
-  retry,
   view = "VIEW_BASIC",
   pageSize,
   page,
@@ -20,7 +19,6 @@ export function usePaginatedModelRuns({
   modelName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   view?: ResourceView;
   pageSize?: number;
   page?: number;
@@ -71,6 +69,5 @@ export function usePaginatedModelRuns({
       return Promise.resolve(data);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useUserModel.tsx
+++ b/packages/toolkit/src/lib/react-query-service/model/useUserModel.tsx
@@ -7,12 +7,10 @@ export function useUserModel({
   modelName,
   accessToken,
   enabled,
-  retry,
 }: {
   modelName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -32,6 +30,5 @@ export function useUserModel({
       return Promise.resolve(model);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/model/useUserModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useUserModels.ts
@@ -31,7 +31,6 @@ export const useUserModels = ({
   userName,
   enabled,
   accessToken,
-  retry,
   filter,
   visibility,
 }: {
@@ -40,7 +39,6 @@ export const useUserModels = ({
   accessToken: Nullable<string>;
   filter: Nullable<string>;
   visibility: Nullable<Visibility>;
-  retry?: false | number;
 }) => {
   let enableQuery = false;
 
@@ -64,6 +62,5 @@ export const useUserModels = ({
       return Promise.resolve(models);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 };

--- a/packages/toolkit/src/lib/react-query-service/model/useWatchUserModels.ts
+++ b/packages/toolkit/src/lib/react-query-service/model/useWatchUserModels.ts
@@ -8,12 +8,10 @@ export function useWatchUserModels({
   modelNames,
   accessToken,
   enabled,
-  retry,
 }: {
   modelNames: Nullable<string[]>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
   const queryKey = ["models", "watch"];
@@ -48,6 +46,5 @@ export function useWatchUserModels({
       return Promise.resolve(watches);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/use-organization-memberships/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/use-organization-memberships/client.ts
@@ -12,12 +12,10 @@ export function useOrganizationMemberships({
   organizationID,
   accessToken,
   enabled,
-  retry,
 }: {
   organizationID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -36,6 +34,5 @@ export function useOrganizationMemberships({
       });
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/use-organization/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/use-organization/client.ts
@@ -9,12 +9,10 @@ export function useOrganization({
   organizationID,
   accessToken,
   enabled,
-  retry,
 }: {
   organizationID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -33,6 +31,5 @@ export function useOrganization({
       });
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useOrganizationMembership.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useOrganizationMembership.ts
@@ -8,14 +8,11 @@ export function useOrganizationMembership({
   userID,
   accessToken,
   enabled,
-  retry,
 }: {
   organizationID: Nullable<string>;
   userID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -46,6 +43,5 @@ export function useOrganizationMembership({
       return Promise.resolve(membership);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useOrganizationSubscription.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useOrganizationSubscription.ts
@@ -7,12 +7,10 @@ export function useOrganizationSubscription({
   organizationID,
   accessToken,
   enabled,
-  retry,
 }: {
   organizationID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -43,6 +41,5 @@ export function useOrganizationSubscription({
       return Promise.resolve(subscription);
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useOrganizations.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useOrganizations.ts
@@ -7,11 +7,9 @@ import { listOrganizationsQuery } from "../../vdp-sdk";
 export function useOrganizations({
   accessToken,
   enabled,
-  retry,
 }: {
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   return useQuery({
     queryKey: ["organizations"],
@@ -26,6 +24,5 @@ export function useOrganizations({
       return Promise.resolve(tokens);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useUserMembership.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useUserMembership.ts
@@ -8,13 +8,11 @@ export function useUserMembership({
   organizationID,
   accessToken,
   enabled,
-  retry,
 }: {
   userID: Nullable<string>;
   organizationID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -46,6 +44,5 @@ export function useUserMembership({
       return Promise.resolve(membership);
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/organization/useUserMemberships.ts
+++ b/packages/toolkit/src/lib/react-query-service/organization/useUserMemberships.ts
@@ -7,12 +7,10 @@ export function useUserMemberships({
   userID,
   accessToken,
   enabled,
-  retry,
 }: {
   userID: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
 }) {
   let enabledQuery = false;
 
@@ -39,6 +37,5 @@ export function useUserMemberships({
       return Promise.resolve(memberships);
     },
     enabled: enabledQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipeline-releases/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipeline-releases/client.ts
@@ -10,13 +10,11 @@ export function useNamespacePipelineReleases({
   namespacePipelineName,
   enabled,
   accessToken,
-  retry,
   shareCode,
 }: {
   namespacePipelineName: Nullable<string>;
   enabled: boolean;
   accessToken: Nullable<string>;
-  retry?: false | number;
   shareCode?: string;
 }) {
   let enableQuery = false;
@@ -43,6 +41,5 @@ export function useNamespacePipelineReleases({
       }
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipeline/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipeline/client.ts
@@ -12,13 +12,11 @@ export function useNamespacePipeline({
   namespacePipelineName,
   accessToken,
   enabled,
-  retry,
   shareCode,
 }: {
   namespacePipelineName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   shareCode?: string;
 }) {
   let enableQuery = false;
@@ -41,6 +39,5 @@ export function useNamespacePipeline({
       }
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipelines/client.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/use-namespace-pipelines/client.ts
@@ -13,7 +13,6 @@ export function useNamespacePipelines({
   namespaceName,
   enabled,
   accessToken,
-  retry,
   filter,
   visibility,
   disabledViewFull,
@@ -26,11 +25,6 @@ export function useNamespacePipelines({
   visibility: Nullable<Visibility>;
   disabledViewFull?: boolean;
   pageSize?: number;
-  /**
-   * - Default is 3
-   * - Set to false to disable retry
-   */
-  retry?: false | number;
 }) {
   let enableQuery = false;
 
@@ -57,6 +51,5 @@ export function useNamespacePipelines({
       }
     },
     enabled: enableQuery,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/useInfiniteNamespacePipelineReleases.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useInfiniteNamespacePipelineReleases.ts
@@ -20,7 +20,6 @@ export function useInfiniteNamespacePipelineReleases({
   enabledQuery,
   accessToken,
   pageSize,
-  retry,
   shareCode,
   disabledViewFull,
 }: {
@@ -28,7 +27,6 @@ export function useInfiniteNamespacePipelineReleases({
   enabledQuery: boolean;
   accessToken: Nullable<string>;
   pageSize?: number;
-  retry?: false | number;
   shareCode?: string;
   disabledViewFull?: boolean;
 }): UseInfiniteQueryResult<
@@ -76,6 +74,5 @@ export function useInfiniteNamespacePipelineReleases({
       return lastPage.nextPageToken;
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/usePaginatedPipelineRunComponents.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/usePaginatedPipelineRunComponents.ts
@@ -9,7 +9,6 @@ export function usePaginatedPipelineRunComponents({
   pipelineRunId,
   accessToken,
   enabled,
-  retry,
   pageSize,
   page,
   orderBy,
@@ -20,7 +19,6 @@ export function usePaginatedPipelineRunComponents({
   pipelineRunId: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   view?: ResourceView;
   pageSize?: number;
   page?: number;
@@ -72,6 +70,5 @@ export function usePaginatedPipelineRunComponents({
       return Promise.resolve(data);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/lib/react-query-service/pipeline/usePaginatedPipelineRuns.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/usePaginatedPipelineRuns.ts
@@ -9,7 +9,6 @@ export function usePaginatedPipelineRuns({
   pipelineName,
   accessToken,
   enabled,
-  retry,
   view = "VIEW_BASIC",
   pageSize,
   page,
@@ -20,7 +19,6 @@ export function usePaginatedPipelineRuns({
   pipelineName: Nullable<string>;
   accessToken: Nullable<string>;
   enabled: boolean;
-  retry?: false | number;
   view?: ResourceView;
   pageSize?: number;
   page?: number;
@@ -73,6 +71,5 @@ export function usePaginatedPipelineRuns({
       return Promise.resolve(data);
     },
     enabled,
-    retry: retry === false ? false : retry ? retry : 3,
   });
 }

--- a/packages/toolkit/src/server/utility/generateNextMetaBase.tsx
+++ b/packages/toolkit/src/server/utility/generateNextMetaBase.tsx
@@ -1,0 +1,3 @@
+export function generateNextMetaBase({ defaultBase }: { defaultBase: string }) {
+  return new URL(process.env.NEXT_PUBLIC_CONSOLE_BASE_URL ?? defaultBase);
+}

--- a/packages/toolkit/src/server/utility/index.ts
+++ b/packages/toolkit/src/server/utility/index.ts
@@ -13,3 +13,4 @@ export * from "./getModelTabTitle";
 export * from "./getPipelineTabTitle";
 export * from "./formatResourceId";
 export * from "./parseResourceId";
+export * from "./generateNextMetaBase";

--- a/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/PipelineBuilderMainView.tsx
@@ -82,7 +82,6 @@ export const PipelineBuilderMainView = ({
     namespacePipelineName: routeInfo.data.pipelineName,
     enabled: enabledQuery && routeInfo.isSuccess && !pipelineIsNew,
     accessToken,
-    retry: false,
   });
 
   React.useEffect(() => {

--- a/packages/toolkit/src/view/pipeline-builder/components/BackToLatestVersionTopBar.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/BackToLatestVersionTopBar.tsx
@@ -50,7 +50,6 @@ export const BackToLatestVersionTopBar = () => {
     enabled: enabledQuery && !pipelineIsNew,
     namespacePipelineName: pipelineName,
     accessToken,
-    retry: false,
   });
 
   return currentVersion === "latest" ||

--- a/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/BottomBar.tsx
@@ -63,7 +63,6 @@ export const BottomBar = () => {
     namespacePipelineName: routeInfo.data.pipelineName,
     enabled: enabledQuery && routeInfo.isSuccess && !pipelineIsNew,
     accessToken,
-    retry: false,
   });
 
   return (

--- a/packages/toolkit/src/view/pipeline-builder/lib/hooks/usePipelineBuilderGraph.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/lib/hooks/usePipelineBuilderGraph.tsx
@@ -53,7 +53,6 @@ export function usePipelineBuilderGraph() {
     enabled: enabledQuery && !pipelineIsNew && routeInfo.isSuccess,
     namespacePipelineName: routeInfo.data.pipelineName,
     accessToken,
-    retry: false,
   });
 
   // Initialize the pipeline graph for existed pipeline

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -73,7 +73,6 @@ export const Head = ({
   const me = useAuthenticatedUser({
     enabled: enabledQuery,
     accessToken,
-    retry: false,
   });
 
   const deletePipeline = useDeleteNamespacePipeline();


### PR DESCRIPTION
Because

- Standardize retry behavior to handle retry mechanism in just one place, so when we encounter 400 related error code, react-query won't retry, instead it will directly redirect user to 404 page.
- Add browser list
- Clean up metabase issue

This commit

- unify retry option of react-query, clean up metabase issue and browserlist
