### PR TITLE
fix: fix sdk integration-test caused by the new revamp of instill-ai protobuf

### DIFF
--- a/packages/sdk/generate-mocks/main.ts
+++ b/packages/sdk/generate-mocks/main.ts
@@ -1,17 +1,9 @@
 import { generate } from "./generate";
 
 function main() {
-  generate("protobufs/openapiv2/vdp/service.swagger.yaml", {
+  generate("protobufs/openapi/v2/service.swagger.yaml", {
     baseUrl: "http://localhost:8080",
-    output: "mocks/vdp",
-  });
-  generate("protobufs/openapiv2/core/service.swagger.yaml", {
-    baseUrl: "http://localhost:8080",
-    output: "mocks/core",
-  });
-  generate("protobufs/openapiv2/model/service.swagger.yaml", {
-    baseUrl: "http://localhost:8080",
-    output: "mocks/model",
+    output: "mocks",
   });
 }
 

--- a/packages/sdk/generate-mocks/transform.ts
+++ b/packages/sdk/generate-mocks/transform.ts
@@ -91,28 +91,33 @@ export function transformToHandlerCode(
 
       const identifier = getResIdentifierName(successResponse);
 
+      return `http.${op.verb}(\`\${baseURL}${op.path}\`, async () => {
+          return HttpResponse.json(await ${identifier}())
+        }),\n`;
+
+      // The code below is for future reference
       // We have namespace path like /namespaces/*/pipelines/pid
       // For it we need to generate two route
       // - /users/*/pipelines/pid
       // - /organizations/*/pipelines/pid
 
-      const namespacesRegex = /namespaces/g;
+      // const namespacesRegex = /namespaces/g;
 
-      if (namespacesRegex.test(op.path)) {
-        const orgPath = op.path.replace(namespacesRegex, "organizations");
-        const userPath = op.path.replace(namespacesRegex, "users");
+      // if (namespacesRegex.test(op.path)) {
+      //   const orgPath = op.path.replace(namespacesRegex, "organizations");
+      //   const userPath = op.path.replace(namespacesRegex, "users");
 
-        return `http.${op.verb}(\`\${baseURL}${orgPath}\`, async () => {
-          return HttpResponse.json(await ${identifier}())
-        }),\n
-        http.${op.verb}(\`\${baseURL}${userPath}\`, async () => {
-          return HttpResponse.json(await ${identifier}())
-        }),\n`;
-      } else {
-        return `http.${op.verb}(\`\${baseURL}${op.path}\`, async () => {
-          return HttpResponse.json(await ${identifier}())
-        }),\n`;
-      }
+      //   return `http.${op.verb}(\`\${baseURL}${orgPath}\`, async () => {
+      //     return HttpResponse.json(await ${identifier}())
+      //   }),\n
+      //   http.${op.verb}(\`\${baseURL}${userPath}\`, async () => {
+      //     return HttpResponse.json(await ${identifier}())
+      //   }),\n`;
+      // } else {
+      //   return `http.${op.verb}(\`\${baseURL}${op.path}\`, async () => {
+      //     return HttpResponse.json(await ${identifier}())
+      //   }),\n`;
+      // }
     })
     .join("  ")
     .trimEnd();

--- a/packages/sdk/generate_mocks.sh
+++ b/packages/sdk/generate_mocks.sh
@@ -7,8 +7,6 @@ git clone --depth 1 --branch "${1:-main}" https://github.com/instill-ai/protobuf
 
 cd protobufs
 
-make openapi
-
 ## Back to the root of the SDK
 cd ..
 

--- a/packages/sdk/setupTests.ts
+++ b/packages/sdk/setupTests.ts
@@ -2,14 +2,12 @@ import { config } from "dotenv";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll } from "vitest";
 
-import { handlers as coreHandlers } from "./mocks/core/handlers.js";
-import { handlers as modelHandlers } from "./mocks/model/handlers.js";
-import { handlers as vdpHandlers } from "./mocks/vdp/handlers.js";
+import { handlers } from "./mocks/handlers.js";
 
 config();
 
 // The order is important.
-const worker = setupServer(...vdpHandlers, ...coreHandlers, ...modelHandlers);
+const worker = setupServer(...handlers);
 
 // Start worker before all tests
 beforeAll(() => {


### PR DESCRIPTION
Because

- In https://github.com/instill-ai/protobufs/commit/9d69b5c4ad755c613fdf0d0da47e9a4f03ab4461, we merge multiple openapi swagger into the single one, which cause the sdk's gen-mocks script failed. 

This commit

- fix sdk integration-test caused by the new revamp of instill-ai protobuf
