### PR TITLE
fix: fix duplicated getting started tab and event message hint text on recipe editor

### DIFF
--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.111.0-rc.2",
+  "version": "0.111.0-rc.4",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/EventMessage.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/EventMessage.tsx
@@ -1,20 +1,41 @@
+import type { Nullable } from "instill-sdk";
+import * as React from "react";
+
 import { CodeBlock } from "../../../../components";
 
 export const EventMessage = ({
   id,
   messageSnippet,
+  messageDataFirstDataKey,
 }: {
   id: string;
   messageSnippet: string;
+  messageDataFirstDataKey: Nullable<string>;
 }) => {
   return (
-    <div className="flex flex-col gap-2 w-full py-2">
-      <p className="product-body-text-1-semibold text-semantic-fg-primary">
-        {id}
-      </p>
-      <p className=" product-body-text-3-medium text-semantic-fg-secondary">
-        This is the fake message of this event.
-      </p>
+    <div className="flex flex-col gap-y-1 w-full py-2">
+      <div className="flex flex-col gap-y-2">
+        <p className="product-body-text-1-semibold text-semantic-fg-primary">
+          {id}
+        </p>
+        <p className=" product-body-text-4-regular">
+          <span className="font-semibold text-semantic-fg-primary">
+            Fake message data:
+          </span>{" "}
+          <span className="text-semantic-fg-disabled">
+            This is the fake message of this event. Please paste the
+            object&apos;s path in the recipe to use it.
+          </span>{" "}
+          {messageDataFirstDataKey ? (
+            <React.Fragment>
+              <span className="text-semantic-fg-disabled">for example:</span>{" "}
+              <span className="font-semibold text-semantic-fg-primary">
+                {"${" + `on.${id}.message.${messageDataFirstDataKey}` + "}"}
+              </span>
+            </React.Fragment>
+          ) : null}
+        </p>
+      </div>
       <CodeBlock
         codeString={messageSnippet}
         wrapLongLines={true}

--- a/packages/toolkit/src/view/recipe-editor/flow/nodes/RunOnEventNode.tsx
+++ b/packages/toolkit/src/view/recipe-editor/flow/nodes/RunOnEventNode.tsx
@@ -94,6 +94,11 @@ export const RunOnEventNode = ({ id, data }: NodeProps<RunOnEventNodeData>) => {
                   null,
                   2,
                 )}
+                messageDataFirstDataKey={
+                  eventSpec.messageExamples[0]
+                    ? (Object.keys(eventSpec.messageExamples[0])[0] ?? null)
+                    : null
+                }
               />
             ),
             title: viewId,

--- a/packages/toolkit/src/view/settings/integrations/connectable-integration/ConnectableIntegration.tsx
+++ b/packages/toolkit/src/view/settings/integrations/connectable-integration/ConnectableIntegration.tsx
@@ -110,6 +110,8 @@ export const ConnectableIntegration = ({
                 namespaceId,
                 integrationId: integration.id,
               });
+
+              return;
             }
           } catch (error) {
             toastInstillError({


### PR DESCRIPTION
Because

- fix duplicated getting started tab and event message hint text on recipe editor

This commit

- fix duplicated getting started tab and event message hint text on recipe editor
