### PR TITLE
fix: allow more data types in the variable default field

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -91,7 +91,6 @@ export const InstillYamlSchema = {
               type: "string",
             },
             default: {
-              type: "string",
             },
             "instill-ui-multiline": {
               type: "boolean",

--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -90,8 +90,7 @@ export const InstillYamlSchema = {
             description: {
               type: "string",
             },
-            default: {
-            },
+            default: {},
             "instill-ui-multiline": {
               type: "boolean",
             },


### PR DESCRIPTION
Because

- the default value in the variable section can represent various data types.

This commit

- expands support for additional data types in the variable default field. Since the default value can be of any data type, we remove the `type` limitation.