### PR TITLE
fix(ui): prevent iterator input field overlapping when content is long

### DIFF
--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-input/IteratorInput.tsx
@@ -91,7 +91,7 @@ export const IteratorInput = ({ className }: { className?: string }) => {
           Input
         </p>
       </div>
-      <div className="flex flex-row items-center gap-x-2">
+      <div className="flex min-w-0 flex-1 flex-row items-center gap-x-2">
         <Select.Root
           value={selectedInputOption?.path}
           onValueChange={(value) => {
@@ -120,7 +120,7 @@ export const IteratorInput = ({ className }: { className?: string }) => {
             }
           }}
         >
-          <Select.Trigger className="!w-[245px]">
+          <Select.Trigger className="!min-w-[300px] !flex-1">
             <Select.Value aria-label={selectedInputOption?.path}>
               {selectedInputOption ? (
                 <p className="rounded bg-semantic-accent-bg px-2 py-0.5 text-semantic-accent-default product-body-text-4-medium">

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/IteratorOutput.tsx
@@ -59,16 +59,16 @@ export const OutputSet = ({
   disabledDeleteButton?: boolean;
 }) => {
   return (
-    <div key={outputKey} className="flex flex-row items-center gap-x-3">
+    <div key={outputKey} className="flex flex-row flex-wrap items-center gap-x-3">
       <p className="text-semantic-fg-primary product-body-text-3-semibold">
         {outputKey}
       </p>
-      <div className="flex flex-row gap-x-2">
-        <p className="text-semantic-fg-secondary product-body-text-4-semibold">
+      <div className="flex min-w-0 flex-1 flex-row items-center gap-x-2">
+        <p className="shrink-0 text-semantic-fg-secondary product-body-text-4-semibold">
           array of
         </p>
+        <OutputValueInput outputKey={outputKey} />
       </div>
-      <OutputValueInput outputKey={outputKey} />
       {disabledDeleteButton ? null : (
         <DeleteOutputButton outputKey={outputKey} />
       )}

--- a/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueInput.tsx
+++ b/packages/toolkit/src/view/pipeline-builder/components/iterator-editor/iterator-output/OutputValueInput.tsx
@@ -37,7 +37,7 @@ export const OutputValueInput = ({ outputKey }: { outputKey: string }) => {
   }, [tempSavedNodesForEditingIteratorFlow, editingIteratorID, outputKey]);
 
   return (
-    <Input.Root className="!h-8 !w-[250px]">
+    <Input.Root className="!h-8 !min-w-[250px] !flex-1">
       <Input.Core
         className="!product-body-text-4-medium"
         value={outputValue}


### PR DESCRIPTION
## Summary
Fix overlapping of input fields in the iterator when content is too long.

## Problem
When the input in the iterator is too long, it overlaps with adjacent elements (as noted in instill-ai/instill-core#503).

## Solution
- IteratorInput Select.Trigger: use min-w-[300px] and flex-1 to allow expansion
- OutputValueInput: use min-w-[250px] and flex-1 instead of fixed width
- OutputSet row: add flex-wrap and flex-1 for the input container
- Ensures fields expand automatically or wrap when content is long

Fixes instill-ai/instill-core#503

Made with [Cursor](https://cursor.com)