### PR TITLE
fix: update outdated artifact image URLs

### DIFF
--- a/packages/toolkit/src/constant/model.ts
+++ b/packages/toolkit/src/constant/model.ts
@@ -31,7 +31,7 @@ export const defaultCodeSnippetStyles = {
 
 const imageUrlTask = `{
       "data": {
-        "image-url": "https://artifacts.instill.tech/imgs/bear.jpg",
+        "image-url": "https://artifacts.instill-ai.com/imgs/bear.jpg",
         "type":"image-url"
       }
     }`;
@@ -49,7 +49,7 @@ const taskPayloads = {
             "type": "text"
           },
           {
-            "image-url": "https://artifacts.instill.tech/imgs/bear.jpg",
+            "image-url": "https://artifacts.instill-ai.com/imgs/bear.jpg",
             "type": "image-url"
           },
           {


### PR DESCRIPTION
Because

- we've migrated the artifacts.instill.tech domain to artifacts.instill-ai.com

This commit

- update outdated artifact image URLs to reflect the new domain