### PR TITLE
chore: support `required` attribute in variable section

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -105,6 +105,9 @@ export const InstillYamlSchema = {
               type: "array",
               items: { type: "string" },
             },
+            required: {
+              type: "boolean",
+            },
           },
           additionalProperties: false,
           required: ["format"],

--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -49,7 +49,7 @@ const connectorDefinitionIds = [
   "google-sheets",
   "perplexity-ai",
   "leadiq",
-  "smartlead"
+  "smartlead",
 ];
 
 export const InstillYamlSchema = {


### PR DESCRIPTION
Because

- we want users to explicitly define which variables are required.

This commit

- adds support for the required attribute in variables.