### PR TITLE
fix: replace logout link with button

### DIFF
--- a/apps/console/src/pages/api/remove-user-cookie.ts
+++ b/apps/console/src/pages/api/remove-user-cookie.ts
@@ -3,6 +3,8 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { env, removeCookie } from "@instill-ai/toolkit/server";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  console.log("remove-user-cookie");
+
   const { method } = req;
 
   if (method !== "POST") {

--- a/apps/console/src/pages/api/set-user-cookie.ts
+++ b/apps/console/src/pages/api/set-user-cookie.ts
@@ -52,14 +52,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     // Use localhost for local development, otherwise use the extracted hostname
     const cookieDomain = hostname === "console" ? "localhost" : null;
 
-    console.log("Cookie debug info:", {
-      host: req.headers.host,
-      hostname,
-      cookieDomain,
-      userAgent: req.headers["user-agent"],
-      consoleBaseUrl: env("NEXT_PUBLIC_CONSOLE_BASE_URL"),
-    });
-
     const payload: SetCookiePayload = {
       res: res,
       key: body.key,
@@ -69,8 +61,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       maxAge: 60 * 60 * 24 * 30,
       httpOnly: true,
     };
-
-    console.log("Setting cookie with payload:", payload);
 
     setCookie(payload);
 

--- a/apps/console/src/pages/api/set-user-cookie.ts
+++ b/apps/console/src/pages/api/set-user-cookie.ts
@@ -45,15 +45,32 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       });
     }
 
+    // Extract hostname from request for proper domain setting
+    const host = req.headers.host;
+    const hostname = host ? host.split(":")[0] : null;
+
+    // Use localhost for local development, otherwise use the extracted hostname
+    const cookieDomain = hostname === "console" ? "localhost" : null;
+
+    console.log("Cookie debug info:", {
+      host: req.headers.host,
+      hostname,
+      cookieDomain,
+      userAgent: req.headers["user-agent"],
+      consoleBaseUrl: env("NEXT_PUBLIC_CONSOLE_BASE_URL"),
+    });
+
     const payload: SetCookiePayload = {
       res: res,
       key: body.key,
       value: body.value,
       secure: env("NEXT_PUBLIC_SET_SECURE_COOKIE") ?? false,
-      domain: null,
+      domain: cookieDomain,
       maxAge: 60 * 60 * 24 * 30,
-      httpOnly: env("NEXT_PUBLIC_SET_SECURE_COOKIE") ?? false,
+      httpOnly: true,
     };
+
+    console.log("Setting cookie with payload:", payload);
 
     setCookie(payload);
 

--- a/apps/instill-form-playground/package.json
+++ b/apps/instill-form-playground/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev-playground": "next dev",
     "build-playground": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
