### PR TITLE
fix: fix number format key and object in column definition

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.17.0",
+  "version": "0.17.1-rc.0",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/packages/sdk/src/table/types.ts
+++ b/packages/sdk/src/table/types.ts
@@ -121,6 +121,19 @@ export type ColumnSelectionStringOption = {
   color: string;
 };
 
+export type NumberFormatType =
+  | "FORMAT_UNSPECIFIED"
+  | "FORMAT_PLAIN"
+  | "FORMAT_COMMAS"
+  | "FORMAT_CURRENCY"
+  | "FORMAT_PERCENTAGE";
+
+export type NumberFormat = {
+  format?: NumberFormatType;
+  decimalPlaces?: number;
+  currencyCode?: string;
+};
+
 export type ColumnDefinition = {
   columnUid: string;
   name?: string;
@@ -130,6 +143,7 @@ export type ColumnDefinition = {
   sort?: ColumnSort;
   agentConfig?: ColumnAgentConfig;
   selection: ColumnSelection;
+  numberFormat?: NumberFormat;
 };
 
 export type ColumnDefinitions = Record<string, ColumnDefinition>;
@@ -209,21 +223,12 @@ export type StringCell = BaseCell & {
   };
 };
 
-export type NumberFormat =
-  | "FORMAT_UNSPECIFIED"
-  | "FORMAT_COMMAS"
-  | "FORMAT_CURRENCY"
-  | "FORMAT_PERCENTAGE";
-
 export type NumberCell = BaseCell & {
   numberValue?: {
     value: number;
     userInput?: number;
     computedValue?: number;
   };
-  format?: NumberFormat;
-  decimalPlaces?: number;
-  currencyCode?: string;
 };
 
 export type BooleanCell = BaseCell & {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.119.2",
+  "version": "0.119.3-rc.1",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",

--- a/packages/toolkit/src/lib/use-instill-store/tableSlice.ts
+++ b/packages/toolkit/src/lib/use-instill-store/tableSlice.ts
@@ -117,4 +117,12 @@ export const createTableSlice: StateCreator<
         uploadingFileCells: fn(state.uploadingFileCells),
       };
     }),
+  tableUidForAgGrid: null,
+  updateTableUidForAgGrid: (fn: (prev: Nullable<string>) => Nullable<string>) =>
+    set((state) => {
+      return {
+        ...state,
+        tableUidForAgGrid: fn(state.tableUidForAgGrid),
+      };
+    }),
 });

--- a/packages/toolkit/src/lib/use-instill-store/types.ts
+++ b/packages/toolkit/src/lib/use-instill-store/types.ts
@@ -424,6 +424,10 @@ export type TableSlice = {
       prev: Record<string, UploadingFileCell[]>,
     ) => Record<string, UploadingFileCell[]>,
   ) => void;
+  tableUidForAgGrid: Nullable<string>;
+  updateTableUidForAgGrid: (
+    fn: (prev: Nullable<string>) => Nullable<string>,
+  ) => void;
 };
 
 export type InstillStore = SmartHintSlice &


### PR DESCRIPTION
We previously put the numberFormat in the cell object, but this is wrong, it should be in the column definition object, this PR fixes this issue