### PR TITLE
fix: fix secure cookie issue, default to use not-secure cookie on http site

### DIFF
--- a/apps/console/src/pages/api/set-user-cookie.ts
+++ b/apps/console/src/pages/api/set-user-cookie.ts
@@ -49,10 +49,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       res: res,
       key: body.key,
       value: body.value,
-      secure: env("NEXT_PUBLIC_SET_SECURE_COOKIE") ?? true,
+      secure: env("NEXT_PUBLIC_SET_SECURE_COOKIE") ?? false,
       domain: null,
       maxAge: 60 * 60 * 24 * 30,
-      httpOnly: true,
+      httpOnly: env("NEXT_PUBLIC_SET_SECURE_COOKIE") ?? false,
     };
 
     setCookie(payload);

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -23,6 +23,7 @@
     "build": "pnpm rimraf dist && tsup src && pnpm ts-types",
     "test": "vitest --run --passWithNoTests",
     "dev": "tsup src --watch",
+    "dev-ts": "tsc --watch --emitDeclarationOnly",
     "watch:css": "npx tailwindcss -i ./src/styles/global.css -o ./public/tailwind.css --watch",
     "build:css": "npx tailwindcss -i ./src/styles/global.css -o ./public/tailwind.css",
     "publish-rc": "pnpm rimraf dist && tsup src && pnpm ts-types && pnpm publish --no-git-checks"


### PR DESCRIPTION
Previously we set the auth state cookie running on the localhost:3000 as HttpOnly cookie, this won't work since the browser when soon remove this cookie cause the user need to login again, this PR fix this problem by default the cookie setting process to not-secure, and user can set it up by using `NEXT_PUBLIC_SET_SECURE_COOKIE` env variable
