### PR TITLE
chore(toolkit): add gemini connector definition

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/lib/schema.ts
+++ b/packages/toolkit/src/view/recipe-editor/lib/schema.ts
@@ -14,6 +14,7 @@ const connectorDefinitionIds = [
   "stability-ai",
   "instill-model",
   "hugging-face",
+  "gemini",
   "openai",
   "anthropic",
   "mistral-ai",


### PR DESCRIPTION
Because

- the pipeline builder didn't recognize the component type `gemini`.

This commit

- adds Gemini connector (i.e., component) definition.