+++ b/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-// import Link from "next/link";
+import Link from "next/link";
+
 import {
   ComplicateIcons,
   DropdownMenu,
@@ -158,14 +159,18 @@ export const CETopbarDropdown = () => {
           </TopbarDropdownItem>
         </TopbarDropdownGroup>
         <Separator orientation="horizontal" />
-        {/* <TopbarDropdownGroup>
+        <TopbarDropdownGroup>
           <TopbarDropdownItem asChild>
-            <Link href="/api/auth/logout" className="flex gap-x-2">
+            <Link
+              prefetch={false}
+              href="/api/auth/logout"
+              className="flex gap-x-2"
+            >
               <Icons.Logout01 className=" my-auto h-4 w-4 stroke-semantic-fg-disabled" />
               <div className="my-auto">Log out</div>
             </Link>
           </TopbarDropdownItem>
-        </TopbarDropdownGroup> */}
+        </TopbarDropdownGroup>
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   ) : (

--- a/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
+++ b/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import {
+  Button,
   ComplicateIcons,
   DropdownMenu,
   Icons,
@@ -26,6 +27,7 @@ const selector = (store: InstillStore) => ({
 });
 
 export const CETopbarDropdown = () => {
+  const router = useRouter();
   const { accessToken, enabledQuery } = useInstillStore(useShallow(selector));
 
   const me = useAuthenticatedUser({
@@ -161,14 +163,15 @@ export const CETopbarDropdown = () => {
         <Separator orientation="horizontal" />
         <TopbarDropdownGroup>
           <TopbarDropdownItem asChild>
-            <Link
-              prefetch={false}
-              href="/api/auth/logout"
-              className="flex gap-x-2"
+            <Button
+              variant="tertiaryGrey"
+              onClick={() => {
+                router.push("/api/auth/logout");
+              }}
             >
-              <Icons.Logout01 className=" my-auto h-4 w-4 stroke-semantic-fg-disabled" />
+              <Icons.Logout01 className="my-auto h-4 w-4 stroke-semantic-fg-disabled" />
               <div className="my-auto">Log out</div>
-            </Link>
+            </Button>
           </TopbarDropdownItem>
         </TopbarDropdownGroup>
       </DropdownMenu.Content>

--- a/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
+++ b/packages/toolkit/src/components/top-bar/CETopbarDropdown.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Link from "next/link";
-
+// import Link from "next/link";
 import {
   ComplicateIcons,
   DropdownMenu,
@@ -159,14 +158,14 @@ export const CETopbarDropdown = () => {
           </TopbarDropdownItem>
         </TopbarDropdownGroup>
         <Separator orientation="horizontal" />
-        <TopbarDropdownGroup>
+        {/* <TopbarDropdownGroup>
           <TopbarDropdownItem asChild>
             <Link href="/api/auth/logout" className="flex gap-x-2">
               <Icons.Logout01 className=" my-auto h-4 w-4 stroke-semantic-fg-disabled" />
               <div className="my-auto">Log out</div>
             </Link>
           </TopbarDropdownItem>
-        </TopbarDropdownGroup>
+        </TopbarDropdownGroup> */}
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   ) : (

--- a/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
+++ b/packages/toolkit/src/lib/use-instill-form/pick/pickComponentOutputFieldsFromInstillFormTree.tsx
@@ -124,8 +124,6 @@ export function pickComponentOutputFieldsFromInstillFormTree(
     return null;
   }
 
-  // console.log("tree", tree, data, JSON.stringify(propertyValue));
-
   // Process objectArray
   // Becase we don't know the index of the output objectArray, we need to use
   // the data as a hint here

--- a/packages/toolkit/src/view/chat/ToolList.tsx
+++ b/packages/toolkit/src/view/chat/ToolList.tsx
@@ -65,7 +65,6 @@ export const ToolList = React.forwardRef<ToolListRef, ToolListProps>(
     React.useImperativeHandle(ref, () => ({
       onKeyDown: ({ event }) => {
         if (event.key === "ArrowUp") {
-          console.log("ArrowUp");
           upHandler();
           return true;
         }
@@ -91,8 +90,6 @@ export const ToolList = React.forwardRef<ToolListRef, ToolListProps>(
     }
 
     const rect = props.clientRect();
-
-    console.log("rect", props.clientRect());
 
     const selectItem = (index: number) => {
       const item = props.items[index];

--- a/packages/toolkit/src/view/chat/useToolSuggestionConfig.ts
+++ b/packages/toolkit/src/view/chat/useToolSuggestionConfig.ts
@@ -13,8 +13,6 @@ export const useToolSuggestionConfig = () => {
 
   const config: MentionOptions["suggestion"] = {
     items: ({ query }) => {
-      console.log("items", query);
-
       return [
         {
           id: "ask-lead-tool",
@@ -53,7 +51,6 @@ export const useToolSuggestionConfig = () => {
 
           element.appendChild(component.element);
           updateEnableToolSuggestion(() => true);
-          console.log("onStart", props);
         },
         onUpdate(props) {
           component?.updateProps(props);
@@ -84,7 +81,6 @@ export const useToolSuggestionConfig = () => {
         onExit() {
           component?.destroy();
           updateEnableToolSuggestion(() => false);
-          console.log("onExit");
         },
       };
     },

--- a/packages/toolkit/src/view/recipe-editor/lib/validateVSCodeYaml.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/validateVSCodeYaml.ts
@@ -44,7 +44,6 @@ export function validateVSCodeYaml(
   try {
     yamlData = YAML.parse(recipe);
   } catch (error) {
-    console.log("parse error", error);
     if (error instanceof YAML.YAMLError) {
       if (error.linePos && error.linePos.length > 0) {
         markers.push({


### PR DESCRIPTION
Previously we use <Link /> component in the `CETopbarDropdown`, when user open this dropdown, Nextjs will prefetch the link to pre-render the target page. But we use the api route path in the Link's href props. This means when the Nextjs prefetch the page, it's actually calling the api route, this operates the logout procedure. Hence user need to re-login, this PR replace the Nextjs Link component with the Button, so Nextjs won't pre-fetch it anymore