### PR TITLE
feat: add catalog related data into fileCell

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.15.0-rc.55",
+  "version": "0.15.0-rc.56",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/packages/sdk/src/table/types.ts
+++ b/packages/sdk/src/table/types.ts
@@ -236,16 +236,20 @@ export type FileCell = BaseCell & {
     mimeType: string;
     namespace: string;
     objectUid: string;
+    catalogId: string;
+    fileUrl: string;
   };
 };
 
 export type DocumentCell = BaseCell & {
   documentValue?: {
-    namespace: string;
     fileUid?: string;
-    objectUid: string;
     name: string;
     mimeType: string;
+    namespace: string;
+    objectUid: string;
+    catalogId: string;
+    fileUrl: string;
   };
 };
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.118.0-rc.7",
+  "version": "0.118.0-rc.8",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",


### PR DESCRIPTION
We need `catalogId` and `fileUrl` to enable some of the UI interaction in console. For example, the file overview and summary. So BE help us return this kind of information. 