### PR TITLE
feat: add editing table column state

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.15.0-rc.47",
+  "version": "0.15.0-rc.49",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/packages/sdk/src/table/types.ts
+++ b/packages/sdk/src/table/types.ts
@@ -88,8 +88,10 @@ export type ColumnSort =
 export type ColumnAgentConfig = {
   instructions: string;
   enableWebSearch: boolean;
-  enableAutomateComputation: boolean;
-  context?: string[];
+  enableAutomateComputation?: boolean;
+  context?: {
+    columnUids: string[];
+  };
 };
 
 export type CellType =

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.117.0-rc.62",
+  "version": "0.118.0-rc.0",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.117.0-rc.61",
+  "version": "0.117.0-rc.62",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/use-instill-store/tableSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/tableSlice.ts
@@ -92,4 +92,16 @@ export const createTableSlice: StateCreator<
         currentSelectedTableRowsUid: fn(state.currentSelectedTableRowsUid),
       };
     }),
+  currentLeftPanelEditingColumnUid: null,
+  updateCurrentLeftPanelEditingColumnUid: (
+    fn: (prev: Nullable<string>) => Nullable<string>,
+  ) =>
+    set((state) => {
+      return {
+        ...state,
+        currentLeftPanelEditingColumnUid: fn(
+          state.currentLeftPanelEditingColumnUid,
+        ),
+      };
+    }),
 });

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -402,6 +402,10 @@ export type TableSlice = {
   ) => void;
   currentSelectedTableRowsUid: string[];
   updateCurrentSelectedTableRowsUid: (fn: (prev: string[]) => string[]) => void;
+  currentLeftPanelEditingColumnUid: Nullable<string>;
+  updateCurrentLeftPanelEditingColumnUid: (
+    fn: (prev: Nullable<string>) => Nullable<string>,
+  ) => void;
 };
 
 export type InstillStore = SmartHintSlice &


### PR DESCRIPTION
Because

-  add editing table column state to be used in the cloud's Table.
