### PR TITLE
feat: update store type to support broader range of cell preview

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.15.0-rc.56",
+  "version": "0.15.0-rc.57",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/packages/sdk/src/table/types.ts
+++ b/packages/sdk/src/table/types.ts
@@ -233,11 +233,11 @@ export type FileCell = BaseCell & {
   fileValue?: {
     fileUid?: string;
     name: string;
-    mimeType: string;
-    namespace: string;
+    mimeType?: string;
+    namespace?: string;
     objectUid: string;
-    catalogId: string;
-    fileUrl: string;
+    catalogId?: string;
+    fileUrl?: string;
   };
 };
 
@@ -245,11 +245,11 @@ export type DocumentCell = BaseCell & {
   documentValue?: {
     fileUid?: string;
     name: string;
-    mimeType: string;
-    namespace: string;
+    mimeType?: string;
+    namespace?: string;
     objectUid: string;
-    catalogId: string;
-    fileUrl: string;
+    catalogId?: string;
+    fileUrl?: string;
   };
 };
 

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.118.0-rc.8",
+  "version": "0.118.0-rc.11",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CellType,
   Citation,
   GeneralRecord,
   PipelineStreamStatus,
@@ -375,6 +376,7 @@ export type CurrentTableSort = {
 };
 
 export type CurrentCellPreviewAnchor = {
+  type: CellType;
   rowUid: string;
   columnUid: string;
 };


### PR DESCRIPTION
We want to support different logic upon the cell preview. So we need a broader range of setting on cell preview state
