### PR TITLE
chore(integration): update the OAuth scope for google-sheets

### DIFF
--- a/packages/toolkit/src/lib/integrations/core.ts
+++ b/packages/toolkit/src/lib/integrations/core.ts
@@ -37,6 +37,7 @@ const googleDriveScopes = [
 
 const googleSheetsScopes = [
   "https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/drive.file",
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
 ];


### PR DESCRIPTION
Because

- the `drive.file` scope is required to allow users to delete spreadsheets from Google.

This commit

- updates the OAuth scope for google-sheets to include `drive.file`.