### PR TITLE
chore(run logging): clarify actors in Run objects

### DIFF
--- a/packages/sdk/src/model/types.ts
+++ b/packages/sdk/src/model/types.ts
@@ -194,9 +194,8 @@ export type ListModelRunsRequest = {
 
 export type ModelRun = {
   uid: string;
-  modelUid: string;
   runnerId: string;
-  namespaceId: string;
+  modelNamespaceId: string;
   status: RunStatus;
   source: RunSource;
   totalDuration: number;

--- a/packages/sdk/src/vdp/trigger/types.ts
+++ b/packages/sdk/src/vdp/trigger/types.ts
@@ -11,9 +11,8 @@ import { PipelineTrace } from "../pipeline";
 import { ResourceView, RunSource, RunStatus } from "../types";
 
 export type PipelineRun = {
-  namespaceId: string;
+  pipelineNamespaceId: string;
   pipelineId: string;
-  pipelineUid: string;
   pipelineRunUid: string;
   pipelineVersion: string;
   status: RunStatus;

--- a/packages/toolkit/src/view/dashboard/cost/model/DashboardListModel.tsx
+++ b/packages/toolkit/src/view/dashboard/cost/model/DashboardListModel.tsx
@@ -89,7 +89,7 @@ export const DashboardListModel = ({ start }: DashboardListModelProps) => {
           return (
             <div className="font-normal text-semantic-bg-secondary-secondary truncate">
               <Link
-                href={`/${row.original.namespaceId}/models/${row.original.modelId}`}
+                href={`/${row.original.modelNamespaceId}/models/${row.original.modelId}`}
                 className="text-semantic-accent-default hover:underline"
               >
                 {row.getValue("modelId")}
@@ -105,7 +105,7 @@ export const DashboardListModel = ({ start }: DashboardListModelProps) => {
           return (
             <div className="font-normal text-semantic-bg-secondary-secondary truncate">
               <Link
-                href={`/${row.original.namespaceId}/models/${row.original.modelId}/runs/${row.original.uid}`}
+                href={`/${row.original.modelNamespaceId}/models/${row.original.modelId}/runs/${row.original.uid}`}
                 className="text-semantic-accent-default hover:underline"
               >
                 {row.getValue("uid")}

--- a/packages/toolkit/src/view/dashboard/cost/pipeline/DashboardListPipeline.tsx
+++ b/packages/toolkit/src/view/dashboard/cost/pipeline/DashboardListPipeline.tsx
@@ -91,7 +91,7 @@ export const DashboardListPipeline = ({
           return (
             <div className="font-normal text-semantic-bg-secondary-secondary truncate">
               <Link
-                href={`/${row.original.namespaceId}/pipelines/${row.original.pipelineId}`}
+                href={`/${row.original.pipelineNamespaceId}/pipelines/${row.original.pipelineId}`}
                 className="text-semantic-accent-default hover:underline"
               >
                 {row.getValue("pipelineId")}
@@ -107,7 +107,7 @@ export const DashboardListPipeline = ({
           return (
             <div className="font-normal text-semantic-bg-secondary-secondary truncate">
               <Link
-                href={`/${row.original.namespaceId}/pipelines/${row.original.pipelineId}/runs/${row.original.pipelineRunUid}`}
+                href={`/${row.original.pipelineNamespaceId}/pipelines/${row.original.pipelineId}/runs/${row.original.pipelineRunUid}`}
                 className="text-semantic-accent-default hover:underline"
               >
                 {row.getValue("pipelineRunUid")}


### PR DESCRIPTION
Because

- The `PipelineRun` and `ModelRun` objects have confusing documentation for
  the requester, runner and owner of a pipeline/model run.

This commit

- Adopts the changes in https://github.com/instill-ai/protobufs/pull/519
