### PR TITLE
fix: fix array file wrong UX that will make user feel that can add more files step by step

### DIFF
--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/AudiosField.tsx
@@ -68,7 +68,7 @@ export const AudiosField = ({
                         binaries.push(binary);
                       }
                       field.onChange(binaries);
-                      setAudioFiles((prev) => [...prev, ...files]);
+                      setAudioFiles(() => files);
                     }
                   }}
                   disabled={disabled}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/FilesField.tsx
@@ -72,7 +72,7 @@ export const FilesField = ({
                         binaries.push(binary);
                       }
                       field.onChange(binaries);
-                      setUploadedFiles((prev) => [...prev, ...files]);
+                      setUploadedFiles(() => files);
                     }
                   }}
                   disabled={disabled}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/ImagesField.tsx
@@ -114,7 +114,7 @@ export const ImagesField = ({
                         binaries.push(binary);
                       }
                       field.onChange(binaries);
-                      setImageFiles((prev) => [...prev, ...files]);
+                      setImageFiles(() => files);
                     }
                   }}
                   disabled={disabled}

--- a/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/components/trigger-request-form-fields/VideosField.tsx
@@ -114,7 +114,6 @@ export const VideosField = ({
                         binaries.push(binary);
                       }
                       field.onChange(binaries);
-                      setVideoFiles((prev) => [...prev, ...files]);
                     }
                   }}
                   disabled={disabled}


### PR DESCRIPTION
Because

- For multiple file upload the user need to select all the file at once instead of upload file one by one

This commit

- fix array file wrong UX that will make user feel that can add more files step by step
