### PR TITLE
fix: reset playground i/o data on namespace change

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.107.0",
+  "version": "0.107.0-rc.6",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.107.0-rc.6",
+  "version": "0.107.0",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
@@ -156,6 +156,9 @@ export const ModelPlayground = ({
     },
   );
 
+  console.log('ROUTE INFO', routeInfo);
+  console.log('NAMESPACE', routeInfo?.data?.namespaceId);
+
   const existingModelTriggerResult = useModelVersionTriggerResult({
     accessToken,
     modelId: model?.id || null,
@@ -169,6 +172,9 @@ export const ModelPlayground = ({
       routeInfo.isSuccess,
     requesterUid: targetNamespace ? targetNamespace.uid : undefined,
   });
+
+  console.log('TRIGGER RESULT', existingModelTriggerResult.data?.operation);
+  console.log('TRIGGER RESULT', existingModelTriggerResult.data?.operation?.response);
 
   const pollForResponse = React.useCallback(async () => {
     // If the polling is already running, stop

--- a/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
@@ -282,6 +282,10 @@ export const ModelPlayground = ({
         setExistingTriggerState(existingModelTriggerResult.data.operation);
       }
     }
+    // "toast" update doesn't matter here
+    // and the "pollForResponse" mainly uses ref and a couple of methods that
+    // don't depend on the state of the data
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     existingTriggerState,
     existingModelTriggerResult.isSuccess,

--- a/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
+++ b/packages/toolkit/src/view/model/view-model/ModelPlayground.tsx
@@ -97,7 +97,7 @@ export const ModelPlayground = ({
     timeoutRunning: boolean;
     isRendered: boolean;
     modelVersion: Nullable<string>;
-    targetNamespace: Nullable<string>
+    targetNamespace: Nullable<string>;
   }>(defaultCurrentOperationIdPollingData);
   const { toast } = useToast();
   const { amplitudeIsInit } = useAmplitudeCtx();
@@ -213,11 +213,12 @@ export const ModelPlayground = ({
   }, [model?.name, queryClient, existingModelTriggerResult]);
 
   const resetStatesAndCurrentOperationIdPollingData = () => {
-    currentOperationIdPollingData.current = defaultCurrentOperationIdPollingData;
+    currentOperationIdPollingData.current =
+      defaultCurrentOperationIdPollingData;
     setExistingTriggerState(null);
     setInputFromExistingResult(null);
     setModelRunResult(null);
-  }
+  };
 
   useEffect(() => {
     if (


### PR DESCRIPTION
To test this this toolkit version could be used for cloud `0.107.0-rc.15`

Because

- changing namespace on model playground did not reset the i/o forms data

This commit

- now it do reset it

https://github.com/user-attachments/assets/f058e1ed-804f-4d53-bcf9-03286eea226a

