### PR TITLE
fix(editor): fix can't construct multiple edges to multiple components from single component

### DIFF
--- a/apps/console/src/app/(providers)/root-provider.tsx
+++ b/apps/console/src/app/(providers)/root-provider.tsx
@@ -80,7 +80,7 @@ export const RootProvider = ({
     closeModal();
     dismissToast();
     setPreviousPathname(pathname);
-  }, [pathname, previousPathname]);
+  }, [pathname]);
 
   return (
     <ReactQueryProvider>

--- a/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromAny.ts
+++ b/packages/toolkit/src/view/pipeline-builder/lib/getReferencesFromAny.ts
@@ -11,10 +11,12 @@ export function getReferencesFromAny(value: any) {
     references: InstillReference[] = [],
   ): InstillReference[] {
     if (Array.isArray(value)) {
+      const refs = [...references];
       for (const item of value) {
-        const refs = getReferences(item, references);
-        return [...references, ...refs];
+        const itemRefs = getReferences(item, references);
+        refs.push(...itemRefs);
       }
+      return refs;
     } else if (typeof value === "string") {
       const refs = getReferencesFromString(value);
 


### PR DESCRIPTION
Because

- For example, if I want to connect a to b,c,d. The factory we have right now only form the first edge

This commit

- fix can't construct multiple edges to multiple components from single component
