### PR TITLE
feat(integration): add drive.file scope into google sheet

### DIFF
--- a/packages/toolkit/src/lib/integrations/core.ts
+++ b/packages/toolkit/src/lib/integrations/core.ts
@@ -37,6 +37,7 @@ const googleDriveScopes = [
 
 const googleSheetsScopes = [
   "https://www.googleapis.com/auth/spreadsheets",
+  "https://www.googleapis.com/auth/drive.file",
   "https://www.googleapis.com/auth/userinfo.email",
   "https://www.googleapis.com/auth/userinfo.profile",
 ];


### PR DESCRIPTION
Because

- add drive.file scope into google sheet

This commit

- add drive.file scope into google sheet
