### PR TITLE
feat(catalog): add Requester UID to example code in Ask and Retrieve pages 

### DIFF
--- a/packages/toolkit/src/view/catalog/CatalogMainView.tsx
+++ b/packages/toolkit/src/view/catalog/CatalogMainView.tsx
@@ -373,6 +373,8 @@ export const CatalogMainView = (props: CatalogViewProps) => {
               isProcessed={isProcessed}
               onGoToUpload={handleGoToUpload}
               namespaceId={selectedNamespace}
+              namespaceType={namespaceType}
+              isLocalEnvironment={isLocalEnvironment}
             />
           ) : null}
           {activeTab === "ask_question" && selectedCatalog ? (
@@ -381,6 +383,8 @@ export const CatalogMainView = (props: CatalogViewProps) => {
               isProcessed={isProcessed}
               onGoToUpload={handleGoToUpload}
               namespaceId={selectedNamespace}
+              namespaceType={namespaceType}
+              isLocalEnvironment={isLocalEnvironment}
             />
           ) : null}
           {activeTab === "get_catalog" && selectedCatalog ? (

--- a/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
@@ -157,6 +157,8 @@ ${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" :
             <a
               href="https://www.instill.tech/docs/artifact/ask"
               className="text-semantic-accent-default underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Artifact&apos;s API reference
             </a>

--- a/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
@@ -20,15 +20,14 @@ export const AskQuestionTab = ({
   onGoToUpload,
   namespaceId,
   namespaceType,
-  isLocalEnvironment
+  isLocalEnvironment,
 }: {
   catalog: Catalog;
   isProcessed: boolean;
   onGoToUpload: () => void;
   namespaceId: Nullable<string>;
   namespaceType: Nullable<"user" | "organization">;
-  isLocalEnvironment: boolean
-
+  isLocalEnvironment: boolean;
 }) => {
   const catalogId = catalog.catalogId;
 

--- a/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
@@ -89,7 +89,7 @@ export const AskQuestionTab = ({
             </p>
             <CodeBlock
               codeString={`$ export INSTILL_API_TOKEN=********
-${isOrganization && !isLocalEnvironment ? "export ORGANIZATION_UID=********" : ""}`}
+${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" : ""}`}
               wrapLongLines={true}
               language="bash"
               customStyle={defaultCodeSnippetStyles}

--- a/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/AskQuestionTab.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Nullable } from "instill-sdk";
 
-import { Separator } from "@instill-ai/design-system";
+import { cn, Separator } from "@instill-ai/design-system";
 
 import { CodeBlock, ModelSectionHeader } from "../../../../components";
 import { defaultCodeSnippetStyles } from "../../../../constant";
@@ -93,7 +93,9 @@ ${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" :
               wrapLongLines={true}
               language="bash"
               customStyle={defaultCodeSnippetStyles}
-              className="mb-4"
+              className={cn({
+                "mb-4": isOrganization && !isLocalEnvironment,
+              })}
             />
             {isOrganization && !isLocalEnvironment ? (
               <p className="product-body-text-3-regular">

--- a/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Nullable } from "instill-sdk";
 
-import { Separator } from "@instill-ai/design-system";
+import { cn, Separator } from "@instill-ai/design-system";
 
 import { CodeBlock, ModelSectionHeader } from "../../../../components";
 import { defaultCodeSnippetStyles } from "../../../../constant";
@@ -94,7 +94,9 @@ ${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" :
               wrapLongLines={true}
               language="bash"
               customStyle={defaultCodeSnippetStyles}
-              className="mb-4"
+              className={cn({
+                "mb-4": isOrganization && !isLocalEnvironment,
+              })}
             />
             {isOrganization && !isLocalEnvironment ? (
               <p className="product-body-text-3-regular">

--- a/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
@@ -20,14 +20,14 @@ export const RetrieveTestTab = ({
   onGoToUpload,
   namespaceId,
   namespaceType,
-  isLocalEnvironment
+  isLocalEnvironment,
 }: {
   catalog: Catalog;
   isProcessed: boolean;
   onGoToUpload: () => void;
   namespaceId: Nullable<string>;
   namespaceType: Nullable<"user" | "organization">;
-  isLocalEnvironment: boolean
+  isLocalEnvironment: boolean;
 }) => {
   const catalogId = catalog.catalogId;
 

--- a/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
@@ -158,6 +158,8 @@ ${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" :
             <a
               href="https://www.instill.tech/docs/artifact/search"
               className="text-semantic-accent-default underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Artifact&apos;s API reference
             </a>

--- a/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
@@ -90,7 +90,7 @@ export const RetrieveTestTab = ({
             </p>
             <CodeBlock
               codeString={`$ export INSTILL_API_TOKEN=********
-${isOrganization && !isLocalEnvironment ? "export ORGANIZATION_UID=********" : ""}`}
+${isOrganization && !isLocalEnvironment ? "$ export ORGANIZATION_UID=********" : ""}`}
               wrapLongLines={true}
               language="bash"
               customStyle={defaultCodeSnippetStyles}

--- a/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/RetrieveTestTab.tsx
@@ -19,24 +19,39 @@ export const RetrieveTestTab = ({
   isProcessed,
   onGoToUpload,
   namespaceId,
+  namespaceType,
+  isLocalEnvironment
 }: {
   catalog: Catalog;
   isProcessed: boolean;
   onGoToUpload: () => void;
   namespaceId: Nullable<string>;
+  namespaceType: Nullable<"user" | "organization">;
+  isLocalEnvironment: boolean
 }) => {
   const catalogId = catalog.catalogId;
 
+  const isOrganization = namespaceType === "organization";
+
   const curlCommand = React.useMemo(() => {
     const baseUrl = env("NEXT_PUBLIC_API_GATEWAY_URL");
-    return `curl -X POST '${baseUrl}/v1alpha/namespaces/${namespaceId}/catalogs/${catalogId}/chunks/retrieve' \\
+    let command = `curl -X POST '${baseUrl}/v1alpha/namespaces/${namespaceId}/catalogs/${catalogId}/chunks/retrieve' \\
 --header "Content-Type: application/json" \\
---header "Authorization: Bearer $INSTILL_API_TOKEN" \\
+--header "Authorization: Bearer $INSTILL_API_TOKEN"`;
+
+    if (isOrganization && !isLocalEnvironment) {
+      command += ` \\
+--header "Instill-Requester-Uid: $ORGANIZATION_UID"`;
+    }
+
+    command += ` \\
 --data '{
   "textPrompt": "Please put your query sentence here",
   "topK": 5
 }'`;
-  }, [namespaceId, catalogId]);
+
+    return command;
+  }, [namespaceId, catalogId, isOrganization, isLocalEnvironment]);
 
   return (
     <div className="flex flex-col mb-10">
@@ -74,11 +89,27 @@ export const RetrieveTestTab = ({
               Set Environment Variable:
             </p>
             <CodeBlock
-              codeString={"$ export INSTILL_API_TOKEN=********"}
+              codeString={`$ export INSTILL_API_TOKEN=********
+${isOrganization && !isLocalEnvironment ? "export ORGANIZATION_UID=********" : ""}`}
               wrapLongLines={true}
               language="bash"
               customStyle={defaultCodeSnippetStyles}
+              className="mb-4"
             />
+            {isOrganization && !isLocalEnvironment ? (
+              <p className="product-body-text-3-regular">
+                You can refer{" "}
+                <a
+                  href="/settings/organizations"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-semantic-accent-default underline"
+                >
+                  here
+                </a>{" "}
+                to find the corresponding organization UID.
+              </p>
+            ) : null}
           </div>
           <div className="mb-8">
             <p className="mb-2 text-lg font-semibold">Example cURL command:</p>


### PR DESCRIPTION
Because

- if user is an organization show requester UID in example code blocks 

