### PR TITLE
chore(ci): upgrade artifact actions v3

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -76,7 +76,7 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: ./apps/console/.next/analyze/__bundle_analysis.json


### PR DESCRIPTION
Because

- [actions/upload-artifact@v3 is being deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

This commit

- Upgrade action to v4.
