### PR TITLE
chore(integration): adjust OAuth scope for google-drive component

### DIFF
--- a/packages/toolkit/src/lib/integrations/core.ts
+++ b/packages/toolkit/src/lib/integrations/core.ts
@@ -30,6 +30,7 @@ const slackScopes = [
 
 const googleDriveScopes = [
   "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/drive.file",
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
 ];


### PR DESCRIPTION
Because

- we need `drive.file` scope to create/update/delete data in Google Drive

This commit

- adjusts OAuth scope for google-drive component
