### PR TITLE
fix: remove value in table cell value

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instill-sdk",
-  "version": "0.17.1-rc.2",
+  "version": "0.17.1-rc.3",
   "description": "Instill AI's Typescript SDK",
   "repository": "https://github.com/instill-ai/typescript-sdk.git",
   "bugs": "https://github.com/instill-ai/community/issues",

--- a/packages/sdk/src/table/types.ts
+++ b/packages/sdk/src/table/types.ts
@@ -217,7 +217,6 @@ export type BaseCell = {
 
 export type StringCell = BaseCell & {
   stringValue?: {
-    value: string;
     userInput?: string;
     computedValue?: string;
   };
@@ -225,7 +224,6 @@ export type StringCell = BaseCell & {
 
 export type NumberCell = BaseCell & {
   numberValue?: {
-    value: number;
     userInput?: number;
     computedValue?: number;
   };
@@ -233,7 +231,6 @@ export type NumberCell = BaseCell & {
 
 export type BooleanCell = BaseCell & {
   booleanValue?: {
-    value: boolean;
     userInput?: boolean;
     computedValue?: boolean;
   };

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instill-ai/toolkit",
-  "version": "0.119.3-rc.3",
+  "version": "0.119.3-rc.4",
   "description": "Instill AI's frontend toolkit",
   "repository": "https://github.com/instill-ai/design-system.git",
   "bugs": "https://github.com/instill-ai/design-system/issues",


### PR DESCRIPTION
We will retire the value key in every cell type, let's take StringCell for example, previously it's structure is 

```
stringValue: {
  value: "foo",
  userInput: "foo",
  computedValue: "bar"
}
```

From now on it will be

```
stringValue: {
  userInput: "foo",
  computedValue: "bar"
}
```
