### PR TITLE
fix: fix not correctly invalidate query when delete pipeline

### DIFF
--- a/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteNamespacePipeline.ts
+++ b/packages/toolkit/src/lib/react-query-service/pipeline/useDeleteNamespacePipeline.ts
@@ -31,7 +31,7 @@ export function useDeleteNamespacePipeline() {
 
       return Promise.resolve({ namespaceId, pipelineId });
     },
-    onSuccess: ({ namespaceId, pipelineId }) => {
+    onSuccess: ({ namespaceId }) => {
       queryClient.invalidateQueries({
         queryKey:
           queryKeyStore.pipeline.getUseInfiniteAccessiblePipelinesQueryKey({
@@ -50,15 +50,6 @@ export function useDeleteNamespacePipeline() {
             visibility: null,
             view: null,
           }),
-      });
-
-      queryClient.invalidateQueries({
-        queryKey: queryKeyStore.pipeline.getUseNamespacePipelineQueryKey({
-          namespaceId,
-          pipelineId,
-          view: null,
-          shareCode: null,
-        }),
       });
     },
   });

--- a/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
+++ b/packages/toolkit/src/view/pipeline/view-pipeline/Head.tsx
@@ -78,7 +78,12 @@ export const Head = ({
 
   const deletePipeline = useDeleteNamespacePipeline();
   async function handleDeletePipeline() {
-    if (!accessToken || !pipeline) {
+    if (
+      !accessToken ||
+      !pipeline ||
+      !routeInfo.isSuccess ||
+      !routeInfo.data.namespaceId
+    ) {
       return;
     }
 
@@ -96,6 +101,7 @@ export const Head = ({
         variant: "alert-success",
         size: "large",
       });
+
       router.push(`/${routeInfo.data.namespaceId}/pipelines`);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
Because

- fix not correctly invalidate query when delete pipeline

This commit

- fix not correctly invalidate query when delete pipeline
