### PR TITLE
fix: replace restapi with http on the schema validation 

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -10,7 +10,7 @@ const operatorDefinitionIds = [
 ];
 
 const connectorDefinitionIds = [
-  "restapi",
+  "http",
   "stability-ai",
   "instill-model",
   "hugging-face",


### PR DESCRIPTION
Because

- replace restapi with http on the schema validation 

This commit

- replace restapi with http on the schema validation 
