### PR TITLE
fix(ui): add spacing between Stop button and Running status text

### DIFF
--- a/packages/toolkit/src/view/recipe-editor/RunButton.tsx
+++ b/packages/toolkit/src/view/recipe-editor/RunButton.tsx
@@ -20,7 +20,7 @@ export const RunButton = () => {
   );
 
   return (
-    <div className="flex flex-row gap-x-1 items-center">
+    <div className="flex flex-row gap-x-3 items-center">
       <EditorButtonTooltipWrapper
         tooltipContent={isMac ? "CMD Enter" : "CTRL Enter"}
       >


### PR DESCRIPTION
## Summary
Add spacing between the Stop button and Running status text in the pipeline builder top bar to improve visual clarity and usability.

## Problem
The 'Running' status text appears too close to the 'Stop' button, making the interface look cramped and harder to read.

## Solution
Increase the gap from \gap-x-1\ (4px) to \gap-x-3\ (12px) in the RunButton component.

Fixes instill-ai/instill-core#1272