### PR TITLE
fix(catalog): start file upload progress tracking immediately after uploading files 

### DIFF
--- a/packages/toolkit/src/view/catalog/components/lib/uploadFileWithProgress.ts
+++ b/packages/toolkit/src/view/catalog/components/lib/uploadFileWithProgress.ts
@@ -13,13 +13,15 @@ export function useUploadWithProgress() {
     async (file: File, onProgress: (progress: number) => void) => {
       try {
         setUploadProgress((prev) => ({ ...(prev ?? {}), [file.name]: 0 }));
+        onProgress(0);
+
         const totalSize = file.size;
         let uploadedSize = 0;
         const chunkSize = 1024 * 1024; // 1MB chunks
         while (uploadedSize < totalSize) {
           await new Promise((resolve) => setTimeout(resolve, 100)); // Simulate network delay
           uploadedSize = Math.min(uploadedSize + chunkSize, totalSize);
-          const progress = (uploadedSize / totalSize) * 100;
+          const progress = Math.round((uploadedSize / totalSize) * 100);
           setUploadProgress((prev) => ({
             ...(prev ?? {}),
             [file.name]: progress,

--- a/packages/toolkit/src/view/catalog/components/tabs/UploadExploreTab.tsx
+++ b/packages/toolkit/src/view/catalog/components/tabs/UploadExploreTab.tsx
@@ -298,6 +298,13 @@ export const UploadExploreTab = ({
         setProcessingFileIndex(i);
 
         try {
+          await uploadFile(file, (progress) => {
+            setUploadProgress((prev) => ({
+              ...prev,
+              [file.name]: progress,
+            }));
+          });
+
           const content = await readFileAsBase64(file);
 
           const payload: CreateNamespaceCatalogFileRequest = {
@@ -311,13 +318,6 @@ export const UploadExploreTab = ({
           const uploadedFile = await createNamespaceCatalogFile.mutateAsync({
             payload,
             accessToken,
-          });
-
-          await uploadFile(file, (progress) => {
-            setUploadProgress((prev) => ({
-              ...prev,
-              [file.name]: progress,
-            }));
           });
 
           await processCatalogFiles.mutateAsync({


### PR DESCRIPTION
Because

- Start progress bar immediately after clicking process files 


